### PR TITLE
fix(model): add cancelled_at to ShiftSignup fillable (#28)

### DIFF
--- a/app/Models/ShiftSignup.php
+++ b/app/Models/ShiftSignup.php
@@ -19,6 +19,7 @@ class ShiftSignup extends Model
         'signed_up_at',
         'notification_24h_sent',
         'notification_4h_sent',
+        'cancelled_at',
     ];
 
     protected function casts(): array

--- a/tests/Feature/Models/ShiftSignupScopeTest.php
+++ b/tests/Feature/Models/ShiftSignupScopeTest.php
@@ -73,6 +73,14 @@ it('shift spotsRemaining ignores cancelled signups', function () {
     expect($shift->spotsRemaining())->toBe(1);
 });
 
+it('cancelled_at is mass assignable via update', function () {
+    $signup = ShiftSignup::factory()->create(['shift_id' => $this->shift->id]);
+
+    $signup->update(['cancelled_at' => now()]);
+
+    expect($signup->fresh()->cancelled_at)->not->toBeNull();
+});
+
 it('ShiftSignup isCancelled returns correct boolean', function () {
     $active = ShiftSignup::factory()->create(['shift_id' => $this->shift->id]);
     $cancelled = ShiftSignup::factory()->create([


### PR DESCRIPTION
## Summary
- Add `cancelled_at` to `ShiftSignup::$fillable` — it was cast as `datetime` but missing from fillable, causing `->update(['cancelled_at' => ...])` to silently ignore the field
- Add test verifying mass-assignment works via `update()`

## Test plan
- [x] New test for mass-assignment via `update()` passes
- [x] Full test suite green (830 tests, 1801 assertions)
- [x] Pint formatting clean
- [x] Reviewed all 22 models for same issue — no other mismatches found

Closes #28