### PR TITLE
fix: move HTTPS forcing to register() for reverse proxy compatibility

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        if (str_starts_with(config('app.url'), 'https://')) {
+            URL::forceScheme('https');
+            URL::forceRootUrl(config('app.url'));
+        }
     }
 
     /**
@@ -45,10 +48,6 @@ class AppServiceProvider extends ServiceProvider
      */
     protected function configureDefaults(): void
     {
-        if (app()->isProduction()) {
-            URL::forceScheme('https');
-        }
-
         Date::use(CarbonImmutable::class);
 
         DB::prohibitDestructiveCommands(


### PR DESCRIPTION
## Summary
- Moves `URL::forceScheme('https')` from `boot()` to `register()` so the scheme is set before any package caches URLs
- Adds `URL::forceRootUrl(config('app.url'))` to override the request-derived root entirely
- Fixes mixed content (HTTP/HTTPS) errors behind Traefik reverse proxy

## Test plan
- [x] All 400 tests pass
- [ ] After deployment: `curl -s https://schichten.skhc.de/register | grep -c 'http://schichten'` returns 0
- [ ] No mixed content errors in browser console