### PR TITLE
fix(signup): remove duplicate Volunteer firstOrCreate (#27)

### DIFF
--- a/app/Actions/CompleteEmailVerification.php
+++ b/app/Actions/CompleteEmailVerification.php
@@ -41,11 +41,9 @@ class CompleteEmailVerification
         VolunteerVerified::dispatch($volunteer, $event);
 
         $result = $this->signUpAction->execute(
-            name: $volunteer->name,
-            email: $volunteer->email,
+            volunteer: $volunteer,
             event: $event,
             shiftIds: $token->shift_ids,
-            phone: $volunteer->phone,
         );
 
         if ($token->gear_selections) {

--- a/app/Actions/ProcessVolunteerSignup.php
+++ b/app/Actions/ProcessVolunteerSignup.php
@@ -41,11 +41,9 @@ class ProcessVolunteerSignup
 
         if ($volunteer->isEmailVerified()) {
             $result = $this->signUpAction->execute(
-                name: $name,
-                email: $email,
+                volunteer: $volunteer,
                 event: $event,
                 shiftIds: $shiftIds,
-                phone: $phone,
             );
 
             if ($gearSelections !== null) {

--- a/app/Actions/SignUpVolunteer.php
+++ b/app/Actions/SignUpVolunteer.php
@@ -19,18 +19,14 @@ class SignUpVolunteer
      * @return array{volunteer: Volunteer, signup: ShiftSignup}
      */
     public function execute(
-        string $name,
-        string $email,
+        Volunteer $volunteer,
         Event $event,
         Shift $shift,
-        ?string $phone = null,
     ): array {
         $result = $this->batchAction->execute(
-            name: $name,
-            email: $email,
+            volunteer: $volunteer,
             event: $event,
             shiftIds: [$shift->id],
-            phone: $phone,
         );
 
         if (count($result->skippedFull) > 0) {

--- a/app/Actions/SignUpVolunteerForShifts.php
+++ b/app/Actions/SignUpVolunteerForShifts.php
@@ -22,11 +22,9 @@ class SignUpVolunteerForShifts
      * @param  array<int>  $shiftIds
      */
     public function execute(
-        string $name,
-        string $email,
+        Volunteer $volunteer,
         Event $event,
         array $shiftIds,
-        ?string $phone = null,
     ): SignupBatchResult {
         $eventJobIds = $event->volunteerJobs()->pluck('id');
         $validShiftIds = Shift::whereIn('volunteer_job_id', $eventJobIds)
@@ -41,15 +39,7 @@ class SignUpVolunteerForShifts
         $sortedShiftIds = $shiftIds;
         sort($sortedShiftIds);
 
-        $result = DB::transaction(function () use ($name, $email, $phone, $event, $sortedShiftIds) {
-            $volunteer = Volunteer::firstOrCreate(
-                ['email' => $email],
-                ['name' => $name, 'phone' => $phone],
-            );
-
-            if ($phone !== null && $volunteer->phone !== $phone) {
-                $volunteer->update(['phone' => $phone]);
-            }
+        $result = DB::transaction(function () use ($volunteer, $event, $sortedShiftIds) {
 
             $newSignups = [];
             $skippedFull = [];

--- a/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
+++ b/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
@@ -25,9 +25,10 @@ beforeEach(function () {
 });
 
 it('signs up for multiple shifts in one call', function () {
+    $volunteer = Volunteer::factory()->create(['email' => 'jane@example.com', 'name' => 'Jane Doe']);
+
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
@@ -42,12 +43,12 @@ it('signs up for multiple shifts in one call', function () {
 });
 
 it('signs up for shifts across different jobs', function () {
+    $volunteer = Volunteer::factory()->create();
     $job2 = VolunteerJob::factory()->for($this->event)->create();
     $shift3 = Shift::factory()->for($job2, 'volunteerJob')->create(['capacity' => 5]);
 
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $shift3->id],
     );
@@ -57,23 +58,23 @@ it('signs up for shifts across different jobs', function () {
 });
 
 it('creates only one ticket and one magic link', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
 
     expect(Ticket::where('event_id', $this->event->id)->count())->toBe(1);
-
-    $volunteer = Volunteer::where('email', 'jane@example.com')->first();
     expect(MagicLinkToken::where('volunteer_id', $volunteer->id)->count())->toBe(1);
 });
 
 it('sends one notification with all shifts', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
@@ -84,9 +85,10 @@ it('sends one notification with all shifts', function () {
 });
 
 it('notification content includes all shift details', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
@@ -100,12 +102,11 @@ it('notification content includes all shift details', function () {
 });
 
 it('skips already-signed-up shifts gracefully', function () {
-    $volunteer = Volunteer::factory()->create(['email' => 'existing@example.com']);
+    $volunteer = Volunteer::factory()->create();
     ShiftSignup::factory()->create(['shift_id' => $this->shift1->id, 'volunteer_id' => $volunteer->id]);
 
     $result = $this->action->execute(
-        name: 'Existing',
-        email: 'existing@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
@@ -117,13 +118,13 @@ it('skips already-signed-up shifts gracefully', function () {
 });
 
 it('skips full shifts gracefully', function () {
+    $volunteer = Volunteer::factory()->create();
     $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
     $otherVolunteer = Volunteer::factory()->create();
     ShiftSignup::factory()->create(['shift_id' => $fullShift->id, 'volunteer_id' => $otherVolunteer->id]);
 
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$fullShift->id, $this->shift1->id],
     );
@@ -135,6 +136,7 @@ it('skips full shifts gracefully', function () {
 });
 
 it('returns empty newSignups when all shifts are full', function () {
+    $volunteer = Volunteer::factory()->create();
     $full1 = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
     $full2 = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
     $v1 = Volunteer::factory()->create();
@@ -143,8 +145,7 @@ it('returns empty newSignups when all shifts are full', function () {
     ShiftSignup::factory()->create(['shift_id' => $full2->id, 'volunteer_id' => $v2->id]);
 
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$full1->id, $full2->id],
     );
@@ -156,13 +157,12 @@ it('returns empty newSignups when all shifts are full', function () {
 });
 
 it('returns empty newSignups when all shifts are duplicate', function () {
-    $volunteer = Volunteer::factory()->create(['email' => 'dup@example.com']);
+    $volunteer = Volunteer::factory()->create();
     ShiftSignup::factory()->create(['shift_id' => $this->shift1->id, 'volunteer_id' => $volunteer->id]);
     ShiftSignup::factory()->create(['shift_id' => $this->shift2->id, 'volunteer_id' => $volunteer->id]);
 
     $result = $this->action->execute(
-        name: 'Dup',
-        email: 'dup@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $this->shift2->id],
     );
@@ -174,20 +174,21 @@ it('returns empty newSignups when all shifts are duplicate', function () {
 });
 
 it('throws DomainException when a shift does not belong to the event', function () {
+    $volunteer = Volunteer::factory()->create();
     $otherOrg = Organization::factory()->create();
     $otherEvent = Event::factory()->for($otherOrg)->published()->create();
     $otherJob = VolunteerJob::factory()->for($otherEvent)->create();
     $otherShift = Shift::factory()->for($otherJob, 'volunteerJob')->create(['capacity' => 5]);
 
     expect(fn () => $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id, $otherShift->id],
     ))->toThrow(\App\Exceptions\DomainException::class, 'One or more shifts do not belong to this event.');
 });
 
 it('cancelled signups do not count toward capacity', function () {
+    $volunteer = Volunteer::factory()->create();
     $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
     $cancelled = Volunteer::factory()->create();
     ShiftSignup::factory()->create([
@@ -197,8 +198,7 @@ it('cancelled signups do not count toward capacity', function () {
     ]);
 
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$fullShift->id],
     );
@@ -208,7 +208,7 @@ it('cancelled signups do not count toward capacity', function () {
 });
 
 it('re-signup reactivates a cancelled row', function () {
-    $volunteer = Volunteer::factory()->create(['email' => 'returning@example.com']);
+    $volunteer = Volunteer::factory()->create();
     $signup = ShiftSignup::factory()->create([
         'shift_id' => $this->shift1->id,
         'volunteer_id' => $volunteer->id,
@@ -216,8 +216,7 @@ it('re-signup reactivates a cancelled row', function () {
     ]);
 
     $result = $this->action->execute(
-        name: 'Returning',
-        email: 'returning@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shiftIds: [$this->shift1->id],
     );
@@ -225,23 +224,4 @@ it('re-signup reactivates a cancelled row', function () {
     expect($result->hasNewSignups())->toBeTrue()
         ->and($result->newSignups)->toHaveCount(1)
         ->and($signup->fresh()->cancelled_at)->toBeNull();
-});
-
-it('creates volunteer via firstOrCreate and updates phone for returning volunteer', function () {
-    $existing = Volunteer::factory()->create([
-        'email' => 'returning@example.com',
-        'phone' => '+10000000000',
-    ]);
-
-    $result = $this->action->execute(
-        name: 'Returning',
-        email: 'returning@example.com',
-        event: $this->event,
-        shiftIds: [$this->shift1->id],
-        phone: '+19999999999',
-    );
-
-    expect($result->volunteer->id)->toBe($existing->id)
-        ->and($result->volunteer->fresh()->phone)->toBe('+19999999999')
-        ->and(Volunteer::where('email', 'returning@example.com')->count())->toBe(1);
 });

--- a/tests/Feature/Actions/SignUpVolunteerTest.php
+++ b/tests/Feature/Actions/SignUpVolunteerTest.php
@@ -24,38 +24,25 @@ beforeEach(function () {
     $this->action = app(SignUpVolunteer::class);
 });
 
-it('creates volunteer and signup records', function () {
+it('creates signup for volunteer', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     );
 
-    expect($result['volunteer']->name)->toBe('Jane Doe')
-        ->and($result['volunteer']->email)->toBe('jane@example.com')
+    expect($result['volunteer']->id)->toBe($volunteer->id)
         ->and($result['signup']->shift_id)->toBe($this->shift->id)
-        ->and($result['signup']->volunteer_id)->toBe($result['volunteer']->id);
-});
-
-it('upserts volunteer by email', function () {
-    $existing = Volunteer::factory()->create(['email' => 'returning@example.com', 'name' => 'Original Name']);
-
-    $result = $this->action->execute(
-        name: 'Different Name',
-        email: 'returning@example.com',
-        event: $this->event,
-        shift: $this->shift,
-    );
-
-    expect($result['volunteer']->id)->toBe($existing->id)
-        ->and(Volunteer::where('email', 'returning@example.com')->count())->toBe(1);
+        ->and($result['signup']->volunteer_id)->toBe($volunteer->id);
 });
 
 it('generates a ticket for the volunteer', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     );
@@ -64,27 +51,25 @@ it('generates a ticket for the volunteer', function () {
 });
 
 it('generates a magic link token', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     );
-
-    $volunteer = Volunteer::where('email', 'jane@example.com')->first();
 
     expect($volunteer->magicLinkTokens()->count())->toBe(1);
 });
 
 it('dispatches signup confirmation notification with shift array', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     );
-
-    $volunteer = Volunteer::where('email', 'jane@example.com')->first();
 
     Notification::assertSentTo($volunteer, SignupConfirmation::class, function ($notification) {
         return is_array($notification->shiftIds) && count($notification->shiftIds) === 1;
@@ -92,103 +77,43 @@ it('dispatches signup confirmation notification with shift array', function () {
 });
 
 it('throws ShiftFullException when shift is at capacity', function () {
-    $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
     $volunteer = Volunteer::factory()->create();
-    ShiftSignup::factory()->create(['shift_id' => $fullShift->id, 'volunteer_id' => $volunteer->id]);
+    $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
+    $otherVolunteer = Volunteer::factory()->create();
+    ShiftSignup::factory()->create(['shift_id' => $fullShift->id, 'volunteer_id' => $otherVolunteer->id]);
 
     expect(fn () => $this->action->execute(
-        name: 'New Person',
-        email: 'new@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $fullShift,
     ))->toThrow(ShiftFullException::class);
 });
 
 it('throws AlreadySignedUpException for duplicate signup', function () {
+    $volunteer = Volunteer::factory()->create();
+
     $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     );
 
     expect(fn () => $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $this->shift,
     ))->toThrow(AlreadySignedUpException::class);
 });
 
-it('stores phone number when provided', function () {
-    $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
-        event: $this->event,
-        shift: $this->shift,
-        phone: '+15551234567',
-    );
-
-    expect($result['volunteer']->phone)->toBe('+15551234567');
-});
-
-it('stores null phone when not provided', function () {
-    $result = $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
-        event: $this->event,
-        shift: $this->shift,
-    );
-
-    expect($result['volunteer']->phone)->toBeNull();
-});
-
-it('updates phone for returning volunteer when new phone is provided', function () {
-    Volunteer::factory()->create([
-        'email' => 'returning@example.com',
-        'phone' => '+10000000000',
-    ]);
-
-    $otherShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 5]);
-
-    $result = $this->action->execute(
-        name: 'Returning',
-        email: 'returning@example.com',
-        event: $this->event,
-        shift: $otherShift,
-        phone: '+19999999999',
-    );
-
-    expect($result['volunteer']->fresh()->phone)->toBe('+19999999999');
-});
-
-it('preserves existing phone for returning volunteer when phone is null', function () {
-    Volunteer::factory()->create([
-        'email' => 'returning@example.com',
-        'phone' => '+10000000000',
-    ]);
-
-    $otherShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 5]);
-
-    $result = $this->action->execute(
-        name: 'Returning',
-        email: 'returning@example.com',
-        event: $this->event,
-        shift: $otherShift,
-    );
-
-    expect($result['volunteer']->fresh()->phone)->toBe('+10000000000');
-});
-
 it('throws DomainException when shift does not belong to event', function () {
+    $volunteer = Volunteer::factory()->create();
     $otherOrg = Organization::factory()->create();
     $otherEvent = Event::factory()->for($otherOrg)->published()->create();
     $otherJob = VolunteerJob::factory()->for($otherEvent)->create();
     $otherShift = Shift::factory()->for($otherJob, 'volunteerJob')->create(['capacity' => 5]);
 
     expect(fn () => $this->action->execute(
-        name: 'Jane Doe',
-        email: 'jane@example.com',
+        volunteer: $volunteer,
         event: $this->event,
         shift: $otherShift,
     ))->toThrow(\App\Exceptions\DomainException::class, 'One or more shifts do not belong to this event.');


### PR DESCRIPTION
## Summary
- `SignUpVolunteerForShifts::execute()` now accepts a `Volunteer` model instead of name/email/phone strings
- Removed redundant `Volunteer::firstOrCreate()` and phone update logic from `SignUpVolunteerForShifts` — volunteer creation is now solely `ProcessVolunteerSignup`'s responsibility
- Updated all 3 callers: `ProcessVolunteerSignup`, `CompleteEmailVerification`, `SignUpVolunteer`
- Net reduction: -172 lines added / +59 lines = **113 fewer lines**

## Test plan
- [x] All 35 directly affected tests pass (SignUpVolunteerForShifts, SignUpVolunteer, ProcessVolunteerSignup, CompleteEmailVerification)
- [x] Full test suite green (824 tests, 1791 assertions)
- [x] Pint formatting clean
- [x] Verified only one `Volunteer::firstOrCreate` call remains (in ProcessVolunteerSignup)

Closes #27