### PR TITLE
Fix fragile Livewire route name in RequirePasswordChange middleware (#35)

### DIFF
--- a/app/Http/Middleware/RequirePasswordChange.php
+++ b/app/Http/Middleware/RequirePasswordChange.php
@@ -11,7 +11,8 @@ class RequirePasswordChange
     public function handle(Request $request, Closure $next): Response
     {
         if ($request->user()?->must_change_password
-            && ! $request->routeIs('change-password', 'logout', 'default-livewire.update')) {
+            && ! $request->routeIs('change-password', 'logout')
+            && ! $request->hasHeader('X-Livewire')) {
             return redirect()->route('change-password');
         }
 

--- a/tests/Feature/Auth/ChangePasswordTest.php
+++ b/tests/Feature/Auth/ChangePasswordTest.php
@@ -73,17 +73,6 @@ it('requires a password', function () {
         ->assertHasErrors(['password']);
 });
 
-it('does not redirect livewire update requests for must_change_password users', function () {
-    $user = User::factory()->mustChangePassword()->create();
-
-    $response = $this->actingAs($user)
-        ->post(route('default-livewire.update'), []);
-
-    // Should NOT redirect to change-password (middleware must allow through).
-    // Livewire will return a 422 for invalid payload, which is fine — we're testing the middleware, not Livewire.
-    expect($response->status())->not->toBe(302);
-});
-
 it('rejects a weak password', function () {
     $user = User::factory()->mustChangePassword()->create();
 

--- a/tests/Feature/RequirePasswordChangeTest.php
+++ b/tests/Feature/RequirePasswordChangeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\User;
+
+it('redirects must_change_password users to change-password page', function () {
+    $user = User::factory()->mustChangePassword()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertRedirect(route('change-password'));
+});
+
+it('allows must_change_password users to access change-password route', function () {
+    $user = User::factory()->mustChangePassword()->create();
+
+    $this->actingAs($user)
+        ->get(route('change-password'))
+        ->assertOk();
+});
+
+it('allows must_change_password users to access logout route', function () {
+    $user = User::factory()->mustChangePassword()->create();
+
+    $this->actingAs($user)
+        ->post(route('logout'))
+        ->assertRedirect();
+});
+
+it('allows livewire requests through for must_change_password users', function () {
+    $user = User::factory()->mustChangePassword()->create();
+
+    $response = $this->actingAs($user)
+        ->withHeaders(['X-Livewire' => 'true'])
+        ->get(route('dashboard'));
+
+    expect($response->status())->not->toBe(302);
+});
+
+it('does not redirect users without must_change_password flag', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk();
+});
+
+it('does not redirect guest requests', function () {
+    $this->get(route('login'))
+        ->assertOk();
+});


### PR DESCRIPTION
## Summary
- Replace `routeIs('default-livewire.update')` with `hasHeader('X-Livewire')` in RequirePasswordChange middleware — the route name is a Livewire internal that could change across versions
- Add dedicated `RequirePasswordChangeTest` with 6 middleware scenarios (redirect, allowed routes, Livewire bypass, normal users, guests)
- Remove duplicate middleware test from `ChangePasswordTest` to eliminate redundancy

## Test plan
- [x] Unit/feature tests added and passing (6 new middleware tests)
- [x] Full test suite green (830 tests)
- [x] Automated review: no sibling patterns found in codebase

Closes #35