### PR TITLE
feat(auth): persist selected organization across login sessions

### DIFF
--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -26,7 +26,7 @@ class ResolveOrganization
         if ($organizations->count() === 1) {
             $organization = $organizations->first();
         } else {
-            $preferredId = session('current_organization_id');
+            $preferredId = session('current_organization_id') ?? $user->current_organization_id;
 
             if ($preferredId) {
                 $organization = $organizations->firstWhere('id', $preferredId);
@@ -36,6 +36,11 @@ class ResolveOrganization
         }
 
         session(['current_organization_id' => $organization->id]);
+
+        if ($user->current_organization_id !== $organization->id) {
+            $user->updateQuietly(['current_organization_id' => $organization->id]);
+        }
+
         app()->instance(Organization::class, $organization);
 
         return $next($request);

--- a/app/Livewire/OrganizationSwitcher.php
+++ b/app/Livewire/OrganizationSwitcher.php
@@ -37,6 +37,7 @@ class OrganizationSwitcher extends Component
         Gate::authorize('view', $organization);
 
         session(['current_organization_id' => $organization->id]);
+        auth()->user()->updateQuietly(['current_organization_id' => $organization->id]);
 
         $this->redirect(route('dashboard'), navigate: true);
     }
@@ -62,6 +63,7 @@ class OrganizationSwitcher extends Component
         );
 
         session(['current_organization_id' => $organization->id]);
+        auth()->user()->updateQuietly(['current_organization_id' => $organization->id]);
 
         $this->reset('showCreateModal', 'newOrgName', 'newOrgSlug');
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'must_change_password',
         'email_verified_at',
+        'current_organization_id',
     ];
 
     /**

--- a/database/migrations/2026_03_08_114502_add_current_organization_id_to_users_table.php
+++ b/database/migrations/2026_03_08_114502_add_current_organization_id_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('current_organization_id')
+                ->nullable()
+                ->constrained('organizations')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('current_organization_id');
+        });
+    }
+};

--- a/tests/Feature/ResolveOrganizationTest.php
+++ b/tests/Feature/ResolveOrganizationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Enums\StaffRole;
+use App\Models\Organization;
+
+beforeEach(function () {
+    ['user' => $this->user, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
+
+    $this->secondOrg = Organization::factory()->create();
+    $this->secondOrg->users()->attach($this->user, ['role' => StaffRole::Organizer]);
+});
+
+it('persists selected organization to user record', function () {
+    $this->actingAs($this->user)
+        ->withSession(['current_organization_id' => $this->secondOrg->id])
+        ->get(route('dashboard'));
+
+    expect($this->user->fresh()->current_organization_id)->toBe($this->secondOrg->id);
+});
+
+it('restores last organization after re-login with fresh session', function () {
+    $this->user->updateQuietly(['current_organization_id' => $this->secondOrg->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('dashboard'));
+
+    expect(session('current_organization_id'))->toBe($this->secondOrg->id);
+});
+
+it('falls back to first organization when user has no saved preference', function () {
+    $this->actingAs($this->user)
+        ->get(route('dashboard'));
+
+    expect($this->user->fresh()->current_organization_id)->not->toBeNull();
+});
+
+it('does not write to database when organization unchanged', function () {
+    $this->user->updateQuietly(['current_organization_id' => $this->org->id]);
+    $updatedAt = $this->user->fresh()->updated_at;
+
+    $this->actingAs($this->user)
+        ->withSession(['current_organization_id' => $this->org->id])
+        ->get(route('dashboard'));
+
+    expect($this->user->fresh()->updated_at->toDateTimeString())->toBe($updatedAt->toDateTimeString());
+});


### PR DESCRIPTION
## Summary
- Adds `current_organization_id` column to `users` table so the selected organization survives logout/session invalidation
- `ResolveOrganization` middleware reads the saved preference when no session value exists
- `OrganizationSwitcher` persists the selection to the user record on switch/create

## Test plan
- [x] Migration runs cleanly
- [x] 4 new tests in `ResolveOrganizationTest` pass (9 total including existing)
- [x] Existing `OrganizationSwitcherTest` tests still pass (7 tests)
- [x] Pint formatting passes