### PR TITLE
docs: add use cases, guest lists, private events, and docs index

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,43 @@
+# Voluntify — Dokumentationsindex
+
+## Übersicht
+
+- [Gesamtübersicht](review_voluntify-gesamtuebersicht.md) — Architektur, alle Features, Entscheidungen (Hauptreferenz)
+- [Ubiquitous Language](ubiquitous-language.md) — Glossar aller Fachbegriffe
+
+## Guides
+
+- [Getting Started](getting-started.md) — Erstes Projekt und Event in 15 Minuten
+- [Managing Projects](managing-projects.md) — Projekte, Gear, Custom Fields, Projektwebsite
+- [Creating Events](creating-events.md) — Events, Jobs, Schichten, E-Mail-Vorlagen, Announcements
+- [Recruiting Volunteers](recruiting-volunteers.md) — Signup-Flow, Projektwebsite, Helfer-Portal
+- [Managing Volunteers](managing-volunteers.md) — Volunteer-Liste, manuelles Anlegen, Organizer-Aktionen, Dashboard
+- [Checking In Volunteers](checking-in-volunteers.md) — Entry Staff Scanner, Volunteer Admin Scanner, Gear Pickup, Offline
+- [Tracking Attendance](tracking-attendance.md) — Schicht-Anwesenheit
+- [Managing Your Team](managing-your-team.md) — Organizer einladen, Scanner-Staff zuweisen
+- [Settings and Account](settings-and-account.md) — Profil, Passwort, 2FA, SMTP, Activity Log
+
+## Rollen & Berechtigungen
+
+- [Roles and Permissions](roles-and-permissions.md) — Rollenmodell und Permission Matrix
+
+## Use Cases
+
+- [Use Cases Index](use-cases/INDEX.md) — Alle Use Cases nach Bereich
+
+## Spezifikationen
+
+- [Gästelisten](use-cases/uc-15-gaesteliste-erstellen.md) — VIPs, Künstler, Begleitpersonen mit QR-Codes und Gear (#90)
+- [Private Events](use-cases/uc-02-privates-event.md) — Events nur über Direktlink zugänglich (#91)
+
+## Entscheidungen
+
+- [PO-Session 2026-03-30](decisions/2026-03-30-po-session.md) — F1–F10, Announcements, Volunteer Management, Docs-Rewrite
+
+## Deployment
+
+- [Deploying with Docker + Caddy](deployment.md) — Docker Compose Setup
+
+## Veraltete Dateien
+
+- [Managing Event Groups](managing-event-groups.md) — ⚠️ Deprecated → siehe [Managing Projects](managing-projects.md)

--- a/docs/checking-in-volunteers.md
+++ b/docs/checking-in-volunteers.md
@@ -74,7 +74,11 @@ A volunteer's QR code is valid if they have at least one shift in the past or fu
 ### Tabs
 
 1. **QR-Scanner** -- Camera viewfinder
-2. **Gastliste** (optional) -- Browse all eligible volunteers
+2. **Gastliste** (optional) -- Browse all eligible volunteers AND guests from assigned guest lists. The list is split into two sections:
+   - **Volunteers** -- All volunteers with active shifts (as before)
+   - **Gäste** -- Grouped by guest group (e.g. "DJ Soundwave 2/3 eingecheckt"), with individual check-in status per entry
+
+Guests from guest lists are also scannable via QR code. See [Managing Volunteers > Gästelisten](managing-volunteers.md#gästelisten) for setup.
 
 ## Volunteer Admin Scanner
 
@@ -105,6 +109,15 @@ The Organizer configures which modes are active for each scanner:
 - No gear assigned → neutral message "Kein Gear zugewiesen" (no error/red -- this is not an error state)
 
 > Why a neutral message instead of an error? Not every volunteer has gear. A gear-only scanner should not alarm the operator when a volunteer simply has no gear items. Neutral grey, not red.
+
+### Guests in the Volunteer Admin Scanner
+
+Guests from guest lists also appear in the Volunteer Admin Scanner -- but only if they have gear assigned. The gear flow is the same as for volunteers, with one difference for Typ-1 items:
+
+- **Typ-1 with selection:** Normal state change (e.g. "Ausstehend" → "Abgeholt")
+- **Typ-1 without selection ("Auswahl ausstehend"):** The operator selects directly in the scanner via dropdown (e.g. asks the guest for their T-shirt size, then selects "L"). The selection is saved for statistics. This differs from volunteers, where "Auswahl ausstehend" blocks pickup until the volunteer selects via the portal.
+
+> Why can operators select for guests but not for volunteers? Guests have no portal for self-service. The scanner is the only touchpoint.
 
 ### Gear Pickup via Scanner
 

--- a/docs/creating-events.md
+++ b/docs/creating-events.md
@@ -24,6 +24,7 @@ The event is created in **Draft** status.
 1. Go to the event's **Einstellungen > Allgemein**.
 2. Update name, date, location, description, or title image.
 3. Additional settings:
+   - **Sichtbarkeit** -- Öffentlich (default) or Privat. Private events are not shown on the project website and can only be accessed via a secret direct link (`/event/{token}`). Toggle is changeable at any time, even after publishing.
    - **Anmeldefrist** -- Date/time after which signups automatically close (Published Open → Published Closed).
    - **Telefon-Pflichtfeld** -- Toggle to require phone number during signup.
    - **Attendance Grace Period (Minuten)** -- Minutes after shift start where a scan is still "On Time".
@@ -95,7 +96,11 @@ Draft --> Published Open <--> Published Closed --> Archived
 1. Go to **Übersicht**.
 2. Click **Veröffentlichen**.
 
-**Blocked if no shifts exist.** On first publish of any event in the project, the project website is activated.
+**Blocked if no shifts exist.** On first publish of a **public** event in the project, the project website is activated. Private events do not activate the project website.
+
+**Private events** are published the same way but remain invisible on the project website. Share the direct link (`/event/{token}`) with the intended participants.
+
+> Example: "Workshop Hauptorga" is a private event for core organisers. "Hauptabend" is public. Publishing the workshop does not activate the project website -- only publishing "Hauptabend" does.
 
 > Why block without shifts? An event without shifts has nothing for volunteers to sign up for. Publishing it would create confusion.
 

--- a/docs/managing-projects.md
+++ b/docs/managing-projects.md
@@ -144,6 +144,45 @@ Read-only project overview for Organizers:
 - CSV export
 - Gear Tracker Mode in the Volunteer Admin Scanner
 
+## Guest Lists
+
+Guest lists manage non-volunteer guests (VIPs, artists, companions) who need entrance access and optionally gear, but don't go through the volunteer signup flow.
+
+### Create a Guest List
+
+1. Go to Projekt > **Gästelisten**.
+2. Click **Neue Gästeliste**.
+3. Configure:
+   - **Name** -- e.g. "Künstler Hauptabend"
+   - **Entry Staff Scanner** -- Assign to a scanner (required -- no scanner, no guest list)
+   - **Gear Items** -- Optional, select available items (Typ-1 and Typ-2)
+4. Add guest groups: Label (e.g. "DJ Soundwave") + number of entries.
+5. Per entry: Name (optional), Email (optional), Gear selection (optional).
+
+### Confirm and Send
+
+The guest list starts in **Entwurf** status -- no emails are sent.
+
+Click **Gästeliste bestätigen** to:
+- Generate one QR code per entry
+- Send grouped emails: if the same email appears for multiple entries, one email with all QR codes is sent
+- Entries without email: no email sent, QR code only in the system
+
+### After Confirmation
+
+- **Add guest:** New QR code, email sent immediately (if email provided)
+- **Remove guest:** QR code becomes invalid (scanner shows red)
+- **Edit guest:** QR code stays valid, data updated
+
+### Scanner Integration
+
+- **Entry Staff Scanner:** Guests appear in the Gastliste tab, searchable by name or group. QR codes are scannable.
+- **Volunteer Admin Scanner:** Guests appear only if they have gear. Typ-1 selection can be made directly in the scanner (guests have no portal).
+
+For the full specification, see [Use Case: Gästeliste erstellen](use-cases/uc-15-gaesteliste-erstellen.md).
+
+**Who can do this**: Organizer only.
+
 ## Clone a Project
 
 1. From the Dashboard, click the project tile's quick action menu.

--- a/docs/review_voluntify-gesamtuebersicht.md
+++ b/docs/review_voluntify-gesamtuebersicht.md
@@ -125,14 +125,31 @@ Draft ──→ Published Open ⇄ Published Closed ──→ Archived
   └──── (Wartung: zurück zu Draft) ────────────┘
 ```
 
+### Event-Sichtbarkeit
+
+Events haben eine Sichtbarkeitseigenschaft:
+
+| Typ | Projektwebsite | Zugang |
+|---|---|---|
+| **Öffentlich** (Standard) | Sichtbar | Jeder mit Projektwebsite-Link |
+| **Privat** | Nicht sichtbar | Nur über geheimen Direktlink (`/event/{token}`) |
+
+**Privat** bedeutet: Das Event erscheint nie auf der Projektwebsite — weder als Published Open noch als Published Closed. Volunteers können sich ausschließlich über den geheimen Direktlink anmelden, den der Organizer gezielt teilt (per E-Mail, Messenger etc.).
+
+> Beispiel 1: „Workshop Hauptorga" — die Kernorganisatoren sind selbst Volunteers (wegen Gear, QR-Tickets), aber das Event soll nicht öffentlich sichtbar sein, da es nur für eingeladene Personen ist.
+>
+> Beispiel 2: „Grafikteam" — Designer arbeiten wochenlang vor dem Event, haben keine klassische Schicht, sollen aber im System erfasst werden (Gear, Anwesenheit). Privates Event mit flexiblen Schichtzeiten (z.B. „nach Bedarf").
+
+Der Organizer setzt die Sichtbarkeit in den **Event-Einstellungen** (Toggle: Öffentlich / Privat). Der Wechsel ist jederzeit möglich — auch nach Veröffentlichung.
+
 ### Statusbeschreibungen
 
-| Status | Projektwebsite | Anmeldung | Organizer-Ansicht |
-|---|---|---|---|
-| **Draft** | Verborgen | Nicht möglich | Sichtbar mit Draft-Badge |
-| **Published Open** | Sichtbar mit CTA | Möglich | Aktiv |
-| **Published Closed** | Sichtbar mit „Abgelaufen" | Nicht möglich | Geschlossen |
-| **Archived** | Entfernt | Nicht möglich | Archiviert |
+| Status | Projektwebsite (öffentlich) | Projektwebsite (privat) | Anmeldung | Organizer-Ansicht |
+|---|---|---|---|---|
+| **Draft** | Verborgen | Verborgen | Nicht möglich | Sichtbar mit Draft-Badge |
+| **Published Open** | Sichtbar mit CTA | **Nicht sichtbar** (nur Direktlink) | Möglich | Aktiv |
+| **Published Closed** | Sichtbar mit „Abgelaufen" | **Nicht sichtbar** | Nicht möglich | Geschlossen |
+| **Archived** | Entfernt | Entfernt | Nicht möglich | Archiviert |
 
 ### Organizer-Controls
 
@@ -143,6 +160,7 @@ Draft ──→ Published Open ⇄ Published Closed ──→ Archived
 - **Re-Publish**: Draft → Published Open (sendet Update-E-Mail an alle aktiven Angemeldeten, #84)
 - **Archivieren**: Published Closed → Archived (endgültig, vorher Archivierungs-Pflicht)
 - **Geplantes Veröffentlichen**: Zeitgesteuerte Aktivierung
+- **Sichtbarkeit ändern**: Öffentlich ⇄ Privat (jederzeit)
 
 ### Re-Publish-Benachrichtigung (#84)
 
@@ -865,4 +883,115 @@ Dieselbe Standard-E-Mail wie bei einer Änderung durch den Volunteer selbst — 
 
 ---
 
-*Dokument basiert auf GitHub Issues #45–#86 (Stand: 2026-03-30)*
+## 18. Gästelisten (#90)
+
+Organizer können Gästelisten für nicht-registrierte Personen (VIPs, Künstler, Ehrengäste, Begleitpersonen) verwalten. Gäste durchlaufen keinen Signup-Flow, erhalten aber QR-Codes und können Gear erhalten.
+
+### Use Case
+
+Künstler erhalten als Teil ihrer Bezahlung Einlass für sich und Begleitpersonen. Organizer legt fest: „DJ Soundwave — 3 Gäste". Jeder Gast erhält einen eigenen QR-Code. Am Einlass wird per Entry Staff Scanner gescannt. Gear wird über den Volunteer Admin Scanner ausgegeben.
+
+### 18.1 Datenmodell
+
+```
+GuestList (Projekt-Level)
+├── project_id
+├── scanner_id          (FK → Entry Staff Scanner, Pflicht)
+├── name                ("Künstler Hauptabend")
+├── status              (draft / confirmed)
+├── gear_items          (welche Gear Items verfügbar)
+
+GuestGroup
+├── guest_list_id
+├── label               ("DJ Soundwave")
+├── guest_count         (3)
+
+GuestEntry
+├── guest_group_id
+├── number              (1, 2, 3)
+├── name                (nullable)
+├── email               (nullable)
+├── qr_token            (null bis Bestätigung)
+├── checked_in_at       (nullable)
+
+GuestEntryGear
+├── guest_entry_id
+├── project_gear_item_id    (Typ-1 ODER Typ-2)
+├── quantity                 (Typ-2: Kontingent, Typ-1: immer 1)
+├── picked_up_count          (Typ-2: 0...quantity)
+├── selection                (Typ-1: nullable — "M", "L", etc.)
+├── status                   (Typ-1: aus konfigurierbarer Zustandsliste)
+```
+
+### 18.2 Lifecycle
+
+**Entwurf:** Organizer erstellt Gästeliste, ordnet Entry Staff Scanner zu, legt Gruppen und Einträge an. Keine E-Mails.
+
+**Bestätigung:** Organizer klickt „Gästeliste bestätigen":
+- QR-Codes generiert (ein Code pro Eintrag)
+- E-Mails gruppiert versendet: gleiche E-Mail bei mehreren Einträgen → eine Mail mit allen QR-Codes
+- Einträge ohne E-Mail: kein Versand, QR-Code nur im System
+
+**Nachträgliche Änderungen (nach Bestätigung):**
+- Gast hinzufügen → neuer QR-Code → E-Mail sofort (wenn E-Mail vorhanden)
+- Gast entfernen → QR-Code ungültig → Scanner zeigt Rot
+- Gast bearbeiten → QR-Code bleibt gültig, Daten aktualisiert
+
+### 18.3 Beispiel
+
+| Gruppe | # | Name | E-Mail | Gear |
+|---|---|---|---|---|
+| DJ Soundwave | 1 | DJ Soundwave | dj@example.com | 3 Getränkemarken, T-Shirt (–) |
+| DJ Soundwave | 2 | – | dj@example.com | 2 Getränkemarken |
+| DJ Soundwave | 3 | – | – | 2 Getränkemarken |
+| Moderatorin Meier | 1 | Anna Meier | anna@example.com | 3 Getränkemarken, T-Shirt (L) |
+
+E-Mail-Versand bei Bestätigung:
+- dj@example.com → 1 Mail mit 2 QR-Codes (#1 + #2)
+- anna@example.com → 1 Mail mit 1 QR-Code (#1)
+- Eintrag DJ #3 (keine E-Mail) → kein Versand
+
+### 18.4 Scanner-Integration
+
+**Entry Staff Scanner:**
+- QR-Scan: 🟢 „Gast — DJ Soundwave 1/3" / 🟡 „Bereits eingecheckt" / 🔴 „Ungültig"
+- Gastliste-Tab: Volunteers (oben) + Gäste gruppiert (unten) mit Check-in-Status
+- Manuelle Suche: findet Gäste nach Name oder Gruppe
+- „Nächsten scannen"-Button wie bei Volunteers
+
+**Volunteer Admin Scanner:**
+- Gäste erscheinen nur wenn sie Gear haben
+- Typ-2: normaler Flow („2/3 abgeholt" → Tap → +1)
+- Typ-1 mit Auswahl: normaler Zustandswechsel
+- Typ-1 ohne Auswahl: Operator wählt direkt im Scanner (Dropdown) nach mündlicher Abfrage → Auswahl + Zustand gespeichert → Statistik korrekt
+
+> Unterschied zu Volunteers: Bei Volunteers blockiert „Auswahl ausstehend" die Ausgabe (Portal-Auswahl nötig). Bei Gästen kann der Operator die Auswahl direkt im Scanner treffen — Gäste haben kein Portal.
+
+| Feature | Entry Staff Scanner | Volunteer Admin Scanner |
+|---|---|---|
+| Gast QR scannen | ✓ | — |
+| Gastliste durchsuchen | ✓ | — |
+| Check-in (Einlass) | ✓ | — |
+| Gear Typ-1 ausgeben | — | ✓ (mit Größen-Abfrage) |
+| Gear Typ-2 ausgeben | — | ✓ |
+
+### 18.5 Tracking
+
+**Gästeliste Übersicht (Projekt > Gästelisten):**
+- DJ Soundwave: 2/3 eingecheckt
+- Moderatorin Meier: 0/2 eingecheckt
+- Gesamt: 2/5 eingecheckt
+
+**Gear-Tracking:**
+- Getränkemarken: 4/12 abgeholt
+- T-Shirt: 1/2 ausgegeben (1× „Auswahl ausstehend")
+
+### 18.6 Begründungen
+
+- **An Entry Staff Scanner gebunden:** Scanner-Offline-Daten müssen die Gäste enthalten. Verschiedene Eingänge können verschiedene Listen haben (VIP-Eingang vs. Haupteingang). Kein Scanner = kein Feature.
+- **E-Mails erst bei Bestätigung:** Organizer baut Liste in Ruhe auf. Kein versehentlicher Versand.
+- **Typ-1 direkt im Scanner (nur Gäste):** Gäste haben kein Portal. Mündliche Abfrage + Scanner-Eingabe ist der pragmatischste Weg. Statistik bleibt korrekt.
+
+---
+
+*Dokument basiert auf GitHub Issues #45–#90 (Stand: 2026-03-31)*

--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -91,6 +91,7 @@ A volunteer without any active shifts is a **valid state** (not an error) -- the
 | Scanner konfigurieren | Yes | Yes | -- | -- |
 | Volunteer manuell anlegen | Yes | Yes | -- | -- |
 | Announcements senden | Yes | Yes | -- | -- |
+| Gästelisten verwalten | Yes | Yes | -- | -- |
 | Dashboard | Yes | Yes | -- | -- |
 
 ### Scanner Level

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -180,3 +180,21 @@ After each result, a **manual "Nächsten scannen" button** must be tapped to pro
 **Helfer-Portal (Volunteer Portal)** -- A self-service page where volunteers view their shifts, QR code, gear status, personal data, and attendance history. Accessed via magic link -- no account needed. Shows all events within the project context.
 
 **Clone** -- Duplicating a project or individual event. Creates a Draft copy with structure (jobs, shifts, gear definitions, custom fields, email templates, scanner configs) but without volunteers, signups, or announcements. Optional date offset shifts all dates forward.
+
+**Private Event** -- An event that is not visible on the project website. Volunteers can only access it via a secret direct link (`/event/{token}`) shared by the Organizer. All other behaviour (signup flow, QR codes, gear, scanner) is identical to public events. Private events do not trigger project website activation on first publish.
+
+> Example: "Workshop Hauptorga" is a private event for core organisers who are themselves volunteers (need gear and QR tickets). "Grafikteam" is a private event for designers who work weeks before the festival and need to be in the system.
+
+## Guest Lists
+
+**Guest List (Gästeliste)** -- A project-level list of non-volunteer guests (VIPs, artists, companions) who need entrance access and optionally gear. Each guest list is bound to a specific Entry Staff Scanner. No scanner configured = no guest list feature.
+
+**Guest Group** -- A named group within a guest list (e.g. "DJ Soundwave") with a defined number of entries. Groups are used for tracking ("DJ Soundwave: 2/3 eingecheckt").
+
+**Guest Entry** -- A single person within a guest group. Has an optional name, optional email, and an individual QR code (generated on guest list confirmation). If email is provided, the QR code is sent automatically.
+
+> Example: "DJ Soundwave" is a guest group with 3 entries: entry #1 is the artist (name + email), entries #2 and #3 are unnamed companions (one with shared email, one without).
+
+**Guest List Confirmation** -- The act of finalising a guest list. Generates QR codes for all entries and sends grouped emails (same email for multiple entries → one email with all QR codes). Before confirmation, the list is in draft status and no emails are sent.
+
+**Guest Gear** -- Gear assigned to guest entries. Supports both Typ-1 and Typ-2. Key difference to volunteer gear: for Typ-1 items without a selection ("Auswahl ausstehend"), the scanner operator can select directly in the scanner (guests have no portal for self-service). This keeps statistics accurate.

--- a/docs/use-cases/INDEX.md
+++ b/docs/use-cases/INDEX.md
@@ -1,0 +1,36 @@
+# Use Cases
+
+Alle Use Cases, gruppiert nach Bereich. Jeder Use Case beschreibt einen konkreten Ablauf aus Sicht eines Akteurs mit Vorbedingungen, Schritten und Ergebnis.
+
+## Projekt & Event Setup
+
+- [UC-01: Projekt erstellen und erstes Event veröffentlichen](uc-01-projekt-erstellen.md)
+- [UC-02: Privates Event für interne Teams](uc-02-privates-event.md)
+- [UC-03: Event duplizieren für Folgejahr](uc-03-event-duplizieren.md)
+
+## Volunteer Signup
+
+- [UC-04: Neuer Volunteer meldet sich an](uc-04-volunteer-signup-neu.md)
+- [UC-05: Rückkehrender Volunteer meldet sich für weiteres Event an](uc-05-volunteer-signup-rueckkehr.md)
+- [UC-06: Organizer legt Volunteer manuell an](uc-06-volunteer-manuell-anlegen.md)
+
+## Scanner & Einlass
+
+- [UC-07: Entry Staff scannt Volunteer am Einlass](uc-07-einlass-scan.md)
+- [UC-08: Volunteer Admin checkt Schicht ein und gibt Gear aus](uc-08-checkin-gear.md)
+- [UC-09: Gast von Gästeliste am Einlass](uc-09-gaesteliste-einlass.md)
+
+## Gear
+
+- [UC-10: Gear Typ-1 Ausgabe mit fehlender Auswahl](uc-10-gear-typ1-auswahl-ausstehend.md)
+- [UC-11: Gear Typ-2 Ausgabe (Getränkemarken)](uc-11-gear-typ2-ausgabe.md)
+
+## Kommunikation
+
+- [UC-12: Announcement an gefilterte Gruppe senden](uc-12-announcement-senden.md)
+
+## Verwaltung
+
+- [UC-13: Organizer ändert Schichten eines Volunteers](uc-13-organizer-schicht-aendern.md)
+- [UC-14: Volunteer sagt Schicht selbst ab](uc-14-volunteer-absage.md)
+- [UC-15: Gästeliste erstellen und bestätigen](uc-15-gaesteliste-erstellen.md)

--- a/docs/use-cases/uc-01-projekt-erstellen.md
+++ b/docs/use-cases/uc-01-projekt-erstellen.md
@@ -1,0 +1,39 @@
+# UC-01: Projekt erstellen und erstes Event veröffentlichen
+
+**Akteur:** Organizer
+**Ziel:** Neues Projekt mit erstem Event live auf der Projektwebsite
+
+## Vorbedingungen
+
+- Organizer ist eingeloggt
+- Organisation existiert
+
+## Ablauf
+
+1. Dashboard → **Neues Projekt**
+2. Name eingeben (z.B. "Hochschulball 2026"), optional Beschreibung
+3. **Erstellen** → Projekt angelegt
+4. Im Projekt → **Neues Event**
+5. Name, Datum, Ort eingeben → **Erstellen** → Event im Status Draft
+6. **Jobs & Schichten** → Job hinzufügen (z.B. "Einlass")
+7. Schicht hinzufügen: Datum, Start/Endzeit, Kapazität
+8. Zurück zu **Übersicht** → **Veröffentlichen**
+9. Event wechselt zu Published Open
+10. Projektwebsite wird aktiviert unter `/p/{token}`
+11. Organizer kopiert den Link und teilt ihn
+
+## Ergebnis
+
+- Projektwebsite zeigt das Event mit Anmelde-Button
+- Volunteers können sich über den Link anmelden
+- Organizer sieht das Event im Dashboard
+
+## Sonderfälle
+
+- **Veröffentlichen ohne Schichten:** Blockiert — Fehlermeldung "Mindestens eine Schicht erforderlich"
+- **Mehrere Events:** Zweites Event wird nach Veröffentlichung automatisch auf der bestehenden Projektwebsite angezeigt
+
+## Referenz
+
+- Gesamtübersicht Sek. 4 (Event-Lifecycle), Sek. 5.1 (Projektwebsite)
+- Issues: #52, #45, #83

--- a/docs/use-cases/uc-02-privates-event.md
+++ b/docs/use-cases/uc-02-privates-event.md
@@ -1,0 +1,43 @@
+# UC-02: Privates Event für interne Teams
+
+**Akteur:** Organizer
+**Ziel:** Internes Event erstellen, das nur über Direktlink zugänglich ist
+
+## Vorbedingungen
+
+- Projekt existiert
+- Organizer ist eingeloggt
+
+## Ablauf
+
+1. Im Projekt → **Neues Event**
+2. Name eingeben (z.B. "Workshop Hauptorga" oder "Grafikteam")
+3. Event-Einstellungen → Sichtbarkeit auf **Privat** setzen
+4. Jobs & Schichten anlegen (z.B. Job "Vorbereitung", Schicht "nach Bedarf" ohne feste Zeiten)
+5. **Veröffentlichen** → Event ist Published Open
+6. **Direktlink kopieren** (`/event/{token}`)
+7. Link per E-Mail oder Messenger an die eingeladenen Personen teilen
+
+## Ergebnis
+
+- Event erscheint **nicht** auf der Projektwebsite
+- Nur Personen mit dem Direktlink können sich anmelden
+- Angemeldete Volunteers sind ganz normale Projekt-Volunteers (gleicher QR-Code, gleiche Gear-Ansprüche)
+- Organizer sieht das Event im Dashboard mit "Privat"-Badge
+
+## Beispiele
+
+**Workshop Hauptorga:** 8 Kernorganisatoren organisieren einen internen Workshop. Sie sollen im System sein (Gear, QR-Tickets), aber das Event ist nicht öffentlich — nur eingeladene Personen sollen sich anmelden.
+
+**Grafikteam:** 4 Designer arbeiten wochenlang vor dem Festival. Sie haben keine klassische Schicht, sondern arbeiten "nach Bedarf". Privates Event mit flexibler Schicht erfasst sie im System für Gear und Anwesenheit.
+
+## Sonderfälle
+
+- **Privates Event aktiviert nicht die Projektwebsite:** Erst ein öffentliches Event aktiviert `/p/{token}`
+- **Sichtbarkeit wechseln:** Organizer kann jederzeit zwischen Öffentlich und Privat wechseln
+- **Signup-Flow:** Identisch zum öffentlichen Event — gleiche Schritte, gleiche Validierung
+
+## Referenz
+
+- Gesamtübersicht Sek. 4 (Event-Sichtbarkeit)
+- Issue: #91

--- a/docs/use-cases/uc-03-event-duplizieren.md
+++ b/docs/use-cases/uc-03-event-duplizieren.md
@@ -1,0 +1,25 @@
+# UC-03: Event duplizieren für Folgejahr
+
+**Akteur:** Organizer
+**Ziel:** Bestehendes Event als Vorlage für ein neues Event nutzen
+
+## Vorbedingungen
+
+- Quell-Event existiert (beliebiger Status)
+
+## Ablauf
+
+1. Event-Übersicht → **Event duplizieren**
+2. Optional: **Datumsoffset** eingeben (z.B. +365 Tage)
+3. **Erstellen** → Neues Event im Status Draft
+
+## Ergebnis
+
+**Dupliziert:** Jobs, Schichten (mit verschobenen Daten), Gear-Referenzen, Custom Fields, E-Mail-Vorlagen, Scanner-Konfigurationen (ohne Zuweisungen)
+
+**Nicht dupliziert:** Volunteers, Anmeldungen, Announcements, Anwesenheitseinträge
+
+## Referenz
+
+- Gesamtübersicht Sek. 13 (Klon)
+- Issue: #78

--- a/docs/use-cases/uc-04-volunteer-signup-neu.md
+++ b/docs/use-cases/uc-04-volunteer-signup-neu.md
@@ -1,0 +1,45 @@
+# UC-04: Neuer Volunteer meldet sich an
+
+**Akteur:** Volunteer (neu, nicht im System)
+**Ziel:** Für Schichten anmelden und QR-Code erhalten
+
+## Vorbedingungen
+
+- Mindestens ein Event ist Published Open
+- Volunteer hat den Projektwebsite-Link oder einen Direktlink
+
+## Ablauf
+
+1. Volunteer öffnet Projektwebsite → sieht Events mit "Anmelden"-Button
+2. Klickt auf ein Event → **Schritt 1: E-Mail eingeben**
+3. System erkennt: neue E-Mail → sendet **Verifizierungs-E-Mail** (Code oder Link, 24h gültig)
+4. Volunteer verifiziert → System sendet **Willkommens-E-Mail** (`volunteer_welcome`) mit Portal-Link
+5. Volunteer klickt Link → landet auf **Schritt 2: Daten + Schichtauswahl**
+   - 20-Minuten-Timer startet
+   - Vorname, Nachname eingeben
+   - Schichten auswählen (Kapazitätsanzeige, Überschneidungsprüfung)
+6. **Schritt 3: Custom Fields + Gear**
+   - Projektfelder beantworten (z.B. "Diätanforderungen")
+   - Typ-1 Gear wählen (z.B. T-Shirt-Größe)
+   - Eventfelder beantworten (z.B. "Parkplatz benötigt?")
+7. **Schritt 4: Zusammenfassung** → **Verbindlich anmelden**
+8. Bestätigungs-E-Mail (`signup_confirmation`) mit Schichtdetails und Portal-Link
+
+## Ergebnis
+
+- Volunteer ist im Projekt registriert
+- Schichten sind reserviert
+- QR-Code (projektweiter) ist im Helfer-Portal verfügbar
+- 24h- und 4h-Reminder werden geplant
+
+## Sonderfälle
+
+- **Timer läuft ab:** Reservierungen werden freigegeben, Volunteer kann neu starten
+- **Schicht voll:** "Voll"-Badge, Auswahl blockiert
+- **Überschneidende Schichten:** Warnung + Server-Validierung, auch eventübergreifend
+- **Schicht ohne Zeiten:** Überschneidungsprüfung wird übersprungen
+
+## Referenz
+
+- Gesamtübersicht Sek. 5.2 (Signup-Flow)
+- Issues: #69, #49, #50, #80, #82

--- a/docs/use-cases/uc-05-volunteer-signup-rueckkehr.md
+++ b/docs/use-cases/uc-05-volunteer-signup-rueckkehr.md
@@ -1,0 +1,40 @@
+# UC-05: Rückkehrender Volunteer meldet sich für weiteres Event an
+
+**Akteur:** Volunteer (bereits im Projekt registriert)
+**Ziel:** Für Schichten eines weiteren Events im selben Projekt anmelden
+
+## Vorbedingungen
+
+- Volunteer hat sich zuvor für ein Event im Projekt angemeldet
+- E-Mail ist bereits verifiziert
+
+## Ablauf
+
+1. Volunteer öffnet Projektwebsite → sieht ein neues Event
+2. Klickt "Anmelden" → **Schritt 1: E-Mail eingeben**
+3. System erkennt: bekannte E-Mail → sendet **Magic Link** (kein erneutes Verifizieren)
+4. Volunteer klickt Magic Link → landet direkt auf **Schritt 2**
+   - Kurzer Hinweis auf bestehende Anmeldungen eingeblendet
+   - Persönliche Daten vorausgefüllt
+   - 20-Minuten-Timer startet
+   - Neue Schichten auswählen
+5. **Schritt 3: Custom Fields + Gear**
+   - Projektfelder bereits vorausgefüllt (nur einmal pro Projekt)
+   - Eventfelder neu (pro Event separat)
+6. **Schritt 4: Zusammenfassung** → **Verbindlich anmelden**
+
+## Ergebnis
+
+- Neue Schichten zum bestehenden Projekt-Volunteer hinzugefügt
+- Gleicher QR-Code (projektweit) — kein neuer Code
+- Bestätigungs-E-Mail mit allen aktiven Schichten
+
+## Sonderfälle
+
+- **Volunteer hat alle Schichten abgesagt:** System erkennt die E-Mail trotzdem → Magic Link, normaler Flow
+- **Volunteer kommt über Direktlink eines privaten Events:** Identischer Ablauf
+
+## Referenz
+
+- Gesamtübersicht Sek. 5.2 (Signup-Flow, Rückkehrender Volunteer)
+- Issues: #69, #51

--- a/docs/use-cases/uc-06-volunteer-manuell-anlegen.md
+++ b/docs/use-cases/uc-06-volunteer-manuell-anlegen.md
@@ -1,0 +1,38 @@
+# UC-06: Organizer legt Volunteer manuell an
+
+**Akteur:** Organizer
+**Ziel:** Volunteer ins System aufnehmen, der nicht den Signup-Flow durchlaufen hat
+
+## Vorbedingungen
+
+- Projekt existiert
+- Organizer kennt mindestens die E-Mail-Adresse des Volunteers
+
+## Ablauf
+
+1. Projekt → Volunteers → **Volunteer hinzufügen**
+2. Formular ausfüllen:
+   - E-Mail (Pflicht)
+   - Vorname, Nachname, Telefon (optional)
+   - Schichten zuweisen (optional)
+   - Custom Fields eintragen (optional)
+   - Gear-Auswahl (optional)
+3. **Speichern**
+4. System sendet `volunteer_added_by_organizer`-E-Mail mit Portal-Link
+
+## Ergebnis
+
+- Volunteer existiert im Projekt
+- Portal-Link in der E-Mail: Volunteer kann fehlende Daten vervollständigen
+- Fehlende Typ-1-Gear-Auswahl: Scanner zeigt "Auswahl ausstehend"
+- Fehlende Custom Fields: "Keine Angabe" im Organizer-UI
+- Fehlender Name: Portal zeigt Banner "Bitte vervollständige deine Registrierung"
+
+## Beispiel
+
+Organizer trifft jemanden auf einer Vereinsveranstaltung, der beim Hochschulball helfen möchte. Er erstellt den Volunteer mit nur der E-Mail. Der Volunteer erhält eine Mail, öffnet das Portal und trägt selbst Name, Schichten und T-Shirt-Größe ein.
+
+## Referenz
+
+- Gesamtübersicht Sek. 17.3 (Manuelles Anlegen)
+- Issue: #88

--- a/docs/use-cases/uc-07-einlass-scan.md
+++ b/docs/use-cases/uc-07-einlass-scan.md
@@ -1,0 +1,43 @@
+# UC-07: Entry Staff scannt Volunteer am Einlass
+
+**Akteur:** Entry Staff
+**Ziel:** Volunteer am Einlass per QR-Code validieren
+
+## Vorbedingungen
+
+- Entry Staff Scanner ist konfiguriert und aktiv (innerhalb Zeitfenster)
+- Entry Staff hat Scanner-Link erhalten und geöffnet
+
+## Ablauf
+
+1. Entry Staff öffnet Scanner-Link → Kamera-Viewfinder
+2. Volunteer zeigt QR-Code auf dem Handy
+3. Scanner erkennt QR automatisch → Ergebnis-Screen:
+   - 🟢 **Grün:** "Zugriff erlaubt" + Name des Volunteers
+   - 🟡 **Gelb:** "Bereits eingecheckt" + Name + letzter Scan-Zeitpunkt
+   - 🔴 **Rot:** "Kein Zugriff" + Grund (z.B. "Keine aktive Schicht")
+4. Entry Staff liest das Ergebnis
+5. Tippt **"Nächsten scannen"** → Kamera-Viewfinder für nächsten Volunteer
+
+## Ergebnis
+
+- Ankunft des Volunteers ist im System erfasst
+- Kein Auto-Dismiss — jedes Ergebnis muss bewusst bestätigt werden
+
+## Sonderfälle
+
+- **Volunteer ohne Schicht:** 🔴 Rot — "Keine aktive Schicht"
+- **QR-Code eines entfernten Gastes:** 🔴 Rot — "QR-Code ungültig"
+- **Offline:** Scanner validiert lokal, Check-in wird bei Reconnect gesynct
+- **Volunteer nicht in Cache:** QR validiert trotzdem (JWT ist self-contained), Hinweis "Nicht in lokaler Liste"
+
+## Alternativ: Manuelle Suche
+
+Wenn Volunteer keinen QR-Code hat:
+1. Tab **Gastliste** → Suche nach Name
+2. Volunteer auswählen → Check-in bestätigen
+
+## Referenz
+
+- Gesamtübersicht Sek. 8.6 (Entry Staff Scanner)
+- Issues: #58, #71, #73

--- a/docs/use-cases/uc-08-checkin-gear.md
+++ b/docs/use-cases/uc-08-checkin-gear.md
@@ -1,0 +1,38 @@
+# UC-08: Volunteer Admin checkt Schicht ein und gibt Gear aus
+
+**Akteur:** Volunteer Admin
+**Ziel:** Volunteer für Schicht einchecken und Gear ausgeben
+
+## Vorbedingungen
+
+- Volunteer Admin Scanner ist konfiguriert (Modus: Beides)
+- Scanner ist aktiv (innerhalb Zeitfenster)
+- Volunteer hat mindestens eine Schicht
+
+## Ablauf
+
+1. Volunteer Admin scannt QR-Code oder sucht manuell
+2. **Eligibility-Check:** Hat der Volunteer eine Schicht? → Ja
+3. **Check-in-Screen:** Schichten des Volunteers angezeigt
+   - Schicht auswählen → Anwesenheit markieren (On Time / Late)
+4. **Gear-Screen:** Gear-Items angezeigt
+   - Typ-1 (T-Shirt): Status "Ausstehend" → Tap → "Abgeholt"
+   - Typ-2 (Getränkemarken): "0/3 abgeholt" → Tap → "1/3 abgeholt"
+5. **"Nächsten scannen"** → bereit für nächsten Volunteer
+
+## Ergebnis
+
+- Anwesenheit für die Schicht erfasst
+- Gear-Status aktualisiert
+- Alles über den Scanner — kein Web-UI nötig
+
+## Sonderfälle
+
+- **Kein Gear zugewiesen:** Neutrale Meldung "Kein Gear zugewiesen" (kein Rot)
+- **Volunteer ohne Schicht:** Eligibility-Check schlägt fehl → kein Check-in möglich
+- **Typ-2 offline:** Nicht möglich — Typ-2 braucht Internetverbindung (Race-Condition-Schutz)
+
+## Referenz
+
+- Gesamtübersicht Sek. 8.7 (Volunteer Admin Scanner)
+- Issues: #56, #53

--- a/docs/use-cases/uc-09-gaesteliste-einlass.md
+++ b/docs/use-cases/uc-09-gaesteliste-einlass.md
@@ -1,0 +1,49 @@
+# UC-09: Gast von Gästeliste am Einlass
+
+**Akteur:** Entry Staff
+**Ziel:** Nicht-Volunteer-Gast (VIP, Künstler, Begleitperson) am Einlass einchecken
+
+## Vorbedingungen
+
+- Gästeliste ist bestätigt und dem Entry Staff Scanner zugeordnet
+- Gast hat QR-Code (per E-Mail erhalten) oder wird manuell gesucht
+
+## Ablauf — mit QR-Code
+
+1. Entry Staff scannt QR-Code des Gastes
+2. Ergebnis-Screen:
+   - 🟢 **Grün:** "Gast — DJ Soundwave 1/3" + Name (wenn vorhanden)
+   - 🟡 **Gelb:** "Bereits eingecheckt um 19:32"
+   - 🔴 **Rot:** "QR-Code ungültig" (Gast wurde entfernt)
+3. **"Nächsten scannen"**
+
+## Ablauf — ohne QR-Code
+
+1. Tab **Gastliste** → Suche "Soundwave"
+2. Gästegruppe erscheint: DJ Soundwave (0/3 eingecheckt)
+3. Entry Staff tippt auf den entsprechenden Eintrag → Check-in bestätigen
+
+## Ergebnis
+
+- Gast ist als eingecheckt markiert
+- Organizer sieht: "DJ Soundwave: 1/3 eingecheckt"
+
+## Ablauf — Gear-Ausgabe (Volunteer Admin Scanner)
+
+Wenn der Gast Gear hat, erscheint er auch im Volunteer Admin Scanner:
+
+1. Scan oder Suche → Gast gefunden
+2. **Typ-2:** "0/3 Getränkemarken" → Tap → +1
+3. **Typ-1 mit Auswahl:** Normaler Zustandswechsel
+4. **Typ-1 ohne Auswahl:** "Auswahl ausstehend" → Operator fragt mündlich → wählt Größe im Dropdown → gespeichert für Statistik
+
+## Sonderfälle
+
+- **Gast ohne E-Mail (kein QR):** Nur über manuelle Suche in der Gastliste auffindbar
+- **Gast nachträglich entfernt:** QR zeigt Rot, in Gastliste nicht mehr sichtbar
+- **Gast hat kein Gear:** Erscheint nicht im Volunteer Admin Scanner
+
+## Referenz
+
+- Gesamtübersicht Sek. 18 (Gästelisten)
+- Issue: #90

--- a/docs/use-cases/uc-10-gear-typ1-auswahl-ausstehend.md
+++ b/docs/use-cases/uc-10-gear-typ1-auswahl-ausstehend.md
@@ -1,0 +1,39 @@
+# UC-10: Gear Typ-1 Ausgabe mit fehlender Auswahl
+
+**Akteur:** Volunteer Admin
+**Ziel:** Gear ausgeben, obwohl der Volunteer keine Auswahl getroffen hat
+
+## Vorbedingungen
+
+- Volunteer wurde manuell vom Organizer angelegt (ohne Typ-1-Auswahl)
+- ODER: Gast auf Gästeliste ohne Typ-1-Auswahl
+
+## Ablauf — Volunteer (manuell angelegt)
+
+1. Volunteer Admin scannt QR-Code
+2. Gear-Screen: T-Shirt zeigt **"Auswahl ausstehend"**
+3. **Ausgabe blockiert** — Volunteer muss Auswahl selbst im Portal treffen
+4. Volunteer Admin informiert den Volunteer: "Bitte wähle deine Größe im Portal"
+
+## Ablauf — Gast (kein Portal)
+
+1. Volunteer Admin scannt Gast-QR
+2. Gear-Screen: T-Shirt zeigt **"Auswahl ausstehend"**
+3. Operator tippt auf "Auswahl ausstehend"
+4. **Dropdown öffnet sich:** XS / S / M / L / XL
+5. Operator fragt mündlich → wählt "L"
+6. System speichert: Auswahl = "L", Status → "Abgeholt"
+
+## Ergebnis
+
+- **Volunteer:** Muss selbst im Portal auswählen → dann Scanner-Ausgabe möglich
+- **Gast:** Auswahl wird direkt im Scanner getroffen → Statistik korrekt
+
+## Warum der Unterschied?
+
+Volunteers haben ein Portal für Self-Service. Die Auswahl gehört zum Volunteer — der Organizer soll nicht raten müssen. Gäste haben kein Portal. Mündliche Abfrage + Scanner-Eingabe ist der einzige Weg.
+
+## Referenz
+
+- Gesamtübersicht Sek. 7 (Gear), Sek. 17.3 ("Auswahl ausstehend"), Sek. 18.4 (Gäste)
+- Issues: #53, #88, #90

--- a/docs/use-cases/uc-11-gear-typ2-ausgabe.md
+++ b/docs/use-cases/uc-11-gear-typ2-ausgabe.md
@@ -1,0 +1,32 @@
+# UC-11: Gear Typ-2 Ausgabe (Getränkemarken)
+
+**Akteur:** Volunteer Admin
+**Ziel:** Mengenbasiertes Gear ausgeben (z.B. Getränkemarken, Essensbons)
+
+## Vorbedingungen
+
+- Volunteer oder Gast hat Typ-2 Gear zugewiesen
+- Volunteer Admin Scanner mit Gear-Pickup-Modus aktiv
+- **Internetverbindung erforderlich** (Typ-2 braucht Online-Sync)
+
+## Ablauf
+
+1. Scan oder manuelle Suche → Volunteer/Gast gefunden
+2. Gear-Screen: "Getränkemarken: 0/3 abgeholt"
+3. Operator tippt → "1/3 abgeholt"
+4. Nächster Tap → "2/3 abgeholt"
+5. Kontingent erreicht → Button deaktiviert
+
+## Ergebnis
+
+- Jede einzelne Ausgabe wird protokolliert
+- Echtzeit-Sync verhindert Doppelausgabe bei mehreren Scannern
+
+## Warum Online-Pflicht?
+
+Typ-2 zählt Mengen. Wenn zwei Scanner offline arbeiten und beide 3 Marken ausgeben, hat der Volunteer 6 statt 3. Online-Sync mit Server-seitigem Counter verhindert diese Race Condition.
+
+## Referenz
+
+- Gesamtübersicht Sek. 7 (Gear Typ-2)
+- Issue: #53

--- a/docs/use-cases/uc-12-announcement-senden.md
+++ b/docs/use-cases/uc-12-announcement-senden.md
@@ -1,0 +1,42 @@
+# UC-12: Announcement an gefilterte Gruppe senden
+
+**Akteur:** Organizer
+**Ziel:** Gezielte E-Mail an eine Teilgruppe der Volunteers senden
+
+## Vorbedingungen
+
+- Projekt mit Volunteers existiert
+
+## Ablauf
+
+1. Projekt → **Announcements** (oder Dashboard Quick Action)
+2. **Empfänger filtern:** Event → Job → Schicht (alle optional, kombinierbar)
+   - Beispiel: Event "Hauptabend" → Job "Kuchenausgabe" → alle Schichten
+3. Empfängeranzahl wird angezeigt (z.B. "12 Volunteers")
+4. **Inhalt:**
+   - Freitext: Subject + Body eingeben
+   - Oder: gespeichertes Template auswählen → Felder vorausgefüllt, editierbar
+5. **Zeitpunkt:** Sofort senden oder Datum/Uhrzeit planen
+6. **Senden** (oder **Planen**)
+
+## Ergebnis
+
+- E-Mail an alle gefilterten Volunteers versendet (oder geplant)
+- Announcement-History zeigt: Subject, Zeitpunkt, Empfängeranzahl
+
+## Beispiele
+
+- **Schicht-spezifisch:** "Schicht Kuchenausgabe: Bitte keine Teller mitbringen"
+- **Event-weit:** "Wegen des Wetters bitte Sonnenschutz mitbringen"
+- **Projekt-weit:** "Wichtige Infos für alle Helfer" (kein Filter)
+
+## Sonderfälle
+
+- **Announcements sind E-Mail-only** — kein Portal-Banner
+- **Keine Häufigkeitsbegrenzung** — Organizer-only Feature
+- **Templates** werden auf Organisationsebene gespeichert (wiederverwendbar über Projekte/Jahre)
+
+## Referenz
+
+- Gesamtübersicht Sek. 16 (Announcements)
+- Issue: #87

--- a/docs/use-cases/uc-13-organizer-schicht-aendern.md
+++ b/docs/use-cases/uc-13-organizer-schicht-aendern.md
@@ -1,0 +1,32 @@
+# UC-13: Organizer ändert Schichten eines Volunteers
+
+**Akteur:** Organizer
+**Ziel:** Schichten eines bestehenden Volunteers hinzufügen, ändern oder entfernen
+
+## Vorbedingungen
+
+- Volunteer existiert im Projekt
+
+## Ablauf
+
+1. Projekt → Volunteers → Volunteer auswählen
+2. **Schichten bearbeiten**
+3. Schichten hinzufügen oder entfernen (eventübergreifend innerhalb des Projekts)
+4. **Speichern**
+5. Volunteer erhält dieselbe Bestätigungs-/Änderungs-E-Mail wie bei eigener Änderung
+
+## Ergebnis
+
+- Schichtzuweisung aktualisiert
+- Volunteer wird per E-Mail informiert (gleiche Templates wie Self-Service)
+- Kapazitäten aktualisiert
+
+## Sonderfälle
+
+- **Alle Schichten entfernt:** Volunteer bleibt im Projekt (Status: "Keine Schicht") — kein Löschen
+- **Volle Schicht:** Organizer kann trotzdem zuweisen (Override der Kapazitätsprüfung)
+
+## Referenz
+
+- Gesamtübersicht Sek. 17.4 (Organizer-Aktionen)
+- Issue: #88

--- a/docs/use-cases/uc-14-volunteer-absage.md
+++ b/docs/use-cases/uc-14-volunteer-absage.md
@@ -1,0 +1,36 @@
+# UC-14: Volunteer sagt Schicht selbst ab
+
+**Akteur:** Volunteer
+**Ziel:** Eigene Schichtanmeldung stornieren
+
+## Vorbedingungen
+
+- Volunteer hat aktive Schichten
+- Absage ist im Projekt aktiviert
+- Absagefrist ist noch nicht abgelaufen
+
+## Ablauf
+
+1. Volunteer öffnet Helfer-Portal (via Magic Link)
+2. Unter **Schichten** → gewünschte Schicht finden
+3. **Absagen** klicken
+4. Bestätigung im Dialog
+5. Platz wird sofort freigegeben
+
+## Ergebnis
+
+- Schicht-Anmeldung storniert
+- Kapazität sofort für andere Volunteers verfügbar
+- Volunteer erhält Stornierungsbestätigung per E-Mail
+- Organizer erhält Stornierung im **Cancellation Digest** (alle 6 Stunden, an Event-Benachrichtigungs-E-Mail)
+
+## Sonderfälle
+
+- **Frist abgelaufen:** Absage-Button nicht sichtbar
+- **Absage deaktiviert:** Button nicht sichtbar
+- **Letzte Schicht abgesagt:** Volunteer bleibt im Projekt mit Status "Keine Schicht"
+
+## Referenz
+
+- Gesamtübersicht Sek. 6 (Shift Cancellation)
+- Issue: #85

--- a/docs/use-cases/uc-15-gaesteliste-erstellen.md
+++ b/docs/use-cases/uc-15-gaesteliste-erstellen.md
@@ -1,0 +1,48 @@
+# UC-15: Gästeliste erstellen und bestätigen
+
+**Akteur:** Organizer
+**Ziel:** Gästeliste für VIPs/Künstler/Begleitpersonen anlegen und QR-Codes versenden
+
+## Vorbedingungen
+
+- Projekt existiert
+- Mindestens ein Entry Staff Scanner ist konfiguriert
+
+## Ablauf
+
+1. Projekt → **Gästelisten** → **Neue Gästeliste**
+2. Konfiguration:
+   - Name: "Künstler Hauptabend"
+   - Entry Staff Scanner zuordnen (Pflicht)
+   - Gear Items zuweisen (optional, Dropdown)
+3. **Gästegruppen anlegen:**
+   - "DJ Soundwave" — 3 Einträge
+     - #1: Name "DJ Soundwave", E-Mail "dj@example.com", Gear: 3 Getränkemarken + T-Shirt
+     - #2: E-Mail "dj@example.com", Gear: 2 Getränkemarken
+     - #3: kein Name, keine E-Mail, Gear: 2 Getränkemarken
+   - "Moderatorin Meier" — 2 Einträge
+4. Status: **Entwurf** — keine E-Mails werden versendet
+5. Organizer prüft die Liste
+6. **Gästeliste bestätigen**:
+   - QR-Codes generiert (einer pro Eintrag)
+   - Gruppierte E-Mails:
+     - dj@example.com → 1 Mail mit 2 QR-Codes (#1 + #2)
+     - Eintrag #3 ohne E-Mail → kein Versand, QR nur im System
+7. Status: **Bestätigt**
+
+## Ergebnis
+
+- Gäste sind im Entry Staff Scanner sichtbar (Gastliste-Tab)
+- QR-Codes sind per Scanner validierbar
+- Gäste mit Gear erscheinen im Volunteer Admin Scanner
+
+## Nachträgliche Änderungen
+
+- **Gast hinzufügen:** Neuer QR-Code, E-Mail sofort versendet
+- **Gast entfernen:** QR wird ungültig (Scanner: Rot)
+- **Daten ändern:** QR bleibt gültig, Daten aktualisiert
+
+## Referenz
+
+- Gesamtübersicht Sek. 18 (Gästelisten)
+- Issue: #90


### PR DESCRIPTION
## Summary

Fortsetzung von PR #89 — Use Cases, Gästelisten, Private Events und Docs-Index.

### Neue Features dokumentiert:

**Gästelisten (#90):**
- VIPs, Künstler, Begleitpersonen mit individuellen QR-Codes
- An Entry Staff Scanner gebunden; Gäste in Gastliste-Tab sichtbar
- Gear-Support (Typ-1 mit Direktauswahl im Scanner, Typ-2 mit Menge)
- Gruppierter E-Mail-Versand bei Bestätigung
- Vollständige Spezifikation in Gesamtübersicht Sek. 18

**Private Events (#91):**
- Events nur über geheimen Direktlink zugänglich
- Use Cases: interne Workshops (Hauptorga), Langzeit-Teams (Grafikteam)
- Aktivieren nicht die Projektwebsite

### Dokumentationsstruktur:
- `docs/INDEX.md` als zentraler Einstiegspunkt
- `docs/use-cases/` mit 15 Use Cases für alle Hauptabläufe

### Aktualisierte Guides:
- checking-in-volunteers.md, creating-events.md, managing-projects.md
- roles-and-permissions.md, ubiquitous-language.md

## Test plan

- [ ] Use Cases auf Konsistenz mit Issues #90, #91 prüfen
- [ ] Keine Code-Änderungen — nur Dokumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)