### PR TITLE
feat: add custom registration fields per event

### DIFF
--- a/app/Livewire/Events/CustomFieldSetup.php
+++ b/app/Livewire/Events/CustomFieldSetup.php
@@ -46,48 +46,30 @@ class CustomFieldSetup extends Component
     public function addField(): void
     {
         Gate::authorize('manageCustomFields', $this->event);
-
-        $this->validate([
-            'newFieldLabel' => ['required', 'string', 'max:255'],
-            'newFieldOptions' => $this->newFieldType === 'select' ? ['required', 'string'] : ['nullable'],
-        ]);
-
-        $type = CustomFieldType::from($this->newFieldType);
-        $options = $this->buildOptions($type);
-
-        try {
-            $type->validateOptions($options);
-        } catch (DomainException $e) {
-            $this->addError('newFieldOptions', $e->getMessage());
-
+        $result = $this->validateAndBuildOptions();
+        if (! $result) {
             return;
         }
 
-        if ($this->newFieldRequired && ! $this->showSignupWarning && $this->eventHasSignups()) {
+        if ($this->newFieldRequired && $this->eventHasSignups()) {
             $this->showSignupWarning = true;
 
             return;
         }
 
-        $maxSort = $this->event->customRegistrationFields()->withTrashed()->max('sort_order') ?? 0;
-
-        CustomRegistrationField::create([
-            'event_id' => $this->event->id,
-            'label' => $this->newFieldLabel,
-            'type' => $type,
-            'options' => $options ?: null,
-            'required' => $this->newFieldRequired,
-            'sort_order' => $maxSort + 1,
-        ]);
-
-        $this->reset('newFieldLabel', 'newFieldType', 'newFieldOptions', 'newFieldRequired', 'newFieldMultiline', 'showSignupWarning');
-        unset($this->customFields);
+        $this->saveField(...$result);
     }
 
     public function confirmAddField(): void
     {
         $this->showSignupWarning = false;
-        $this->addField();
+        Gate::authorize('manageCustomFields', $this->event);
+        $result = $this->validateAndBuildOptions();
+        if (! $result) {
+            return;
+        }
+
+        $this->saveField(...$result);
     }
 
     public function dismissWarning(): void
@@ -129,6 +111,45 @@ class CustomFieldSetup extends Component
     public function getTemplatesProperty(): array
     {
         return CustomFieldTemplates::all();
+    }
+
+    /** @return array{CustomFieldType, array<string, mixed>}|null */
+    private function validateAndBuildOptions(): ?array
+    {
+        $this->validate([
+            'newFieldLabel' => ['required', 'string', 'max:255'],
+            'newFieldOptions' => $this->newFieldType === 'select' ? ['required', 'string'] : ['nullable'],
+        ]);
+
+        $type = CustomFieldType::from($this->newFieldType);
+        $options = $this->buildOptions($type);
+
+        try {
+            $type->validateOptions($options);
+        } catch (DomainException $e) {
+            $this->addError('newFieldOptions', $e->getMessage());
+
+            return null;
+        }
+
+        return [$type, $options];
+    }
+
+    private function saveField(CustomFieldType $type, array $options): void
+    {
+        $maxSort = $this->event->customRegistrationFields()->withTrashed()->max('sort_order') ?? 0;
+
+        CustomRegistrationField::create([
+            'event_id' => $this->event->id,
+            'label' => $this->newFieldLabel,
+            'type' => $type,
+            'options' => $options ?: null,
+            'required' => $this->newFieldRequired,
+            'sort_order' => $maxSort + 1,
+        ]);
+
+        $this->reset('newFieldLabel', 'newFieldType', 'newFieldOptions', 'newFieldRequired', 'newFieldMultiline', 'showSignupWarning');
+        unset($this->customFields);
     }
 
     private function buildOptions(CustomFieldType $type): array

--- a/tests/Feature/Livewire/CustomFieldSetupTest.php
+++ b/tests/Feature/Livewire/CustomFieldSetupTest.php
@@ -120,3 +120,42 @@ it('shows confirmation when adding required field to event with signups', functi
     // Field not saved yet
     expect(CustomRegistrationField::count())->toBe(0);
 });
+
+it('creates field and closes warning when confirming required field with signups', function () {
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+    $volunteer = Volunteer::factory()->create();
+    \App\Models\Ticket::factory()->create(['event_id' => $this->event->id, 'volunteer_id' => $volunteer->id]);
+    ShiftSignup::factory()->create(['shift_id' => $shift->id, 'volunteer_id' => $volunteer->id]);
+
+    Livewire::actingAs($this->user)
+        ->test(CustomFieldSetup::class, ['eventId' => $this->event->id])
+        ->set('newFieldLabel', 'Required field')
+        ->set('newFieldRequired', true)
+        ->call('addField')
+        ->assertSet('showSignupWarning', true)
+        ->call('confirmAddField')
+        ->assertSet('showSignupWarning', false);
+
+    expect(CustomRegistrationField::count())->toBe(1);
+    expect(CustomRegistrationField::first()->label)->toBe('Required field');
+});
+
+it('skips warning for non-required field even when event has signups', function () {
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+    $volunteer = Volunteer::factory()->create();
+    \App\Models\Ticket::factory()->create(['event_id' => $this->event->id, 'volunteer_id' => $volunteer->id]);
+    ShiftSignup::factory()->create(['shift_id' => $shift->id, 'volunteer_id' => $volunteer->id]);
+
+    Livewire::actingAs($this->user)
+        ->test(CustomFieldSetup::class, ['eventId' => $this->event->id])
+        ->set('newFieldLabel', 'Optional notes')
+        ->set('newFieldType', 'text')
+        ->set('newFieldRequired', false)
+        ->call('addField')
+        ->assertSet('showSignupWarning', false)
+        ->assertHasNoErrors();
+
+    expect(CustomRegistrationField::count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- Add organizer-defined custom registration fields (text, checkbox, select) per event with required/optional support, templates, and soft-delete
- Custom field responses are collected during volunteer signup, stored per-volunteer, and displayed in volunteer detail, portal, and CSV export
- Fix signup warning modal not closing on confirm by extracting shared validation/save logic into independent entry points

## Test plan
- [x] 52 new/updated test cases across 13 test files all passing
- [x] Custom field CRUD (add text/select/checkbox, remove via soft-delete, templates)
- [x] Signup flow collects and persists custom field responses through email verification
- [x] CSV export includes custom field data
- [x] Event cloning copies fields but not responses
- [x] Volunteer detail and portal display custom field responses
- [x] Warning modal for required fields on events with existing signups
- [x] Authorization: organizer-only for field management

Closes #14