### PR TITLE
fix(dashboard): exclude cancelled signups from shiftsNeedingAttention (#26)

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -66,7 +66,8 @@ class Dashboard extends Component
         ))
             ->where(
                 ShiftSignup::selectRaw('count(*)')
-                    ->whereColumn('shift_signups.shift_id', 'shifts.id'),
+                    ->whereColumn('shift_signups.shift_id', 'shifts.id')
+                    ->whereNull('shift_signups.cancelled_at'),
                 '<',
                 DB::raw('shifts.capacity')
             )

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -74,6 +74,24 @@ test('shows shifts needing attention count', function () {
         ->assertSee('1'); // shifts needing attention
 });
 
+test('shiftsNeedingAttention excludes cancelled signups', function () {
+    ['user' => $user, 'organization' => $org] = createUserWithOrganization();
+    app()->instance(Organization::class, $org);
+
+    $event = Event::factory()->for($org)->published()->create(['starts_at' => now()->addWeek(), 'ends_at' => now()->addWeek()->addHours(4)]);
+    $job = VolunteerJob::factory()->for($event)->create();
+    // Shift with capacity 1, 1 cancelled signup -> should still need attention
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create(['capacity' => 1]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $shift->id,
+        'cancelled_at' => now(),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Dashboard::class)
+        ->assertSee('1'); // shift still needs attention because signup is cancelled
+});
+
 test('lists upcoming events in table', function () {
     ['user' => $user, 'organization' => $org] = createUserWithOrganization();
     app()->instance(Organization::class, $org);


### PR DESCRIPTION
## Summary
- Add `whereNull('cancelled_at')` to the signup count subquery in `shiftsNeedingAttention`
- Cancelled signups were inflating the count, making shifts appear more filled than they are

## Test plan
- [x] New test: shift with only cancelled signups still counts as needing attention
- [x] All 14 Dashboard tests pass
- [x] Full test suite green (825 tests, 1792 assertions)
- [x] Pint formatting clean
- [x] No other subqueries in the codebase have the same pattern

Closes #26