### PR TITLE
feat(guest-lists): implement M12 guest lists (#90)

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,19 +1,19 @@
 ---
 pipeline_status: in_progress
-current_stage: security-audit
-current_focus: "M11 Scanner Rewrite — all stages complete, all high/medium security findings fixed, ready for milestone retrospective"
-current_milestone: m11-scanner
+current_stage: complete
+current_focus: "M12 Guest Lists — all stages complete, ready for milestone retrospective"
+current_milestone: m12-guest-lists
 entry_point: plan
-stages_to_run:
+stages_to_run: []
+completed_stages:
   - plan
   - implement
   - test
   - security-audit
-completed_stages: []
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-03-31"
-last_updated: "2026-03-31T16:00:00"
+last_updated: "2026-04-01"
 ---
 
 # TALL Pipeline — Index
@@ -26,8 +26,8 @@ last_updated: "2026-03-31T16:00:00"
 | m8-project-scoped | Project-Scoped Data | Volunteer project scope, gear remodel, ticket scope, custom fields, Private Events (#91) | m7 | complete |
 | m9-roles | Roles & Team | project_user pivot, role hierarchy, scanner roles | m7 | complete |
 | m10-signup | Signup Flow Rewrite | Multi-step wizard, shift reservations, manual enrollment | m8 | complete |
-| m11-scanner | Scanner Rewrite | Project scanners, temp auth, dual scanner types, rename volunteer tab to "Volunteers" | m8, m9 | in_progress |
-| m12-guest-lists | Guest Lists (#90) | Guest list CRUD, QR generation, grouped emails, scanner integration | m8, m11 | not_started |
+| m11-scanner | Scanner Rewrite | Project scanners, temp auth, dual scanner types, rename volunteer tab to "Volunteers" | m8, m9 | complete |
+| m12-guest-lists | Guest Lists (#90) | Guest list CRUD, QR generation, grouped emails, scanner integration | m8, m11 | complete |
 | m13-polish | Communication & Polish | Announcements, email templates, remaining features | m8, m9, m11 | not_started |
 
 ## Artifacts
@@ -39,6 +39,8 @@ last_updated: "2026-03-31T16:00:00"
 | `.tall-pipeline/m10-signup.md` | plan | m10-signup | Detailed M10 implementation plan (schema, actions, wizard, reservations, manual enrollment, tests) | complete |
 | `.tall-pipeline/m11-scanner.md` | plan | m11-scanner | Detailed M11 implementation plan (scanner schema, temp auth, dual scanner types, TS rewrite, API, tests) | complete |
 | `.tall-pipeline/m11-security-audit.md` | security-audit | m11-scanner | Security audit report (0 crit, 2 high, 1 med, 4 low) | complete |
+| `.tall-pipeline/m12-guest-lists.md` | plan | m12-guest-lists | Detailed M12 plan (4 migrations, 4 models, 10 actions, 2 Livewire components, scanner extensions, ~59 tests) | complete |
+| `.tall-pipeline/m12-security-audit.md` | security-audit | m12-guest-lists | Security audit report (0 crit, 1 high, 2 med, 3 low) | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/m11-scanner.md
+++ b/.tall-pipeline/m11-scanner.md
@@ -98,7 +98,20 @@
 
 ## Cross-Milestone Interface
 
-*(to be completed when milestone ships)*
+| Category | Items |
+|---|---|
+| Models | `ProjectScanner` (id, project_id, event_id?, name, type, modes, auth_code, scanner_token, starts_at, ends_at); `ProjectScannerAssignee` (id, project_scanner_id, email, link_sent_at, authenticated_at) |
+| Enums | `ScannerType` (EntryStaff, VolunteerAdmin); `ScannerMode` (Checkin, GearPickup) |
+| Actions | `CreateProjectScanner::execute(Project, array): ProjectScanner`; `UpdateProjectScanner::execute(ProjectScanner, array): ProjectScanner`; `DeleteProjectScanner::execute(ProjectScanner): void`; `SendScannerLinks::execute(ProjectScanner): void`; `AuthenticateScanner::execute(ProjectScanner, string): bool` |
+| Jobs | `SendScannerLinksJob` (queued, per-assignee, sends ScannerLinkMail) |
+| Middleware | `scanner-auth` (session-based, web routes); `scanner-api` (X-Scanner-Token header, API routes) |
+| Routes (public) | `scanner.auth` → `GET /s/{scannerToken}` (ScannerAuth); `scanner.app` → `GET /s/{scannerToken}/scan` (ScannerApp, scanner-auth middleware) |
+| Routes (API) | `scanner-api.data` → `GET /api/scanner/{scannerId}/data`; `scanner-api.sync` → `POST .../sync`; `scanner-api.gear-pickup` → `POST .../gear-pickup` (all scanner-api middleware) |
+| Routes (admin) | `projects.scanners` → `GET /projects/{projectId}/scanners` (ScannerManagement) |
+| Livewire | `ScannerAuth` (public auth page, 6-digit PIN); `ScannerApp` (scanner UI, both types); `Projects\ScannerManagement` (admin CRUD) |
+| Controller | `ScannerDataController` (data, sync, gearPickup endpoints) |
+| Policy | `ProjectPolicy::manageScanners()` — Organizer only |
+| Key patterns | Scanner token = 64-byte hex; auth code = bcrypt-hashed 6-digit PIN; session-based web auth; header-based API auth; time window enforcement via `isActive()`/`isExpired()` |
 
 ## Decisions
 

--- a/.tall-pipeline/m12-guest-lists.md
+++ b/.tall-pipeline/m12-guest-lists.md
@@ -1,0 +1,1278 @@
+# Milestone: m12-guest-lists — Guest Lists (#90)
+
+**Features:** Guest list CRUD, QR generation, grouped emails, scanner integration, guest gear tracking
+**Issues:** #90
+**Dependencies:** m8-project-scoped (complete), m11-scanner (complete)
+
+## Plan
+- **Status:** complete
+- **Gate summary:** 4 migrations, 4 new models, 1 new enum, 10 actions, 1 job, 1 mailable, 2 new Livewire components, 1 controller extension, 5 TS type additions, 2 IDB store additions, Alpine scanner extension. 4-pass self-review passed. See Decisions table.
+
+---
+
+## 1. Database Schema
+
+### 1.1 ERD
+
+```
+Project 1──* GuestList
+                ├── project_id (FK → projects)
+                ├── scanner_id (FK → project_scanners, EntryStaff type required)
+                └── gear_items (json — array of project_gear_item_ids)
+
+GuestList 1──* GuestGroup
+                ├── guest_list_id (FK → guest_lists, cascadeOnDelete)
+                └── label, guest_count
+
+GuestGroup 1──* GuestEntry
+                ├── guest_group_id (FK → guest_groups, cascadeOnDelete)
+                ├── qr_token (nullable, unique — generated on confirmation)
+                └── checked_in_at, checked_in_by
+
+GuestEntry 1──* GuestEntryGear
+                ├── guest_entry_id (FK → guest_entries, cascadeOnDelete)
+                └── project_gear_item_id (FK → project_gear_items)
+```
+
+### 1.2 Migration #21: create_guest_lists_table
+
+```php
+Schema::create('guest_lists', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('scanner_id')->constrained('project_scanners')->restrictOnDelete();
+    $table->string('name');
+    $table->string('status')->default('draft'); // 'draft' | 'confirmed'
+    $table->dateTime('confirmed_at')->nullable();
+    $table->json('gear_items')->nullable(); // array of project_gear_item_ids
+    $table->timestamps();
+
+    $table->index(['project_id', 'status']);
+});
+```
+
+### 1.3 Migration #22: create_guest_groups_table
+
+```php
+Schema::create('guest_groups', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('guest_list_id')->constrained()->cascadeOnDelete();
+    $table->string('label');
+    $table->unsignedInteger('guest_count');
+    $table->timestamps();
+
+    $table->index('guest_list_id');
+});
+```
+
+### 1.4 Migration #23: create_guest_entries_table
+
+```php
+Schema::create('guest_entries', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('guest_group_id')->constrained()->cascadeOnDelete();
+    $table->unsignedInteger('number');
+    $table->string('name')->nullable();
+    $table->string('email')->nullable();
+    $table->string('qr_token', 64)->nullable()->unique();
+    $table->dateTime('checked_in_at')->nullable();
+    $table->unsignedBigInteger('checked_in_by')->nullable();
+    $table->timestamps();
+
+    $table->index('guest_group_id');
+    $table->index('qr_token');
+    $table->foreign('checked_in_by')->references('id')->on('users')->nullOnDelete();
+});
+```
+
+**Data classification:**
+- `name`, `email`: **confidential** (PII)
+- `qr_token`: **confidential** (authentication credential)
+- All other columns: **internal**
+
+### 1.5 Migration #24: create_guest_entry_gear_table
+
+```php
+Schema::create('guest_entry_gear', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('guest_entry_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('project_gear_item_id')->constrained()->cascadeOnDelete();
+    $table->unsignedInteger('quantity')->default(1);
+    $table->unsignedInteger('picked_up_count')->default(0);
+    $table->string('selection')->nullable(); // Typ-1: size choice (e.g. "M", "L")
+    $table->string('status')->nullable();    // Typ-1: state from available_states
+    $table->timestamps();
+
+    $table->unique(['guest_entry_id', 'project_gear_item_id']);
+});
+```
+
+### 1.6 Migration Order
+
+All 4 migrations must run in sequence (FK dependencies):
+1. `create_guest_lists_table` (depends on: projects, project_scanners)
+2. `create_guest_groups_table` (depends on: guest_lists)
+3. `create_guest_entries_table` (depends on: guest_groups, users)
+4. `create_guest_entry_gear_table` (depends on: guest_entries, project_gear_items)
+
+Forward-only: no `down()` methods.
+
+---
+
+## 2. Models
+
+### 2.1 GuestList
+
+```php
+class GuestList extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id', 'scanner_id', 'name', 'status', 'confirmed_at', 'gear_items',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => GuestListStatus::class,
+            'confirmed_at' => 'datetime',
+            'gear_items' => 'array',
+        ];
+    }
+
+    // Relationships
+    public function project(): BelongsTo;       // → Project
+    public function scanner(): BelongsTo;        // → ProjectScanner (FK: scanner_id)
+    public function groups(): HasMany;           // → GuestGroup
+    public function entries(): HasManyThrough;   // → GuestEntry through GuestGroup
+
+    // Scopes
+    public function scopeConfirmed(Builder $query): Builder;  // WHERE status = 'confirmed'
+    public function scopeForProject(Builder $query, int $projectId): Builder;
+
+    // Computed
+    public function isConfirmed(): bool;
+    public function isDraft(): bool;
+}
+```
+
+**Soft deletes:** No. Guest lists are explicit entities managed by Organizer. Deletion removes associated groups/entries via cascade.
+
+### 2.2 GuestGroup
+
+```php
+class GuestGroup extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'guest_list_id', 'label', 'guest_count',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'guest_count' => 'integer',
+        ];
+    }
+
+    // Relationships
+    public function guestList(): BelongsTo;  // → GuestList
+    public function entries(): HasMany;       // → GuestEntry
+
+    // Computed
+    public function checkedInCount(): int;    // entries where checked_in_at is not null
+}
+```
+
+### 2.3 GuestEntry
+
+```php
+class GuestEntry extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'guest_group_id', 'number', 'name', 'email', 'qr_token',
+        'checked_in_at', 'checked_in_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'number' => 'integer',
+            'checked_in_at' => 'datetime',
+        ];
+    }
+
+    // Relationships
+    public function group(): BelongsTo;        // → GuestGroup
+    public function gear(): HasMany;           // → GuestEntryGear
+    public function checkedInByUser(): BelongsTo; // → User (FK: checked_in_by)
+
+    // Computed
+    public function isCheckedIn(): bool;       // checked_in_at !== null
+    public function displayLabel(): string;    // "GroupLabel N/Total" e.g. "DJ Soundwave 1/3"
+
+    // QR
+    public function qrCodeSvg(): string;       // uses QrCodeGenerator with qr_token as data
+}
+```
+
+### 2.4 GuestEntryGear
+
+```php
+class GuestEntryGear extends Model
+{
+    use HasFactory;
+
+    protected $table = 'guest_entry_gear';
+
+    protected $fillable = [
+        'guest_entry_id', 'project_gear_item_id', 'quantity',
+        'picked_up_count', 'selection', 'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'integer',
+            'picked_up_count' => 'integer',
+        ];
+    }
+
+    // Relationships
+    public function entry(): BelongsTo;     // → GuestEntry
+    public function gearItem(): BelongsTo;  // → ProjectGearItem
+}
+```
+
+### 2.5 Model Modifications
+
+**Project** (existing):
+- Add `guestLists(): HasMany` relationship.
+
+**ProjectScanner** (existing):
+- Add `guestLists(): HasMany` relationship.
+- Add `guestEntries()` accessor: returns GuestEntry records for all confirmed guest lists linked to this scanner (for data endpoint).
+
+---
+
+## 3. Enums
+
+### 3.1 GuestListStatus
+
+```php
+enum GuestListStatus: string
+{
+    case Draft = 'draft';
+    case Confirmed = 'confirmed';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => 'Draft',
+            self::Confirmed => 'Confirmed',
+        };
+    }
+}
+```
+
+No other new enums needed. `GearItemType` (SizeSelection, Quantity) from M8 is reused for guest gear logic.
+
+---
+
+## 4. Authorization Model
+
+### 4.1 Policy Extension
+
+Guest lists are managed through the existing `ProjectPolicy`. Add one new method:
+
+```php
+// ProjectPolicy
+public function manageGuestLists(User $user, Project $project): bool
+{
+    return $user->projectRoleFor($project) === StaffRole::Organizer;
+}
+```
+
+**Rationale:** Only Organizers create/edit/confirm/delete guest lists (matches design spec). Scanner operators interact with guest data through the scanner only, never the admin UI.
+
+### 4.2 Access Rules Summary
+
+| Action | Allowed Roles |
+|---|---|
+| View guest lists | Organizer (via manageGuestLists) |
+| Create/edit/delete guest list | Organizer |
+| Confirm guest list | Organizer |
+| Add/remove groups/entries | Organizer |
+| Scan guest QR | Entry Staff Scanner (via scanner auth) |
+| Guest gear pickup | Volunteer Admin Scanner (via scanner auth) |
+
+### 4.3 Data Scoping
+
+- Guest lists are scoped by `project_id` and further scoped by `currentOrganization()` in Livewire components.
+- Scanner API scopes guest data by `scanner_id` on the ProjectScanner (confirmed guest lists linked to that scanner).
+- No global scopes needed; scoping is explicit in queries.
+
+---
+
+## 5. Component Architecture
+
+### 5.1 Page Map
+
+```
+Route                                  Component                Middleware              Gate
+GET /projects/{projectId}/guest-lists  GuestListIndex           auth,verified,resolve-org  manageGuestLists
+GET /projects/{projectId}/guest-lists/{guestListId}  GuestListShow  auth,verified,resolve-org  manageGuestLists
+```
+
+### 5.2 Component Hierarchy
+
+#### GuestListIndex (full-page)
+
+```
+GuestListIndex (full-page, #[Locked] projectId)
+├── Header: "Guest Lists" + "New Guest List" button
+├── GuestList cards (Blade loop — no nesting)
+│   └── Each card: name, status badge, scanner name, group count, entry count, checked-in count
+└── Create modal (Flux modal — inline in component)
+    ├── Name input
+    ├── Scanner dropdown (filtered: Entry Staff type only)
+    └── Gear items multi-select (from project gear items)
+```
+
+**Properties:**
+- `#[Locked] public int $projectId`
+- `public bool $showCreateModal = false`
+- Form fields: `name`, `scannerId`, `gearItemIds[]`
+- `#[Computed] guestLists()` — GuestList::forProject with groups count, entries count
+- `#[Computed] entryStaffScanners()` — ProjectScanner::where(type, EntryStaff)
+- `#[Computed] projectGearItems()` — ProjectGearItem for the project
+
+**Actions:** `createGuestList()`, `deleteGuestList(int $guestListId)`
+
+#### GuestListShow (full-page)
+
+```
+GuestListShow (full-page, #[Locked] projectId + guestListId)
+├── Header: name, status badge, "Confirm" button (if draft), "Edit" button
+├── Summary bar: total groups, total entries, checked-in count
+├── Groups section (inline in component)
+│   ├── Add group form (label, guest_count)
+│   └── Group cards (Blade loop)
+│       ├── Group header: label + "X/Y checked in" + delete button
+│       └── Entries table (Blade loop)
+│           ├── Entry row: #, name, email, gear summary, QR status, check-in status
+│           ├── Inline edit (Alpine x-data toggle)
+│           └── Add entry button (if count < guest_count or after confirm)
+└── Edit modal (Flux modal — name, scanner, gear items)
+```
+
+**Properties:**
+- `#[Locked] public int $projectId`
+- `#[Locked] public int $guestListId`
+- `public bool $showEditModal = false`
+- Group form: `newGroupLabel`, `newGroupCount`
+- Entry form: `editingEntryId`, `entryName`, `entryEmail`, `entryGear[]`
+- `#[Computed] guestList()` — with groups.entries.gear
+- `#[Computed] entryStaffScanners()`
+- `#[Computed] projectGearItems()`
+
+**Actions:**
+- `updateGuestList()` — name, scanner, gear items
+- `confirmGuestList()` — generates QR tokens, dispatches email job
+- `addGroup()` — creates GuestGroup with entries
+- `removeGroup(int $groupId)`
+- `addEntry(int $groupId)` — creates GuestEntry. If list is confirmed: generates QR + dispatches email (if email present) + shows success toast ("Entry added, invitation sent")
+- `removeEntry(int $entryId)` — deletes entry (QR becomes invalid)
+- `updateEntry(int $entryId)` — updates name/email/gear (QR stays valid)
+- `assignGear(int $entryId, array $gearSelections)` — creates/updates GuestEntryGear records
+
+### 5.3 Communication Patterns
+
+| From | To | Mechanism | Name |
+|---|---|---|---|
+| GuestListIndex | GuestListShow | Redirect | `route('guest-lists.show')` |
+| GuestListShow confirm | SendGuestInvitationsJob | Job dispatch | Queued per email group |
+
+No cross-component events needed. Both components are independent full-page components.
+
+### 5.4 Scanner Extensions (Existing Components)
+
+**ScannerApp Livewire component** — no PHP changes needed. All scanner logic is in Alpine/TS.
+
+**ScannerApp blade** (`scanner-app.blade.php`) — additions:
+1. Entry Staff: Add "Gastliste" tab alongside existing volunteer display. Tab shows guest groups with entries, check-in status, and manual check-in buttons.
+2. Entry Staff result panel: handle guest QR result states (green/yellow/red) with guest-specific messaging ("Gast -- DJ Soundwave 1/3").
+3. Volunteer Admin: Show guest entries with gear in the volunteer/guest list (guests with gear only).
+
+**ScannerDataController** — extension:
+- `data()` endpoint: include `guest_entries` array in response (for confirmed guest lists linked to the scanner).
+- New `guest-checkin` endpoint: `POST /api/scanner/{scannerId}/guest-checkin` for online guest check-in from scanner.
+- New `guest-gear-pickup` endpoint: `POST /api/scanner/{scannerId}/guest-gear-pickup` for guest gear state changes.
+
+---
+
+## 6. Alpine.js State Plan
+
+### 6.1 GuestListShow — Inline Entry Editing
+
+```js
+// Per entry row
+x-data="{ editing: false }"
+// Toggle edit mode, bind inputs to $wire properties
+```
+
+Minimal Alpine state. Form data is in Livewire properties; Alpine only controls the edit/view toggle.
+
+### 6.2 Scanner Extensions
+
+**Entry Staff scanner (`alpine-scanner.ts`):**
+- New internal state: `_guestEntries: GuestEntry[]` — loaded from data endpoint
+- New state: `_guestCheckins: GuestCheckin[]` — tracks which guests are checked in
+- New method: `_onGuestQrDetected(qrToken: string)` — lookup by `qr_token` in `_guestEntries`
+- New method: `confirmGuestCheckin(guestEntryId: number)` — POST to guest-checkin endpoint, add to outbox for offline
+- Tab state: `activeTab: 'scanner' | 'volunteers' | 'guests'` — controls which panel is shown
+- Guest search: `guestSearchQuery` string, filters `_guestEntries` by name/group label
+- Manual check-in: `manualGuestCheckin(guestEntryId: number)` — same as confirmGuestCheckin but triggered from list
+
+**Volunteer Admin scanner (`alpine-scanner.ts`):**
+- `_guestEntries` loaded alongside volunteers
+- Guest gear display alongside volunteer gear
+- `selectGuestGearState(guestEntryGearId: number, state: string)` — POST to guest-gear-pickup endpoint
+- `incrementGuestGearPickup(guestEntryGearId: number)` — POST to guest-gear-pickup for Typ-2 increment
+- `selectGuestGearSelection(guestEntryGearId: number, selection: string)` — POST for Typ-1 size selection (direct in scanner, no portal)
+
+### 6.3 $wire Integration
+
+No `$wire.entangle()` needed. Scanner data is fetched via API (fetch), not Livewire properties. Admin Livewire components use standard `wire:model` and `wire:click`.
+
+---
+
+## 7. Actions Inventory
+
+### 7.1 Guest List Management
+
+| # | Action | Signature | Side Effects |
+|---|---|---|---|
+| 1 | `CreateGuestList` | `execute(Project $project, array $data): GuestList` | Creates guest list in draft status |
+| 2 | `UpdateGuestList` | `execute(GuestList $guestList, array $data): GuestList` | Updates name, scanner, gear items |
+| 3 | `ConfirmGuestList` | `execute(GuestList $guestList): GuestList` | Sets status=confirmed + confirmed_at, dispatches `ConfirmGuestListJob` (single job handles token generation + email dispatch). Livewire action returns immediately. |
+| 4 | `DeleteGuestList` | `execute(GuestList $guestList): void` | Cascading delete (groups + entries + gear via DB cascade) |
+
+**Scanner deletion guard:** The `scanner_id` FK uses `restrictOnDelete`. Attempting to delete a ProjectScanner that has guest lists will throw a DB constraint exception. The `DeleteProjectScanner` action (from M11) does not need modification — the DB constraint prevents the cascade naturally. The ScannerManagement UI should catch this exception and show "Cannot delete scanner — it has guest lists assigned."
+
+### 7.2 Guest Group Management
+
+| # | Action | Signature | Side Effects |
+|---|---|---|---|
+| 5 | `AddGuestGroup` | `execute(GuestList $guestList, string $label, int $guestCount): GuestGroup` | Creates group + N empty GuestEntry rows (numbered 1..guestCount) |
+| 6 | `RemoveGuestGroup` | `execute(GuestGroup $group): void` | Deletes group (cascades entries + gear) |
+
+### 7.3 Guest Entry Management
+
+| # | Action | Signature | Side Effects |
+|---|---|---|---|
+| 7 | `AddGuestEntry` | `execute(GuestGroup $group, ?string $name, ?string $email, array $gearSelections = []): GuestEntry` | Creates entry with next number. If list is confirmed: generates qr_token + dispatches immediate email (if email present) |
+| 8 | `RemoveGuestEntry` | `execute(GuestEntry $entry): void` | Deletes entry (QR becomes invalid). Does NOT renumber remaining entries. |
+| 9 | `UpdateGuestEntry` | `execute(GuestEntry $entry, array $data): GuestEntry` | Updates name/email. QR token stays valid. Updates gear via nested array. |
+
+### 7.4 Scanner Operations
+
+| # | Action | Signature | Side Effects |
+|---|---|---|---|
+| 10 | `CheckInGuest` | `execute(GuestEntry $entry, ?int $checkedInBy = null): GuestEntry` | Sets checked_in_at + checked_in_by. Returns entry. Throws if already checked in. |
+
+| 11 | `RecordGuestGearPickup` | `execute(GuestEntryGear $gear, array $data): GuestEntryGear` | Typ-1: sets selection + status. Typ-2: increments picked_up_count (capped at quantity). Online-only. |
+
+**Why a separate action for guest gear (unlike the single-table model)?** Guest gear uses a simpler single-table model (`GuestEntryGear` with `picked_up_count`, `selection`, `status` inline) rather than the volunteer's two-table pattern (`volunteer_gear` + `volunteer_gear_pickups`). The reason: volunteers self-serve via portal (need audit trail of individual pickup events), while guests have no portal — the operator makes all decisions at the scanner. A single row per gear item with mutable state is sufficient. Despite the simpler model, the action class is extracted to maintain the project convention of all business logic in actions.
+
+### 7.5 Action Method Convention
+
+All actions use `execute()` (existing project convention), not `__invoke()` or `handle()`.
+
+---
+
+## 8. Queue & Events
+
+### 8.1 Job Inventory
+
+| Job | Queue | Timeout | Tries | Backoff | Idempotent? |
+|---|---|---|---|---|---|
+| `ConfirmGuestListJob` | `default` | 120s | 3 | 10,30,60 | Yes (checks status=confirmed, skips if tokens exist) |
+| `SendGuestInvitationsJob` | `mail` | 60s | 3 | 10,30,60 | Yes (grouped by email, checks qr_token exists) |
+
+### 8.2 ConfirmGuestListJob (Orchestrator)
+
+**Trigger:** `ConfirmGuestList` action dispatches this single job. Livewire action returns immediately after dispatch.
+
+**Logic:**
+1. Receives: `GuestList $guestList`
+2. Generates all `qr_token` values in PHP (`bin2hex(random_bytes(32))` per entry), then bulk-updates entries in a single query via `upsert()` within a DB transaction
+3. Collects unique email addresses across all entries
+4. Dispatches one `SendGuestInvitationsJob` per unique email
+
+### 8.3 SendGuestInvitationsJob
+
+**Trigger:** `ConfirmGuestListJob` dispatches one per unique email. Also dispatched by `AddGuestEntry` when adding to a confirmed list (single entry, immediate).
+
+**Logic:**
+1. Receives: `GuestList $guestList`, `string $email`
+2. Loads all GuestEntry records for this list where email matches
+3. Generates QR code SVGs for each entry
+4. Sends single `GuestInvitationMail` with all QR codes
+
+**Grouping:** Same email across multiple entries in the list receives ONE email with ALL their QR codes.
+
+### 8.3 GuestInvitationMail
+
+```php
+class GuestInvitationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public GuestList $guestList,
+        /** @var Collection<int, GuestEntry> */
+        public Collection $entries,
+    ) {}
+
+    public function envelope(): Envelope;  // Subject: "Your Guest Pass — {guestList.name}"
+    public function content(): Content;    // markdown: 'mail.guest-invitation'
+}
+```
+
+**Template:** Shows guest list name, project name, and for each entry: entry number, group label, QR code SVG inline. No per-org SMTP routing (guests are not volunteers — use default mailer).
+
+### 8.4 Event-Listener Map
+
+No domain events needed for M12. Guest list operations are synchronous admin actions. The only async work is email sending via the job.
+
+---
+
+## 9. API Design (Scanner API Extensions)
+
+### 9.1 Existing Endpoint Extension
+
+**`GET /api/scanner/{scannerId}/data`** — add `guest_entries` to response:
+
+```json
+{
+    "scanner": { ... },
+    "events": [ ... ],
+    "volunteers": [ ... ],
+    "arrivals": [ ... ],
+    "keys": { ... },
+    "guest_entries": [
+        {
+            "id": 1,
+            "guest_group_id": 1,
+            "group_label": "DJ Soundwave",
+            "group_guest_count": 3,
+            "number": 1,
+            "name": "DJ Soundwave",
+            "email": "dj@example.com",
+            "qr_token": "abc123...",
+            "checked_in_at": null,
+            "checked_in_by": null,
+            "gear": [
+                {
+                    "id": 1,
+                    "guest_entry_id": 1,
+                    "project_gear_item_id": 5,
+                    "gear_item_name": "T-Shirt",
+                    "gear_item_type": "size_selection",
+                    "available_sizes": ["S", "M", "L", "XL"],
+                    "available_states": ["ordered", "received", "issued"],
+                    "quantity": 1,
+                    "picked_up_count": 0,
+                    "selection": null,
+                    "status": null
+                }
+            ]
+        }
+    ]
+}
+```
+
+**Scoping:**
+- **Entry Staff:** Only entries from confirmed guest lists where `guest_lists.scanner_id = $scanner->id`. Full payload including `qr_token`.
+- **Volunteer Admin:** Guest entries from all confirmed guest lists in the same project, filtered by `whereHas('gear')` (only entries with gear assigned). `qr_token` is **stripped** from the payload (Volunteer Admin never scans QR — they only handle gear pickup by ID).
+
+**Security note (D11):** `qr_token` is a confidential credential. Entry Staff scanners need it for offline QR matching. Volunteer Admin scanners do not — the token is omitted from their payload to reduce exposure. The scanner device is already trusted (authenticated via scanner token), so Entry Staff having tokens in IDB is an accepted risk.
+
+### 9.2 New Endpoint: Guest Check-In
+
+```
+POST /api/scanner/{scannerId}/guest-checkin
+```
+
+**Request:**
+```json
+{
+    "guest_entry_id": 1
+}
+```
+
+**Response:**
+```json
+{
+    "success": true,
+    "guest_entry": { "id": 1, "checked_in_at": "2026-07-01 19:32:00", ... },
+    "already_checked_in": false
+}
+```
+
+**Auth:** `scanner-api` middleware (X-Scanner-Token). Scanner type must be `EntryStaff`. Guest entry must belong to a confirmed guest list linked to this scanner.
+
+### 9.3 New Endpoint: Guest Gear Pickup
+
+```
+POST /api/scanner/{scannerId}/guest-gear-pickup
+```
+
+**Request:**
+```json
+{
+    "guest_entry_gear_id": 1,
+    "selection": "L",
+    "status": "issued",
+    "quantity": 1
+}
+```
+
+**Response:**
+```json
+{
+    "success": true,
+    "guest_entry_gear": { ... }
+}
+```
+
+**Auth:** `scanner-api` middleware. Scanner type must be `VolunteerAdmin`. Guest entry gear must belong to a guest entry in the same project.
+
+**Logic:**
+- Typ-1 (SizeSelection): set `selection` and/or `status` on the GuestEntryGear record
+- Typ-2 (Quantity): increment `picked_up_count` by `quantity` (capped at `quantity` field)
+- Online-only (consistent with D4/D10 from M11)
+
+### 9.4 New Endpoint: Guest Check-In Sync (Offline Support)
+
+```
+POST /api/scanner/{scannerId}/guest-sync
+```
+
+**Request:**
+```json
+{
+    "guest_checkins": [
+        { "guest_entry_id": 1, "checked_in_at": "2026-07-01 19:32:00" }
+    ]
+}
+```
+
+**Response:**
+```json
+{
+    "guest_entries": [ ... ]
+}
+```
+
+**Rationale:** Entry Staff scanners support offline mode. Guest check-ins must be buffered in outbox just like volunteer arrivals. This endpoint batch-syncs buffered guest check-ins.
+
+---
+
+## 10. TypeScript Changes
+
+### 10.1 New Types (`types.ts`)
+
+```typescript
+export interface GuestEntry {
+    id: number;
+    guest_group_id: number;
+    group_label: string;
+    group_guest_count: number;
+    number: number;
+    name: string | null;
+    email: string | null;
+    qr_token: string | null;
+    checked_in_at: string | null;
+    checked_in_by: number | null;
+    gear: GuestEntryGearItem[];
+}
+
+export interface GuestEntryGearItem {
+    id: number;
+    guest_entry_id: number;
+    project_gear_item_id: number;
+    gear_item_name: string;
+    gear_item_type: 'size_selection' | 'quantity';
+    available_sizes: string[] | null;
+    available_states: string[] | null;
+    quantity: number;
+    picked_up_count: number;
+    selection: string | null;
+    status: string | null;
+}
+```
+
+### 10.2 OutboxEntry Extension
+
+Add `'guest_checkin'` to the `type` union:
+
+```typescript
+export interface OutboxEntry {
+    id?: number;
+    type: 'arrival' | 'attendance' | 'guest_checkin';
+    // ... existing fields ...
+    guest_entry_id?: number;  // for guest_checkin type
+}
+```
+
+### 10.3 IDB Store Changes
+
+**DB_VERSION bump to 4.** The `onupgradeneeded` handler must be refactored to use `event.oldVersion` branching instead of dropping all stores unconditionally:
+
+```typescript
+// In onupgradeneeded:
+const oldVersion = event.oldVersion;
+
+if (oldVersion < 3) {
+    // Full rebuild for versions before 3 (existing behavior)
+    for (const name of db.objectStoreNames) {
+        db.deleteObjectStore(name);
+    }
+    // Create all stores: volunteers, outbox, keys, guest_entries
+}
+
+if (oldVersion >= 3 && oldVersion < 4) {
+    // Additive: only create the new guest_entries store
+    const guestStore = db.createObjectStore('guest_entries', { keyPath: ['scannerId', 'id'] });
+    guestStore.createIndex('byScanner', 'scannerId', { unique: false });
+}
+```
+
+New functions:
+- `storeGuestEntries(scannerId: number, entries: GuestEntry[]): Promise<void>`
+- `getGuestEntries(scannerId: number): Promise<GuestEntry[]>`
+- `searchGuestEntries(scannerId: number, query: string): Promise<GuestEntry[]>` — searches name + group_label
+
+### 10.4 Alpine Scanner Extensions (`alpine-scanner.ts`)
+
+**New internal state:**
+```typescript
+_guestEntries: [] as GuestEntry[],
+_guestCheckins: [] as { guest_entry_id: number; checked_in_at: string }[],
+activeTab: 'scanner' as 'scanner' | 'volunteers' | 'guests',
+guestSearchQuery: '' as string,
+```
+
+**New methods:**
+```typescript
+// Entry Staff only
+_onQrDetected(data: string): // Extended to check guest QR tokens (simple string match, not JWT)
+confirmGuestCheckin(guestEntryId: number): // POST to guest-checkin or add to outbox
+manualGuestCheckin(guestEntryId: number): // Same as confirmGuestCheckin, different trigger
+
+// Volunteer Admin only
+selectGuestGearState(guestEntryGearId: number, state: string): // POST to guest-gear-pickup
+selectGuestGearSelection(guestEntryGearId: number, selection: string): // POST, Typ-1 direct
+incrementGuestGearPickup(guestEntryGearId: number): // POST, Typ-2 increment
+```
+
+**QR detection change:** The `_onQrDetected` method currently assumes all QR codes are JWTs. Must be extended:
+1. First, try JWT validation (existing volunteer flow).
+2. If JWT validation fails, check if the scanned data matches a `qr_token` in `_guestEntries` (simple string lookup).
+3. If match found, show guest result instead of volunteer result.
+
+This dual-path detection lets guest QR tokens (random strings) coexist with volunteer JWT tokens.
+
+### 10.5 Sync Module Extension (`sync.ts`)
+
+**Critical: Replace `clearOutbox()` with selective deletion.** The current `syncOutbox()` calls `clearOutbox()` after syncing arrivals, which deletes ALL outbox entries including unsynced guest check-ins. Must change to:
+1. Sync arrivals → delete only synced arrival entries by ID
+2. Sync guest check-ins → delete only synced guest_checkin entries by ID
+3. Never clear the entire outbox store at once
+
+```typescript
+// Sync arrivals
+const arrivals = entries.filter((e) => e.type === 'arrival');
+if (arrivals.length > 0) {
+    await postArrivals(arrivals);
+    await deleteOutboxEntries(arrivals.map(e => e.id)); // selective delete
+}
+
+// Sync guest check-ins
+const guestCheckins = entries.filter((e) => e.type === 'guest_checkin');
+if (guestCheckins.length > 0) {
+    // POST to guest-sync endpoint
+    await deleteOutboxEntries(guestCheckins.map(e => e.id)); // selective delete
+}
+```
+
+### 10.6 Service Worker (`sw.js`)
+
+Add guest API endpoints to network-first pattern:
+- `/api/scanner/*/guest-checkin`
+- `/api/scanner/*/guest-gear-pickup`
+- `/api/scanner/*/guest-sync`
+
+---
+
+## 11. Scanner Blade Changes
+
+### 11.1 Entry Staff Scanner (`scanner-app.blade.php`)
+
+Add tab navigation and guest panel:
+
+```html
+{{-- Tab bar (Entry Staff only) --}}
+<nav x-show="scannerType === 'entry_staff'" class="flex border-b border-zinc-700">
+    <button @click="activeTab = 'scanner'" :class="activeTab === 'scanner' ? 'border-emerald-500' : ''">
+        Scanner
+    </button>
+    <button @click="activeTab = 'volunteers'" :class="...">
+        Volunteers
+    </button>
+    <button @click="activeTab = 'guests'" :class="...">
+        Gastliste
+    </button>
+</nav>
+
+{{-- Guest tab content --}}
+<div x-show="activeTab === 'guests'" x-cloak>
+    <input type="text" x-model="guestSearchQuery" placeholder="Search guests...">
+    <template x-for="group in filteredGuestGroups" :key="group.label">
+        {{-- Group header with check-in count --}}
+        <template x-for="entry in group.entries" :key="entry.id">
+            {{-- Entry row with manual check-in button --}}
+        </template>
+    </template>
+</div>
+```
+
+### 11.2 Entry Staff Result Panel
+
+Extend the result panel to handle guest results:
+
+```html
+{{-- Guest result (alongside existing volunteer result) --}}
+<div x-show="guestResult" x-transition role="alert" aria-live="assertive">
+    <p x-text="resultMessage"></p>
+    <button @click="confirmGuestCheckin(guestResult.id)">Check In</button>
+</div>
+```
+
+### 11.3 Volunteer Admin Scanner
+
+Add guest entries to the volunteer/guest list display. Guests with gear appear alongside volunteers. Guest entries are visually distinguished with a "Guest" badge. Typ-1 gear shows a dropdown for direct selection (unlike volunteers who self-select in portal).
+
+---
+
+## 12. Factories
+
+### 12.1 GuestListFactory
+
+```php
+public function definition(): array
+{
+    return [
+        'project_id' => Project::factory(),
+        'scanner_id' => ProjectScanner::factory(),
+        'name' => fake()->words(3, true),
+        'status' => GuestListStatus::Draft,
+        'confirmed_at' => null,
+        'gear_items' => null,
+    ];
+}
+
+public function confirmed(): static
+{
+    return $this->state(fn () => [
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+}
+```
+
+### 12.2 GuestGroupFactory
+
+```php
+public function definition(): array
+{
+    return [
+        'guest_list_id' => GuestList::factory(),
+        'label' => fake()->name(),
+        'guest_count' => fake()->numberBetween(1, 5),
+    ];
+}
+```
+
+### 12.3 GuestEntryFactory
+
+```php
+public function definition(): array
+{
+    return [
+        'guest_group_id' => GuestGroup::factory(),
+        'number' => 1,
+        'name' => fake()->optional(0.7)->name(),
+        'email' => fake()->optional(0.6)->safeEmail(),
+        'qr_token' => null,
+        'checked_in_at' => null,
+        'checked_in_by' => null,
+    ];
+}
+
+public function withQrToken(): static
+{
+    return $this->state(fn () => [
+        'qr_token' => bin2hex(random_bytes(32)),
+    ]);
+}
+
+public function checkedIn(): static
+{
+    return $this->state(fn () => [
+        'checked_in_at' => now(),
+    ]);
+}
+```
+
+### 12.4 GuestEntryGearFactory
+
+```php
+public function definition(): array
+{
+    return [
+        'guest_entry_id' => GuestEntry::factory(),
+        'project_gear_item_id' => ProjectGearItem::factory(),
+        'quantity' => 1,
+        'picked_up_count' => 0,
+        'selection' => null,
+        'status' => null,
+    ];
+}
+```
+
+---
+
+## 13. Testing Strategy
+
+### 13.1 Test Pyramid
+
+**Unit tests (Actions):** ~25 tests
+- `CreateGuestListTest` (3): creates draft, validates scanner type is EntryStaff, sets gear_items
+- `UpdateGuestListTest` (3): updates name/scanner/gear, rejects invalid scanner type
+- `ConfirmGuestListTest` (5): generates qr_tokens for all entries, sets status + confirmed_at, dispatches jobs grouped by email, handles entries without email, rejects already-confirmed list
+- `DeleteGuestListTest` (2): cascades, handles empty list
+- `AddGuestGroupTest` (3): creates group + N entries, validates guest_count >= 1, auto-numbers entries
+- `RemoveGuestGroupTest` (2): cascades entries, works on confirmed list
+- `AddGuestEntryTest` (4): adds to draft (no QR), adds to confirmed (generates QR + sends email), handles no-email entry, assigns gear
+- `RemoveGuestEntryTest` (2): deletes entry, does not renumber remaining
+- `UpdateGuestEntryTest` (3): updates name/email (QR stays), updates gear
+- `CheckInGuestTest` (3): sets checked_in_at, rejects already checked in, accepts nullable checked_in_by
+
+**Feature tests (Livewire):** ~20 tests
+- `GuestListIndexTest` (5): displays lists, create form, authorization, delete confirmation, empty state
+- `GuestListShowTest` (10): displays groups/entries, add group, remove group, add entry, edit entry, remove entry, confirm flow, gear assignment, post-confirm add (immediate email), post-confirm remove
+- `ScannerDataControllerGuestTest` (5): includes guest entries for Entry Staff, includes guest gear for Volunteer Admin, excludes draft lists, scopes to scanner, handles no guest lists
+
+**Feature tests (Scanner API):** ~8 tests
+- `GuestCheckinApiTest` (3): successful check-in, duplicate check-in returns already_checked_in, rejects wrong scanner
+- `GuestGearPickupApiTest` (3): Typ-1 selection + status, Typ-2 increment, rejects exceeding quantity
+- `GuestSyncApiTest` (2): batch sync guest check-ins, handles empty array
+
+**TypeScript tests (Vitest):** ~6 tests
+- `idb-store.test.ts`: storeGuestEntries, getGuestEntries, searchGuestEntries
+- `alpine-scanner.test.ts`: QR dual-path detection (JWT vs guest token), guest check-in flow
+
+**Total:** ~59 new tests
+
+### 13.2 Key Test Scenarios
+
+1. **Full lifecycle:** Create list → add groups → add entries with gear → confirm → QR tokens generated → emails grouped → scan QR → check in → gear pickup
+2. **Post-confirm mutation:** Add entry to confirmed list → QR generated immediately → email sent → scan works
+3. **Post-confirm removal:** Remove entry from confirmed list → QR becomes invalid → scanner shows red
+4. **Email grouping:** Two entries with same email → one SendGuestInvitationsJob → one email with two QR codes
+5. **Scanner scoping:** Entry Staff scanner only sees guest lists assigned to it, not other scanners
+6. **Gear Typ-1 direct selection:** Volunteer Admin scanner sets selection + status on guest gear (no portal flow)
+7. **Offline guest check-in:** Guest check-in added to outbox → synced when online → server records check-in
+
+---
+
+## 14. Implementation Phases
+
+### Phase 1: Schema + Models + Enum + Factories (foundation)
+
+**Tasks:**
+- [ ] Create `GuestListStatus` enum
+- [ ] Create migration #21: `create_guest_lists_table`
+- [ ] Create migration #22: `create_guest_groups_table`
+- [ ] Create migration #23: `create_guest_entries_table`
+- [ ] Create migration #24: `create_guest_entry_gear_table`
+- [ ] Run migrations
+- [ ] Create `GuestList` model with factory, relationships, casts, scopes
+- [ ] Create `GuestGroup` model with factory, relationships, casts
+- [ ] Create `GuestEntry` model with factory, relationships, casts, `qrCodeSvg()`
+- [ ] Create `GuestEntryGear` model with factory, relationships, casts
+- [ ] Add `guestLists()` to Project model
+- [ ] Add `guestLists()` to ProjectScanner model
+- [ ] Add `manageGuestLists()` to ProjectPolicy
+- [ ] RED: Write model unit tests (relationships, scopes, computed methods)
+- [ ] GREEN: All model tests pass
+
+**Deployable gate:** migrate:fresh --seed clean, model tests green.
+
+### Phase 2: Actions (business logic)
+
+**Tasks:**
+- [ ] RED: Write CreateGuestList tests (3)
+- [ ] GREEN: Implement CreateGuestList
+- [ ] RED: Write UpdateGuestList tests (3)
+- [ ] GREEN: Implement UpdateGuestList
+- [ ] RED: Write DeleteGuestList tests (2)
+- [ ] GREEN: Implement DeleteGuestList
+- [ ] RED: Write AddGuestGroup tests (3)
+- [ ] GREEN: Implement AddGuestGroup
+- [ ] RED: Write RemoveGuestGroup tests (2)
+- [ ] GREEN: Implement RemoveGuestGroup
+- [ ] RED: Write AddGuestEntry tests (4)
+- [ ] GREEN: Implement AddGuestEntry
+- [ ] RED: Write RemoveGuestEntry tests (2)
+- [ ] GREEN: Implement RemoveGuestEntry
+- [ ] RED: Write UpdateGuestEntry tests (3)
+- [ ] GREEN: Implement UpdateGuestEntry
+- [ ] RED: Write CheckInGuest tests (3)
+- [ ] GREEN: Implement CheckInGuest
+- [ ] RED: Write ConfirmGuestList tests (5) — use `Queue::fake()` to assert `ConfirmGuestListJob` dispatch (job class doesn't exist yet, but Laravel only needs the class name for assertion)
+- [ ] GREEN: Implement ConfirmGuestList
+- [ ] RED: Write RecordGuestGearPickup tests (3)
+- [ ] GREEN: Implement RecordGuestGearPickup
+
+**Deployable gate:** All action tests green (~33 tests).
+
+### Phase 3: Jobs + Mailable (email sending)
+
+**Tasks:**
+- [ ] Create `GuestInvitationMail` mailable with markdown template
+- [ ] Create `ConfirmGuestListJob` (orchestrator: bulk token generation + dispatches SendGuestInvitationsJob per email)
+- [ ] Create `SendGuestInvitationsJob` (queued, per-email grouping)
+- [ ] RED: Write ConfirmGuestListJob tests (4: bulk token generation, email grouping, idempotent, skips entries without email)
+- [ ] RED: Write SendGuestInvitationsJob tests (3: grouped send, no-email skip, idempotent)
+- [ ] GREEN: All job tests pass
+- [ ] Verify end-to-end: ConfirmGuestList → ConfirmGuestListJob → SendGuestInvitationsJob (integration)
+
+**Deployable gate:** Full email pipeline works, job tests green.
+
+### Phase 4: Admin Livewire Components (UI)
+
+**Tasks:**
+- [ ] Create `GuestListIndex` Livewire component + blade
+- [ ] Create `GuestListShow` Livewire component + blade
+- [ ] Register routes in `web.php`
+- [ ] Add navigation link (Scanners page or Project page sidebar)
+- [ ] RED: Write GuestListIndex tests (5)
+- [ ] GREEN: All GuestListIndex tests pass
+- [ ] RED: Write GuestListShow tests (10)
+- [ ] GREEN: All GuestListShow tests pass
+- [ ] Run Pint
+
+**Deployable gate:** Full admin CRUD works, component tests green.
+
+### Phase 5: Scanner API Extensions (backend)
+
+**Tasks:**
+- [ ] Extend `ScannerDataController::data()` to include guest entries
+- [ ] Add `guestCheckin()` method to ScannerDataController
+- [ ] Add `guestGearPickup()` method to ScannerDataController
+- [ ] Add `guestSync()` method to ScannerDataController
+- [ ] Register new API routes in `routes/api.php`
+- [ ] RED: Write ScannerDataControllerGuestTest (5)
+- [ ] GREEN: Data endpoint tests pass
+- [ ] RED: Write GuestCheckinApiTest (3)
+- [ ] GREEN: Check-in endpoint tests pass
+- [ ] RED: Write GuestGearPickupApiTest (3)
+- [ ] GREEN: Gear pickup endpoint tests pass
+- [ ] RED: Write GuestSyncApiTest (2)
+- [ ] GREEN: Sync endpoint tests pass
+
+**Deployable gate:** Scanner API serves guest data, all API tests green.
+
+### Phase 6: TypeScript + Scanner Blade (frontend)
+
+**Tasks:**
+- [ ] Add `GuestEntry` and `GuestEntryGearItem` types to `types.ts`
+- [ ] Extend `OutboxEntry` type with `guest_checkin`
+- [ ] Bump IDB to DB_VERSION 4, add `guest_entries` store
+- [ ] Add `storeGuestEntries`, `getGuestEntries`, `searchGuestEntries` to `idb-store.ts`
+- [ ] Extend `sync.ts` for guest check-in sync
+- [ ] Extend `alpine-scanner.ts` with guest state + methods
+- [ ] Implement dual-path QR detection (JWT vs guest token)
+- [ ] Update `scanner-app.blade.php`: Entry Staff tabs, guest panel, guest result display
+- [ ] Update `scanner-app.blade.php`: Volunteer Admin guest gear display with Typ-1 direct selection
+- [ ] Update `sw.js` with new API paths
+- [ ] RED: Write IDB guest store tests (3)
+- [ ] GREEN: IDB tests pass
+- [ ] RED: Write Alpine scanner guest tests (3)
+- [ ] GREEN: All TS tests pass
+- [ ] Run `npm run build`
+
+**Deployable gate:** Scanner handles guest QR codes + guest gear, TS tests + build green.
+
+### Phase 7: Polish + Final Verification
+
+**Tasks:**
+- [ ] Run Pint on all modified PHP files
+- [ ] Run full test suite: `vendor/bin/sail artisan test --compact`
+- [ ] Run TS tests: Vitest
+- [ ] Verify `migrate:fresh --seed` clean
+- [ ] Manual smoke test: create list → confirm → scan QR → check in → gear pickup
+- [ ] Review for N+1 queries in data endpoint
+- [ ] Update cross-milestone interface table
+
+**Deployable gate:** All tests green, Pint clean, migrate:fresh clean.
+
+---
+
+## 15. Self-Review Results
+
+### Pass 1: Laravel Best Practices
+- [x] `casts()` method (not property) on all 4 new models
+- [x] Business logic in Actions, not Livewire components
+- [x] Validation in Livewire component methods (project convention: inline validation, not Form Request for Livewire)
+- [x] Policy covers guest list management (Organizer only)
+- [x] Routes use `auth`, `verified`, `resolve-org` middleware
+
+### Pass 2: Livewire v4 Correctness
+- [x] No `.defer` syntax used
+- [x] `wire:model.live` only for search inputs
+- [x] No deep nesting — both components are full-page, entries rendered as Blade loops
+- [x] `#[Locked]` on projectId and guestListId
+- [x] `Route::livewire()` for full-page components
+- [x] Result panel uses `role="alert" aria-live="assertive"` (consistent with M11)
+
+### Pass 3: Clean Architecture
+- [x] Default Laravel structure (existing pattern, no DDD)
+- [x] Single responsibility per action class
+- [x] No cross-component events needed (both pages are independent)
+- [x] Data classification assigned: name, email, qr_token are confidential
+- [x] `qr_token` not exposed in admin UI beyond QR image
+
+### Pass 4: Testability
+- [x] All 10 actions unit-testable without HTTP
+- [x] Both Livewire components testable with `Livewire::test()`
+- [x] No static calls preventing mocking
+- [x] Factories defined for all 4 new models with useful states
+- [x] ~59 tests planned across unit, feature, API, and TS layers
+
+---
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Gate summary:** 1221 PHP tests green (2668 assertions), 31 TS tests green, Vite build clean, Pint clean, migrate:fresh --seed clean. 65 new PHP tests, ~0 new TS tests (existing tests updated for IDB v4). 7 phases complete.
+- **Tasks:**
+  - [x] Phase 1: 4 migrations, 4 models, 1 enum, 4 factories, policy extension, 30 model tests GREEN
+  - [x] Phase 2: 11 actions, 32 action tests GREEN
+  - [x] Phase 3: ConfirmGuestListJob, SendGuestInvitationsJob, GuestInvitationMail, 8 job tests GREEN
+  - [x] Phase 4: GuestListIndex + GuestListShow Livewire components, routes, 13 component tests GREEN
+  - [x] Phase 5: ScannerDataController extended (guest data, check-in, gear pickup, sync), 13 API tests GREEN
+  - [x] Phase 6: TypeScript + Scanner Blade (types, IDB v4, dual-path QR, Alpine scanner, guest tabs/panels, SW)
+  - [x] Phase 7: Polish + Final Verification (all green, migrate:fresh clean)
+
+## Test
+- **Status:** complete
+- **Gate summary:** 37 new tests added (14 gaps identified and filled). Coverage: full lifecycle, post-confirm mutations, email grouping, scanner scoping, authorization, validation, edge cases. Total: 1258 PHP tests (2761 assertions), 31 TS tests. New test files: GuestInvitationMailTest (4), GuestListLifecycleTest (5). Extended: GuestListIndexTest (+6), GuestListShowTest (+8), GuestCheckinApiTest (+3), GuestGearPickupApiTest (+2), GuestSyncApiTest (+3), ScannerDataControllerGuestTest (+1), RecordGuestGearPickupTest (+2), AddGuestEntryTest (+3), UpdateGuestEntryTest (+2).
+
+## Security Audit
+- **Status:** complete
+- **Gate summary:** 0 critical, 1 high, 2 medium, 3 low findings. All high/medium findings FIXED: (1) entryGear validation with project-scoped Rule::exists, (2) gearItemIds validation on create+update, (3) ShouldBeUnique on ConfirmGuestListJob, (4) lockForUpdate in ConfirmGuestList action. Low: TOCTOU race now mitigated by lockForUpdate, npm audit build-time deps (accepted), no audit logging (deferred). 4 prior findings verified as fixed. 1258 tests green after fixes.
+
+## Decisions
+
+| # | Stage | Decision | Rationale | Affects |
+|---|---|---|---|---|
+| D1 | plan | Guest QR tokens are 64-char hex random strings (not JWT) | Guests don't have tickets or JWT infrastructure. Simple random token is sufficient — identifies the guest_entry directly. No offline crypto validation needed since guest tokens are looked up by string match in IDB. | GuestEntry, QR generation, scanner TS |
+| D2 | plan | Guest check-in supports offline (outbox buffering) like volunteer arrivals | Entry Staff scanner operates offline. Guest check-ins must not be lost when offline. Same outbox pattern as volunteer arrivals. | sync.ts, idb-store.ts, guest-sync API |
+| D3 | plan | Guest gear pickup is online-only (consistent with D4/D10 from M11) | Gear state changes require real-time confirmation. Same rationale as volunteer gear. | guest-gear-pickup API, alpine-scanner.ts |
+| D4 | plan | No separate GuestListPolicy — use ProjectPolicy::manageGuestLists() | Guest lists are project-scoped resources managed by the same Organizer role. Adding a separate policy adds indirection without benefit. | ProjectPolicy, Livewire components |
+| D5 | plan | GuestInvitationMail uses default mailer (not per-org SMTP) | Guests are not volunteers. The UsesOrganizationMailer trait is for volunteer-facing notifications. Guest emails use the platform default. | SendGuestInvitationsJob, GuestInvitationMail |
+| D6 | plan | RemoveGuestEntry does NOT renumber remaining entries | Renumbering would change the displayed "X/Y" label for existing entries. The number field is immutable after creation. | RemoveGuestEntry action |
+| D7 | plan | Volunteer Admin scanner loads guest entries from ALL confirmed lists in the project (not just its linked scanner) | Volunteer Admin scanners handle gear across the whole project. They are not Entry Staff scanners and don't have a guest_lists.scanner_id link. Gear scope is project-wide. | ScannerDataController, types.ts |
+| D8 | plan | Dual-path QR detection: try JWT first, then string-match against guest tokens | Guest tokens and volunteer JWTs coexist. JWT validation is tried first (existing flow). If it fails, the scanned string is checked against the guest_entries IDB store. No ambiguity since JWTs have a specific format (header.payload.signature). | alpine-scanner.ts |
+| D9 | plan | AddGuestGroup creates N empty GuestEntry rows upfront | The group's guest_count defines expected entries. Pre-creating numbered entries (1..N) simplifies the UI — each entry is immediately editable. Entries beyond guest_count can be added post-confirmation. | AddGuestGroup action |
+| D10 | plan | IDB DB_VERSION bumped from 3 to 4 to add guest_entries store | New IDB object store requires version bump. The onupgradeneeded handler must use `event.oldVersion` branching for additive upgrade (not drop-all). | idb-store.ts |
+| D11 | plan-review | `qr_token` stripped from Volunteer Admin payload, kept for Entry Staff | VA never scans QR (only gear pickup by ID). Reduces credential exposure. Entry Staff needs tokens for offline QR matching — accepted risk since device is already trusted. | ScannerDataController, types.ts |
+| D12 | plan-review | `scanner_id` FK uses `restrictOnDelete` (not cascade) | Prevents accidental destruction of confirmed guest lists with issued QR codes when deleting a scanner. DB constraint is the guard. | Migration #21, DeleteProjectScanner |
+| D13 | plan-review | `syncOutbox` uses selective per-type deletion (not clear-all) | Prevents data loss when arrival sync succeeds but guest check-in sync has not yet run. Each type's entries are deleted only after successful sync. | sync.ts |
+| D14 | plan-review | `ConfirmGuestList` dispatches single `ConfirmGuestListJob` orchestrator | Avoids queue burst (N emails dispatched synchronously in Livewire action). Orchestrator handles bulk token generation + email dispatch. Livewire returns immediately. | ConfirmGuestList, ConfirmGuestListJob |
+| D15 | plan-review | Guest gear uses simpler single-table model + dedicated action | Guests have no portal for self-service — operator decides everything at scanner. No audit trail of individual pickups needed (unlike volunteers). `RecordGuestGearPickup` action extracted for convention consistency. | GuestEntryGear, RecordGuestGearPickup |
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Models (new) | `GuestList` (project_id, scanner_id, name, status, confirmed_at, gear_items); `GuestGroup` (guest_list_id, label, guest_count); `GuestEntry` (guest_group_id, number, name?, email?, qr_token?, checked_in_at?, checked_in_by?); `GuestEntryGear` (guest_entry_id, project_gear_item_id, quantity, picked_up_count, selection?, status?) |
+| Models (modified) | `Project` (+guestLists()); `ProjectScanner` (+guestLists()) |
+| Enums (new) | `GuestListStatus` (Draft, Confirmed) |
+| Actions (new) | `CreateGuestList`, `UpdateGuestList`, `DeleteGuestList`, `ConfirmGuestList`, `AddGuestGroup`, `RemoveGuestGroup`, `AddGuestEntry`, `RemoveGuestEntry`, `UpdateGuestEntry`, `CheckInGuest`, `RecordGuestGearPickup` |
+| Jobs (new) | `ConfirmGuestListJob` (orchestrator: bulk QR tokens + email dispatch); `SendGuestInvitationsJob` (grouped emails per unique address) |
+| Mailables (new) | `GuestInvitationMail` (markdown: mail.guest-invitation) |
+| Policy | `ProjectPolicy::manageGuestLists()` — Organizer only |
+| Routes (admin) | `guest-lists.index` → `GET /admin/projects/{projectId}/guest-lists`; `guest-lists.show` → `GET /admin/projects/{projectId}/guest-lists/{guestListId}` |
+| Routes (API) | `scanner-api.guest-checkin` → `POST /api/scanner/{scannerId}/guest-checkin`; `scanner-api.guest-gear-pickup` → `POST .../guest-gear-pickup`; `scanner-api.guest-sync` → `POST .../guest-sync` |
+| Livewire | `Projects\GuestListIndex` (list + create modal); `Projects\GuestListShow` (group/entry management, confirm flow) |
+| Controller | `ScannerDataController` extended: `data()` includes guest_entries, +`guestCheckin()`, `guestGearPickup()`, `guestSync()` |
+| TypeScript | `GuestEntry`/`GuestEntryGearItem` types; IDB v4 with `guest_entries` store; dual-path QR detection (JWT then guest token); selective outbox deletion; guest sync path |
+| Blade | `scanner-app.blade.php`: 3-tab Entry Staff UI (Scanner/Volunteers/Gastliste), guest result panels, manual guest check-in |
+| Key patterns | Guest QR = 64-char hex random string (not JWT); scanner_id FK uses restrictOnDelete; ConfirmGuestListJob is single orchestrator; VA payload excludes qr_token; syncOutbox uses selective per-type deletion |
+
+## Reviews
+
+### plan — 2026-04-01
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| DA-1 | Devil's Advocate | syncOutbox clear-all will discard guest check-ins | high | accepted | Selective per-type deletion (D13) |
+| DA-2 | Devil's Advocate | cascadeOnDelete on scanner_id destroys confirmed guest lists | high | accepted | Changed to restrictOnDelete (D12) |
+| SS-1 | Scalability Skeptic | VA data endpoint loads ALL guest entries unbounded | high | accepted | Filter whereHas('gear') for VA scanners |
+| SS-2 | Scalability Skeptic | GuestListShow eager-loads full tree without pagination | high | rejected | Guest lists are for VIPs/artists (typically <50 entries). Pagination adds disproportionate UI complexity. |
+| JD-1 | Junior Dev Lens | Guest gear model diverges from volunteer gear without explanation | high | accepted | Added inline rationale in section 7.4 (D15) |
+| DA-3 | Devil's Advocate | IDB onupgradeneeded drops all stores unconditionally | medium | accepted | Specified event.oldVersion branching in section 10.3 |
+| DA-4 | Devil's Advocate | qr_token exposed in IDB to scanner device | medium | accepted | Stripped from VA payload; accepted risk for Entry Staff (D11) |
+| SS-3 | Scalability Skeptic | Queue burst on confirmation (N jobs synchronous) | medium | accepted | Single ConfirmGuestListJob orchestrator (D14) |
+| SS-4 | Scalability Skeptic | VA receives qr_token it never needs | medium | accepted | Merged with DA-4 (D11) |
+| JD-2 | Junior Dev Lens | Test descriptions list what not why | medium | deferred | Will write proper it('...') descriptions with business reasons during implementation |
+| JD-4 | Junior Dev Lens | ConfirmGuestList in Phase 2 depends on Phase 3 job | medium | accepted | Added Queue::fake() note to Phase 2 task |
+| DA-5 | Devil's Advocate | Guest gear pickup inline in controller breaks action convention | low | accepted | Extracted RecordGuestGearPickup action (D15) |
+| SS-5 | Scalability Skeptic | N+1 in ConfirmGuestList token generation | low | accepted | Bulk generation + upsert in ConfirmGuestListJob |
+| JD-3 | Junior Dev Lens | "Gastliste" tab label is German, rest is English | low | rejected | Design spec uses "Gastliste". App targets German-speaking organizations. |
+| JD-5 | Junior Dev Lens | addEntry on confirmed list has unannounced side effects | low | accepted | Added success toast note in component section |
+
+### implement — 2026-04-01
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| S-2 | Simplicity Zealot | Three near-identical guest gear TS methods + fragile URL string-replace | high | accepted | Extracted _postGuestGear helper, added guestGearPickupUrl to config |
+| P-1 | Security Paranoid | qr_token leaks in guestCheckin JSON response — no $hidden | high | accepted | Added protected $hidden = ['qr_token'] to GuestEntry |
+| A-1 | Accessibility Champion | Scanner tabs lack ARIA tab pattern | high | accepted | Added role=tablist/tab/tabpanel, aria-selected, aria-controls, id/aria-labelledby |
+| A-2 | Accessibility Champion | Guest search input has no accessible label | high | accepted | Added aria-label |
+| S-1 | Simplicity Zealot | Delete actions are single-line wrappers | medium | rejected | Project convention: all domain logic in actions |
+| S-4 | Simplicity Zealot | ConfirmGuestList uses raw string instead of enum | medium | accepted | Changed to GuestListStatus::Confirmed |
+| P-2 | Security Paranoid | $editingEntryId not locked | medium | accepted | Added #[Locked] |
+| A-3 | Accessibility Champion | Check In buttons lack identifying context | medium | accepted | Added dynamic aria-label with entry number/name |
+| A-4 | Accessibility Champion | Manual check-in success has no live announcement | medium | accepted | Added aria-live="polite" to entry rows |
+| S-3 | Simplicity Zealot | loadGuestEntries has duplicated map branches | low | deferred | Minor DRY, not worth refactoring now |
+| S-5 | Simplicity Zealot | manualGuestCheckin is a pass-through | low | accepted | Removed, calling confirmGuestCheckin directly |
+| P-3 | Security Paranoid | guestGearPickup scopes by project not scanner | low | rejected | Intentional per D7 — VA handles gear project-wide |
+| P-4 | Security Paranoid | status/selection accept arbitrary strings | low | accepted | Added max:255 validation |
+| P-5 | Security Paranoid | $project is public nullable, not computed | low | deferred | Not exploitable since queries use locked $projectId |
+| A-5 | Accessibility Champion | Admin table headers missing scope="col" | low | accepted | Added scope="col" and sr-only Actions header |
+
+## Feedback Loops
+
+| # | Date | Direction | Trigger | Fix | Resolution |
+|---|---|---|---|---|---|

--- a/.tall-pipeline/m12-security-audit.md
+++ b/.tall-pipeline/m12-security-audit.md
@@ -1,0 +1,504 @@
+# M12 Guest Lists -- Security Audit Report
+
+**Milestone:** m12-guest-lists
+**Audit Date:** 2026-04-01
+**Auditor:** TALL Security Audit (automated + manual)
+**Scope:** All code added or modified in M12 (Guest Lists feature)
+
+---
+
+## Executive Summary
+
+The M12 Guest Lists feature is well-implemented with strong authorization patterns, proper IDOR protections on most surfaces, and good use of cryptographic randomness for QR tokens. The scanner API endpoints inherit the existing `scanner-api` middleware and rate limiting from M11.
+
+**Overall Risk: LOW-MEDIUM**
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 1 |
+| Medium | 2 |
+| Low | 3 |
+| Info | 3 |
+
+**Top risks requiring attention:**
+1. **[HIGH] Unvalidated `entryGear` array** -- Livewire public property passed directly to `updateOrCreate()` without validation; enables IDOR on `project_gear_item_id` across projects.
+2. **[MEDIUM] Unvalidated `gearItemIds`/`editGearItemIds` arrays** -- gear item IDs passed to guest list creation/update without existence or project-scoping validation.
+3. **[MEDIUM] `ConfirmGuestListJob` lacks `ShouldBeUnique`** -- double-dispatch could generate duplicate invitation emails.
+
+---
+
+## Phase 1: Automated Scanning Results
+
+### 1.1 Dependency Audits
+
+**Composer:** No security vulnerability advisories found.
+
+**NPM:** 2 high-severity vulnerabilities found:
+- `picomatch <=2.3.1 || 4.0.0-4.0.3` -- ReDoS via extglob quantifiers (build-time dependency only)
+- `undici 7.0.0-7.23.0` -- Multiple HTTP smuggling and WebSocket issues (build-time dependency)
+
+Both are fixable via `npm audit fix`. These are dev/build dependencies, not runtime, so risk is **low** in production.
+
+**`roave/security-advisories`:** Not installed. Recommend adding as a dev dependency.
+
+### 1.2 Static Analysis
+
+PHPStan/Larastan: Not installed. Recommend adding for type-safety and taint analysis.
+
+### 1.3 Secret Detection
+
+No `.env` files committed (only initial commit included standard scaffolding). `.env` is in `.gitignore`.
+
+### 1.4 Environment Configuration
+
+`.env.example` reviewed:
+- `APP_DEBUG=true` -- correct for example file; production must set `false`
+- `SESSION_DRIVER=database` -- good
+- `MAIL_MAILER=log` -- correct for example; production must use real mailer
+- `APP_KEY=` -- empty in example; correctly generated per environment
+
+### 1.5 Header Security
+
+No explicit security header middleware found. This is a pre-existing condition, not M12-specific. Noted as INFO.
+
+### 1.6 Debug Tool Exposure
+
+No Telescope, Horizon, or Debugbar detected. Clean.
+
+---
+
+## Phase 2: Manual Code Review (OWASP Top 10)
+
+### A01:2021 -- Broken Access Control
+
+#### [HIGH] F-1: Unvalidated `entryGear` Array Enables Cross-Project IDOR
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:61,211-228`
+**Evidence:** The `$entryGear` public property is a raw `array` bound to the Livewire component. When `saveEntry()` is called, it is passed directly to `UpdateGuestEntry::execute()` without any validation:
+
+```php
+// GuestListShow.php:211-228
+public function saveEntry(): void
+{
+    $this->validate([
+        'entryName' => ['nullable', 'string', 'max:255'],
+        'entryEmail' => ['nullable', 'email', 'max:255'],
+    ]);
+    // entryGear is NOT validated at all
+
+    $action = new UpdateGuestEntry;
+    $action->execute($entry, [
+        'gear' => $this->entryGear,  // raw unvalidated array
+    ]);
+}
+```
+
+In `UpdateGuestEntry::execute()`:
+```php
+$entry->gear()->updateOrCreate(
+    ['project_gear_item_id' => $gearData['project_gear_item_id']],
+    ['quantity' => $gearData['quantity'] ?? 1, 'selection' => $gearData['selection'] ?? null]
+);
+```
+
+**Risk:** An attacker can manipulate the Livewire snapshot to inject arbitrary `project_gear_item_id` values from other projects. This creates guest entry gear records linked to gear items belonging to other organizations' projects, which is a cross-project IDOR. Additionally, `quantity` and `selection` are completely unvalidated, allowing negative quantities or arbitrarily long selection strings.
+
+**Remediation:**
+```php
+// In GuestListShow::saveEntry()
+$this->validate([
+    'entryName' => ['nullable', 'string', 'max:255'],
+    'entryEmail' => ['nullable', 'email', 'max:255'],
+    'entryGear' => ['nullable', 'array'],
+    'entryGear.*.project_gear_item_id' => ['required', 'integer', Rule::exists('project_gear_items', 'id')->where('project_id', $this->projectId)],
+    'entryGear.*.quantity' => ['required', 'integer', 'min:1', 'max:100'],
+    'entryGear.*.selection' => ['nullable', 'string', 'max:255'],
+]);
+```
+
+---
+
+#### [MEDIUM] F-2: Unvalidated `gearItemIds` / `editGearItemIds` Arrays
+
+**Location:** `app/Livewire/Projects/GuestListIndex.php:35,88` and `app/Livewire/Projects/GuestListShow.php:46,128`
+**Evidence:** Both `$gearItemIds` and `$editGearItemIds` are public array properties passed to `CreateGuestList` / `UpdateGuestList` actions without validation that the IDs belong to the current project's gear items.
+
+```php
+// GuestListIndex.php:77-91
+public function createGuestList(): void
+{
+    $this->validate([
+        'name' => ['required', 'string', 'max:255'],
+        'scannerId' => ['required', Rule::exists(...)],
+    ]);
+    // gearItemIds NOT validated
+    $action->execute($this->project, [
+        'gear_items' => !empty($this->gearItemIds) ? $this->gearItemIds : null,
+    ]);
+}
+```
+
+**Risk:** An attacker can manipulate the Livewire snapshot to inject gear item IDs from other projects. These IDs are stored in the `gear_items` JSON column on the guest list. While this doesn't directly corrupt data across projects (the JSON is informational), it could cause confusion if gear items from other projects appear in guest list gear setup.
+
+**Remediation:**
+```php
+$this->validate([
+    'name' => ['required', 'string', 'max:255'],
+    'scannerId' => ['required', Rule::exists(...)],
+    'gearItemIds' => ['nullable', 'array'],
+    'gearItemIds.*' => ['integer', Rule::exists('project_gear_items', 'id')->where('project_id', $this->projectId)],
+]);
+```
+
+Apply the same pattern in `GuestListShow::updateGuestList()` for `editGearItemIds`.
+
+---
+
+#### Verified Fixed: `$editingEntryId` is `#[Locked]`
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:55`
+**Status:** VERIFIED-FIXED (P-2 from implement review)
+
+```php
+#[Locked]
+public ?int $editingEntryId = null;
+```
+
+---
+
+#### Verified Fixed: `$projectId` and `$guestListId` are `#[Locked]`
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:31-33` and `GuestListIndex.php:23`
+**Status:** VERIFIED-FIXED
+
+Both ID properties that control data scoping are locked against client tampering.
+
+---
+
+#### Positive: Proper IDOR Protection on Entity Operations
+
+All Livewire public methods that accept entity IDs (`removeGroup`, `removeEntry`, `startEditEntry`, `saveEntry`, `addEntry`) properly scope lookups through the locked `$guestListId`:
+
+```php
+// Example: removeEntry properly scopes through guest_list_id
+$entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
+    ->findOrFail($entryId);
+```
+
+---
+
+#### Positive: Authorization Gate Checks in mount()
+
+Both `GuestListIndex` and `GuestListShow` call `Gate::authorize('manageGuestLists', $this->project)` in `mount()`. The `manageGuestLists` policy correctly restricts to Organizer role only.
+
+---
+
+#### Positive: Scanner API IDOR Protection
+
+All scanner API endpoints (guestCheckin, guestGearPickup, guestSync) properly scope guest entries through scanner ownership:
+
+```php
+$entry = GuestEntry::whereHas('group.guestList', function ($q) use ($scanner) {
+    $q->confirmed()->where('scanner_id', $scanner->id);
+})->findOrFail($request->integer('guest_entry_id'));
+```
+
+---
+
+### A02:2021 -- Cryptographic Failures
+
+#### Positive: QR Token Generation Uses Strong Randomness
+
+**Location:** `app/Jobs/ConfirmGuestListJob.php:40`, `app/Actions/AddGuestEntry.php:32`
+**Evidence:** `bin2hex(random_bytes(32))` generates 64-character hex tokens (256 bits of entropy). This is cryptographically secure and provides sufficient entropy to prevent brute-force guessing.
+
+#### Positive: QR Token in `$hidden`
+
+**Location:** `app/Models/GuestEntry.php:17-19`
+**Status:** VERIFIED-FIXED (P-1 from implement review)
+
+```php
+protected $hidden = ['qr_token'];
+```
+
+This prevents accidental serialization of the token in API responses or Livewire snapshots via standard Eloquent serialization.
+
+#### Note: QR Token Intentionally Exposed to Scanner
+
+**Location:** `app/Http/Controllers/ScannerDataController.php:340`
+The `loadGuestEntries()` method manually includes `qr_token` in the JSON response for EntryStaff scanners. This bypasses `$hidden` intentionally because the scanner needs the raw token for client-side QR matching. The scanner API is protected by `scanner-api` middleware (token auth + active window check), which is appropriate.
+
+---
+
+### A03:2021 -- Injection
+
+#### No SQL Injection
+
+No raw queries (`DB::raw`, `whereRaw`, etc.) found in any M12 code. All queries use Eloquent parameterized queries.
+
+#### No XSS in Blade Views
+
+All user-controlled data in Blade views uses `{{ }}` (escaped) or `x-text` (Alpine, text-only). The only `{!! !!}` usage in M12 views is for `$entry->qrCodeSvg()` in the email template, which outputs SVG generated by the `QrCodeGenerator` service using `chillerlan/php-qrcode`. The input to this is the `qr_token` (hex string), which cannot contain HTML injection vectors.
+
+#### No Command Injection
+
+No `exec()`, `system()`, `shell_exec()`, or similar found in M12 code.
+
+---
+
+### A04:2021 -- Insecure Design
+
+#### [MEDIUM] F-3: `ConfirmGuestListJob` Lacks `ShouldBeUnique`
+
+**Location:** `app/Jobs/ConfirmGuestListJob.php`
+**Evidence:** The job implements `ShouldQueue` but not `ShouldBeUnique`. If `ConfirmGuestList::execute()` is called rapidly (e.g., double-click, network retry), the job could be dispatched twice. While the job checks `whereNull('qr_token')` (idempotent for token generation), the email dispatch loop will send duplicate invitation emails:
+
+```php
+// Line 44-51: emails are sent for ALL entries with email + qr_token
+$emails = $this->guestList->entries()
+    ->whereNotNull('email')
+    ->distinct()
+    ->pluck('email');
+foreach ($emails as $email) {
+    SendGuestInvitationsJob::dispatch($this->guestList, $email);
+}
+```
+
+**Risk:** Users receive duplicate invitation emails, which degrades trust and could trigger spam filters.
+
+**Remediation:**
+```php
+class ConfirmGuestListJob implements ShouldQueue, ShouldBeUnique
+{
+    use Queueable;
+
+    public function uniqueId(): string
+    {
+        return (string) $this->guestList->id;
+    }
+
+    // ... rest of class
+}
+```
+
+Additionally, consider adding `ShouldBeUnique` to `SendGuestInvitationsJob` with a composite unique ID of `guestList.id:email`.
+
+---
+
+#### [LOW] F-4: Double-Confirm Race Condition
+
+**Location:** `app/Actions/ConfirmGuestList.php:14`
+**Evidence:** The `ConfirmGuestList` action checks `$guestList->isConfirmed()` and then updates the status, but without database-level locking:
+
+```php
+if ($guestList->isConfirmed()) {
+    throw new DomainException('Guest list is already confirmed.');
+}
+$guestList->update(['status' => GuestListStatus::Confirmed, ...]);
+```
+
+**Risk:** In a race condition (two concurrent requests), both could pass the `isConfirmed()` check before either updates the status. This would dispatch `ConfirmGuestListJob` twice. The impact is mitigated by the job's `whereNull('qr_token')` idempotency check, but duplicate emails would still be sent.
+
+**Remediation:**
+```php
+public function execute(GuestList $guestList): GuestList
+{
+    return DB::transaction(function () use ($guestList) {
+        $guestList = GuestList::lockForUpdate()->findOrFail($guestList->id);
+
+        if ($guestList->isConfirmed()) {
+            throw new DomainException('Guest list is already confirmed.');
+        }
+
+        $guestList->update([
+            'status' => GuestListStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+
+        ConfirmGuestListJob::dispatch($guestList);
+
+        return $guestList->fresh();
+    });
+}
+```
+
+---
+
+#### Verified Fixed: Status Uses Enum
+
+**Location:** `app/Actions/ConfirmGuestList.php:18`
+**Status:** VERIFIED-FIXED (S-4 from implement review)
+
+```php
+'status' => GuestListStatus::Confirmed,
+```
+
+Uses the `GuestListStatus` enum, not a raw string.
+
+---
+
+### A05:2021 -- Security Misconfiguration
+
+#### [LOW] F-5: npm Audit Vulnerabilities (Build Dependencies)
+
+**Evidence:** `npm audit` reports 2 high-severity vulnerabilities in `picomatch` and `undici`. These are build-time dependencies (Vite ecosystem), not served to users at runtime.
+
+**Risk:** Low -- these affect the build process only. An attacker with access to the build environment could potentially exploit them.
+
+**Remediation:** Run `npm audit fix` and update lock file.
+
+---
+
+### A06:2021 -- Vulnerable and Outdated Components
+
+See F-5 above. PHP dependencies are clean.
+
+---
+
+### A07:2021 -- Identification and Authentication Failures
+
+No new authentication surfaces in M12. Scanner API authentication via `X-Scanner-Token` header is inherited from M11 and was previously audited.
+
+---
+
+### A08:2021 -- Software and Data Integrity Failures
+
+No `unserialize()` usage. No file uploads in M12. Queue jobs use Laravel's built-in serialization which is safe.
+
+---
+
+### A09:2021 -- Security Logging and Monitoring
+
+#### [LOW] F-6: No Audit Logging for Guest List Confirmation
+
+**Location:** `app/Actions/ConfirmGuestList.php`, `app/Jobs/ConfirmGuestListJob.php`
+**Evidence:** Guest list confirmation and QR token generation are not logged. Since these are significant security events (generating authentication credentials), they should be auditable.
+
+**Risk:** Low -- inability to investigate when/who confirmed a guest list or when tokens were generated.
+
+**Remediation:** Add logging in the action:
+```php
+Log::info('Guest list confirmed', [
+    'guest_list_id' => $guestList->id,
+    'project_id' => $guestList->project_id,
+    'entry_count' => $guestList->entries()->count(),
+]);
+```
+
+---
+
+### A10:2021 -- Server-Side Request Forgery
+
+No HTTP client calls or user-controlled URLs in M12 code.
+
+---
+
+### Open Redirect Detection
+
+No redirects using user-supplied input found in M12 code. The `GuestListIndex` redirect uses `route()` with fixed route names.
+
+---
+
+## Phase 3: Threat Modeling
+
+### 3.1 STRIDE Analysis
+
+| Threat | Category | Finding | Mitigation Status |
+|--------|----------|---------|-------------------|
+| Spoofing | Authentication | Scanner API uses token auth; Livewire uses session auth | Mitigated |
+| Tampering | Integrity | `$projectId`, `$guestListId`, `$editingEntryId` use `#[Locked]`; `$entryGear` is unvalidated (F-1) | Partially mitigated |
+| Repudiation | Logging | No audit trail for guest list confirmation (F-6) | Not mitigated |
+| Info Disclosure | Confidentiality | `qr_token` in `$hidden`; intentionally exposed to scanner API (appropriate) | Mitigated |
+| DoS | Availability | `newGroupCount` capped at 100; scanner API rate-limited at 60/min | Mitigated |
+| EoP | Authorization | `manageGuestLists` policy restricts to Organizer; scanner type checks on API | Mitigated |
+
+### 3.2 Data Flow & Trust Boundaries
+
+```
+Browser (Alpine/Livewire)           -- UNTRUSTED
+    |
+    | wire:click, wire:model, $wire
+    |
+=== BOUNDARY: Client -> Livewire Component ===
+    |
+GuestListShow (auth + Gate + #[Locked])   -- TRUSTED (after validation)
+    |                                        EXCEPT: $entryGear, $gearItemIds (F-1, F-2)
+    | ->execute()
+    |
+Actions (CreateGuestList, etc.)     -- TRUSTED
+    |
+=== BOUNDARY: App -> Database ===
+    |
+Database (Eloquent parameterized)
+```
+
+```
+Scanner PWA (IndexedDB + Alpine)    -- UNTRUSTED
+    |
+    | fetch() with X-Scanner-Token
+    |
+=== BOUNDARY: Client -> Scanner API ===
+    |
+ScannerApiMiddleware (token lookup + active check)  -- PARTIALLY TRUSTED
+    |
+ScannerDataController (scanner_id match + type check + scoping)  -- TRUSTED
+    |
+=== BOUNDARY: App -> Database ===
+```
+
+### 3.3 Abuse Cases
+
+| Abuse Case | Mitigated? |
+|---|---|
+| Attacker crafts POST to call any Livewire public method | Yes -- `mount()` enforces `Gate::authorize('manageGuestLists')` |
+| Attacker modifies `$projectId` in snapshot | Yes -- `#[Locked]` prevents tampering |
+| Attacker modifies `$editingEntryId` in snapshot | Yes -- `#[Locked]` prevents tampering |
+| Attacker injects cross-project gear IDs via `$entryGear` | **No** -- F-1 (unvalidated) |
+| Attacker injects cross-project gear item IDs via `$gearItemIds` | **Partially** -- F-2 (stored as JSON only) |
+| Attacker uses scanner token from another project to check in guests | Yes -- scanner-to-guest-list scoping via `scanner_id` match |
+| Attacker brute-forces QR tokens | Mitigated -- 256-bit entropy, rate limiting |
+| Attacker re-confirms guest list to spam emails | Partially -- domain exception prevents re-confirm, but race condition (F-4) |
+
+---
+
+## Phase 4: Findings Summary
+
+### All Findings
+
+| # | Category | Severity | Description | Status |
+|---|----------|----------|-------------|--------|
+| F-1 | A01 Broken Access Control | **HIGH** | `$entryGear` array passed to `updateOrCreate()` without validation; cross-project IDOR on `project_gear_item_id` | New |
+| F-2 | A01 Broken Access Control | **MEDIUM** | `$gearItemIds`/`$editGearItemIds` arrays not validated against project scope | New |
+| F-3 | A04 Insecure Design | **MEDIUM** | `ConfirmGuestListJob` lacks `ShouldBeUnique`; duplicate emails on double-dispatch | New |
+| F-4 | A04 Insecure Design | **LOW** | Race condition in `ConfirmGuestList` (TOCTOU on status check) | New |
+| F-5 | A06 Vulnerable Components | **LOW** | npm audit: picomatch + undici (build-time only) | New |
+| F-6 | A09 Logging Failures | **LOW** | No audit logging for guest list confirmation | New |
+| P-1 | A02 Crypto | -- | `qr_token` in `$hidden` on GuestEntry | Verified-fixed |
+| P-2 | A01 Access Control | -- | `$editingEntryId` uses `#[Locked]` | Verified-fixed |
+| P-4 | A03 Injection | -- | `status`/`selection` validation has `max:255` | Verified-fixed |
+| S-4 | A04 Insecure Design | -- | `ConfirmGuestList` uses `GuestListStatus` enum | Verified-fixed |
+
+### Positive Security Findings
+
+1. **Strong QR token entropy** -- 256 bits via `bin2hex(random_bytes(32))`, unique constraint in DB.
+2. **Consistent IDOR protection** -- All Livewire methods scope entity lookups through locked parent IDs (`$guestListId`, `$projectId`).
+3. **Proper authorization model** -- `manageGuestLists` policy + `Gate::authorize()` in `mount()` on both components.
+4. **Scanner API scoping** -- Guest check-in and gear pickup endpoints scope through scanner ownership chain (`scanner_id` or `project_id`).
+5. **No XSS vectors** -- All Blade output uses `{{ }}` or `x-text`; `{!! !!}` only for server-generated SVG.
+6. **Rate limiting** -- Scanner API endpoints are rate-limited (`throttle:60,1`).
+7. **Cascade deletes** -- Foreign keys use `cascadeOnDelete` ensuring orphaned records are cleaned up.
+8. **Group count cap** -- `newGroupCount` validated `max:100` prevents unbounded entry creation.
+9. **Scanner type enforcement** -- Each API endpoint checks `$scanner->type` before processing.
+10. **CSRF protection** -- All POST endpoints are either Livewire (automatic CSRF) or scanner API (token-authed, no cookies).
+
+---
+
+## Recommended Next Steps
+
+1. **Fix F-1 immediately** -- Add validation for `$entryGear` in `GuestListShow::saveEntry()` before next deployment.
+2. **Fix F-2 and F-3** -- Add gear item ID validation and `ShouldBeUnique` to the confirmation job.
+3. **Add `roave/security-advisories`** -- `composer require --dev roave/security-advisories:dev-latest`.
+4. **Run `npm audit fix`** -- Address build-time dependency vulnerabilities.
+5. **Consider adding PHPStan/Larastan** -- For ongoing type-safety and potential taint analysis.
+6. **Add security headers middleware** -- CSP, HSTS, X-Frame-Options (project-wide, not M12-specific).

--- a/app/Actions/AddGuestEntry.php
+++ b/app/Actions/AddGuestEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions;
+
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+
+class AddGuestEntry
+{
+    public function execute(GuestGroup $group, ?string $name = null, ?string $email = null, array $gearSelections = []): GuestEntry
+    {
+        $nextNumber = ($group->entries()->max('number') ?? 0) + 1;
+
+        $entry = $group->entries()->create([
+            'number' => $nextNumber,
+            'name' => $name,
+            'email' => $email,
+        ]);
+
+        foreach ($gearSelections as $gearSelection) {
+            $entry->gear()->create([
+                'project_gear_item_id' => $gearSelection['project_gear_item_id'],
+                'quantity' => $gearSelection['quantity'] ?? 1,
+                'selection' => $gearSelection['selection'] ?? null,
+            ]);
+        }
+
+        $guestList = $group->guestList;
+
+        if ($guestList->isConfirmed()) {
+            $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
+
+            if ($email) {
+                SendGuestInvitationsJob::dispatch($guestList, $email);
+            }
+        }
+
+        return $entry->load('gear');
+    }
+}

--- a/app/Actions/AddGuestGroup.php
+++ b/app/Actions/AddGuestGroup.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+
+class AddGuestGroup
+{
+    public function execute(GuestList $guestList, string $label, int $guestCount): GuestGroup
+    {
+        $group = $guestList->groups()->create([
+            'label' => $label,
+            'guest_count' => $guestCount,
+        ]);
+
+        for ($i = 1; $i <= $guestCount; $i++) {
+            $group->entries()->create([
+                'number' => $i,
+            ]);
+        }
+
+        return $group->load('entries');
+    }
+}

--- a/app/Actions/CheckInGuest.php
+++ b/app/Actions/CheckInGuest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Actions;
+
+use App\Exceptions\DomainException;
+use App\Models\GuestEntry;
+
+class CheckInGuest
+{
+    public function execute(GuestEntry $entry, ?int $checkedInBy = null): GuestEntry
+    {
+        if ($entry->isCheckedIn()) {
+            throw new DomainException('Guest is already checked in.');
+        }
+
+        $entry->update([
+            'checked_in_at' => now(),
+            'checked_in_by' => $checkedInBy,
+        ]);
+
+        return $entry->fresh();
+    }
+}

--- a/app/Actions/ConfirmGuestList.php
+++ b/app/Actions/ConfirmGuestList.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\GuestListStatus;
+use App\Exceptions\DomainException;
+use App\Jobs\ConfirmGuestListJob;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\DB;
+
+class ConfirmGuestList
+{
+    public function execute(GuestList $guestList): GuestList
+    {
+        return DB::transaction(function () use ($guestList) {
+            $guestList = GuestList::lockForUpdate()->findOrFail($guestList->id);
+
+            if ($guestList->isConfirmed()) {
+                throw new DomainException('Guest list is already confirmed.');
+            }
+
+            $guestList->update([
+                'status' => GuestListStatus::Confirmed,
+                'confirmed_at' => now(),
+            ]);
+
+            ConfirmGuestListJob::dispatch($guestList);
+
+            return $guestList->fresh();
+        });
+    }
+}

--- a/app/Actions/CreateGuestList.php
+++ b/app/Actions/CreateGuestList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\GuestListStatus;
+use App\Models\GuestList;
+use App\Models\Project;
+
+class CreateGuestList
+{
+    public function execute(Project $project, array $data): GuestList
+    {
+        return $project->guestLists()->create([
+            'scanner_id' => $data['scanner_id'],
+            'name' => $data['name'],
+            'status' => GuestListStatus::Draft,
+            'gear_items' => $data['gear_items'] ?? null,
+        ]);
+    }
+}

--- a/app/Actions/DeleteGuestList.php
+++ b/app/Actions/DeleteGuestList.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestList;
+
+class DeleteGuestList
+{
+    public function execute(GuestList $guestList): void
+    {
+        $guestList->delete();
+    }
+}

--- a/app/Actions/RecordGuestGearPickup.php
+++ b/app/Actions/RecordGuestGearPickup.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions;
+
+use App\Exceptions\DomainException;
+use App\Models\GuestEntryGear;
+
+class RecordGuestGearPickup
+{
+    public function execute(GuestEntryGear $gear, array $data): GuestEntryGear
+    {
+        if (isset($data['selection'])) {
+            $gear->selection = $data['selection'];
+        }
+
+        if (isset($data['status'])) {
+            $gear->status = $data['status'];
+        }
+
+        if (isset($data['quantity'])) {
+            $newCount = $gear->picked_up_count + $data['quantity'];
+
+            if ($newCount > $gear->quantity) {
+                throw new DomainException('Pickup count would exceed available quantity.');
+            }
+
+            $gear->picked_up_count = $newCount;
+        }
+
+        $gear->save();
+
+        return $gear->fresh();
+    }
+}

--- a/app/Actions/RemoveGuestEntry.php
+++ b/app/Actions/RemoveGuestEntry.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestEntry;
+
+class RemoveGuestEntry
+{
+    public function execute(GuestEntry $entry): void
+    {
+        $entry->delete();
+    }
+}

--- a/app/Actions/RemoveGuestGroup.php
+++ b/app/Actions/RemoveGuestGroup.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestGroup;
+
+class RemoveGuestGroup
+{
+    public function execute(GuestGroup $group): void
+    {
+        $group->delete();
+    }
+}

--- a/app/Actions/UpdateGuestEntry.php
+++ b/app/Actions/UpdateGuestEntry.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestEntry;
+
+class UpdateGuestEntry
+{
+    public function execute(GuestEntry $entry, array $data): GuestEntry
+    {
+        $entry->update([
+            'name' => array_key_exists('name', $data) ? $data['name'] : $entry->name,
+            'email' => array_key_exists('email', $data) ? $data['email'] : $entry->email,
+        ]);
+
+        if (isset($data['gear'])) {
+            foreach ($data['gear'] as $gearData) {
+                $entry->gear()->updateOrCreate(
+                    ['project_gear_item_id' => $gearData['project_gear_item_id']],
+                    [
+                        'quantity' => $gearData['quantity'] ?? 1,
+                        'selection' => $gearData['selection'] ?? null,
+                    ]
+                );
+            }
+        }
+
+        return $entry->fresh()->load('gear');
+    }
+}

--- a/app/Actions/UpdateGuestList.php
+++ b/app/Actions/UpdateGuestList.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\GuestList;
+
+class UpdateGuestList
+{
+    public function execute(GuestList $guestList, array $data): GuestList
+    {
+        $guestList->update([
+            'name' => $data['name'] ?? $guestList->name,
+            'scanner_id' => $data['scanner_id'] ?? $guestList->scanner_id,
+            'gear_items' => array_key_exists('gear_items', $data) ? $data['gear_items'] : $guestList->gear_items,
+        ]);
+
+        return $guestList->fresh();
+    }
+}

--- a/app/Enums/GuestListStatus.php
+++ b/app/Enums/GuestListStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum GuestListStatus: string
+{
+    case Draft = 'draft';
+    case Confirmed = 'confirmed';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => 'Draft',
+            self::Confirmed => 'Confirmed',
+        };
+    }
+}

--- a/app/Http/Controllers/ScannerDataController.php
+++ b/app/Http/Controllers/ScannerDataController.php
@@ -2,13 +2,18 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\CheckInGuest;
 use App\Actions\RecordArrival;
 use App\Actions\RecordGearPickup;
+use App\Actions\RecordGuestGearPickup;
 use App\Enums\ArrivalMethod;
 use App\Enums\ScannerType;
+use App\Exceptions\DomainException;
 use App\Models\AttendanceRecord;
 use App\Models\Event;
 use App\Models\EventArrival;
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
 use App\Models\ProjectScanner;
 use App\Models\Ticket;
 use App\Models\Volunteer;
@@ -62,6 +67,8 @@ class ScannerDataController extends Controller
         $shiftSignupIds = $volunteers->flatMap(fn ($v) => $v->shiftSignups->pluck('id'));
         $attendanceRecords = AttendanceRecord::whereIn('shift_signup_id', $shiftSignupIds)->get();
 
+        $guestEntries = $this->loadGuestEntries($scanner);
+
         return response()->json([
             'scanner' => [
                 'id' => $scanner->id,
@@ -101,6 +108,7 @@ class ScannerDataController extends Controller
             'arrivals' => $arrivals,
             'attendance_records' => $attendanceRecords,
             'keys' => $jwtKeyService->publicKeys($projectId),
+            'guest_entries' => $guestEntries,
         ]);
     }
 
@@ -191,5 +199,186 @@ class ScannerDataController extends Controller
             'success' => true,
             'pickup' => $pickup,
         ]);
+    }
+
+    public function guestCheckin(
+        int $scannerId,
+        Request $request,
+        CheckInGuest $checkInGuest,
+    ): JsonResponse {
+        /** @var ProjectScanner $scanner */
+        $scanner = $request->attributes->get('scanner');
+
+        if ($scanner->id !== $scannerId) {
+            return response()->json(['error' => 'Scanner ID mismatch.'], 403);
+        }
+
+        if ($scanner->type !== ScannerType::EntryStaff) {
+            return response()->json(['error' => 'Only entry staff scanners can check in guests.'], 403);
+        }
+
+        $request->validate([
+            'guest_entry_id' => ['required', 'integer'],
+        ]);
+
+        $entry = GuestEntry::whereHas('group.guestList', function ($q) use ($scanner) {
+            $q->confirmed()->where('scanner_id', $scanner->id);
+        })->findOrFail($request->integer('guest_entry_id'));
+
+        try {
+            $result = $checkInGuest->execute($entry);
+
+            return response()->json([
+                'success' => true,
+                'guest_entry' => $result,
+                'already_checked_in' => false,
+            ]);
+        } catch (DomainException) {
+            return response()->json([
+                'success' => true,
+                'guest_entry' => $entry->fresh(),
+                'already_checked_in' => true,
+            ]);
+        }
+    }
+
+    public function guestGearPickup(
+        int $scannerId,
+        Request $request,
+        RecordGuestGearPickup $recordGuestGearPickup,
+    ): JsonResponse {
+        /** @var ProjectScanner $scanner */
+        $scanner = $request->attributes->get('scanner');
+
+        if ($scanner->id !== $scannerId) {
+            return response()->json(['error' => 'Scanner ID mismatch.'], 403);
+        }
+
+        if ($scanner->type !== ScannerType::VolunteerAdmin) {
+            return response()->json(['error' => 'Only volunteer admin scanners can record guest gear pickups.'], 403);
+        }
+
+        $request->validate([
+            'guest_entry_gear_id' => ['required', 'integer'],
+            'selection' => ['nullable', 'string', 'max:255'],
+            'status' => ['nullable', 'string', 'max:255'],
+            'quantity' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $gear = GuestEntryGear::whereHas('entry.group.guestList', function ($q) use ($scanner) {
+            $q->confirmed()->where('project_id', $scanner->project_id);
+        })->findOrFail($request->integer('guest_entry_gear_id'));
+
+        $result = $recordGuestGearPickup->execute($gear, $request->only(['selection', 'status', 'quantity']));
+
+        return response()->json([
+            'success' => true,
+            'guest_entry_gear' => $result,
+        ]);
+    }
+
+    public function guestSync(
+        int $scannerId,
+        Request $request,
+        CheckInGuest $checkInGuest,
+    ): JsonResponse {
+        /** @var ProjectScanner $scanner */
+        $scanner = $request->attributes->get('scanner');
+
+        if ($scanner->id !== $scannerId) {
+            return response()->json(['error' => 'Scanner ID mismatch.'], 403);
+        }
+
+        if ($scanner->type !== ScannerType::EntryStaff) {
+            return response()->json(['error' => 'Only entry staff scanners can sync guest check-ins.'], 403);
+        }
+
+        $validated = $request->validate([
+            'guest_checkins' => ['present', 'array'],
+            'guest_checkins.*.guest_entry_id' => ['required', 'integer'],
+            'guest_checkins.*.checked_in_at' => ['required', 'date'],
+        ]);
+
+        foreach ($validated['guest_checkins'] as $checkinData) {
+            $entry = GuestEntry::whereHas('group.guestList', function ($q) use ($scanner) {
+                $q->confirmed()->where('scanner_id', $scanner->id);
+            })->find($checkinData['guest_entry_id']);
+
+            if ($entry && ! $entry->isCheckedIn()) {
+                $entry->update([
+                    'checked_in_at' => Carbon::parse($checkinData['checked_in_at']),
+                ]);
+            }
+        }
+
+        $guestEntries = $this->loadGuestEntries($scanner);
+
+        return response()->json([
+            'guest_entries' => $guestEntries,
+        ]);
+    }
+
+    /**
+     * Load guest entries for the scanner data payload.
+     * Entry Staff: entries from confirmed lists linked to this scanner (includes qr_token).
+     * Volunteer Admin: entries with gear from all confirmed lists in the project (excludes qr_token).
+     */
+    private function loadGuestEntries(ProjectScanner $scanner): array
+    {
+        if ($scanner->type === ScannerType::EntryStaff) {
+            $entries = GuestEntry::whereHas('group.guestList', function ($q) use ($scanner) {
+                $q->confirmed()->where('scanner_id', $scanner->id);
+            })->with(['group', 'gear.gearItem'])->get();
+
+            return $entries->map(fn (GuestEntry $e) => [
+                'id' => $e->id,
+                'guest_group_id' => $e->guest_group_id,
+                'group_label' => $e->group->label,
+                'group_guest_count' => $e->group->guest_count,
+                'number' => $e->number,
+                'name' => $e->name,
+                'qr_token' => $e->qr_token,
+                'checked_in_at' => $e->checked_in_at,
+                'gear' => $e->gear->map(fn ($g) => [
+                    'id' => $g->id,
+                    'gear_item_name' => $g->gearItem->name,
+                    'gear_item_type' => $g->gearItem->type->value,
+                    'quantity' => $g->quantity,
+                    'picked_up_count' => $g->picked_up_count,
+                    'selection' => $g->selection,
+                    'status' => $g->status,
+                ]),
+            ])->all();
+        }
+
+        if ($scanner->type === ScannerType::VolunteerAdmin) {
+            $entries = GuestEntry::whereHas('gear')
+                ->whereHas('group.guestList', function ($q) use ($scanner) {
+                    $q->confirmed()->where('project_id', $scanner->project_id);
+                })->with(['group', 'gear.gearItem'])->get();
+
+            return $entries->map(fn (GuestEntry $e) => [
+                'id' => $e->id,
+                'guest_group_id' => $e->guest_group_id,
+                'group_label' => $e->group->label,
+                'group_guest_count' => $e->group->guest_count,
+                'number' => $e->number,
+                'name' => $e->name,
+                'checked_in_at' => $e->checked_in_at,
+                'gear' => $e->gear->map(fn ($g) => [
+                    'id' => $g->id,
+                    'gear_item_name' => $g->gearItem->name,
+                    'gear_item_type' => $g->gearItem->type->value,
+                    'available_sizes' => $g->gearItem->available_sizes,
+                    'available_states' => $g->gearItem->available_states,
+                    'quantity' => $g->quantity,
+                    'picked_up_count' => $g->picked_up_count,
+                    'selection' => $g->selection,
+                    'status' => $g->status,
+                ]),
+            ])->all();
+        }
+
+        return [];
     }
 }

--- a/app/Jobs/ConfirmGuestListJob.php
+++ b/app/Jobs/ConfirmGuestListJob.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\GuestEntry;
+use App\Models\GuestList;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+
+class ConfirmGuestListJob implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    /** @var int[] */
+    public array $backoff = [10, 30, 60];
+
+    public int $tries = 3;
+
+    public int $timeout = 120;
+
+    public function __construct(
+        public GuestList $guestList,
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->guestList->id;
+    }
+
+    public function handle(): void
+    {
+        if (! $this->guestList->isConfirmed()) {
+            return;
+        }
+
+        $entries = $this->guestList->entries()->whereNull('qr_token')->get();
+
+        if ($entries->isEmpty()) {
+            return;
+        }
+
+        DB::transaction(function () use ($entries) {
+            $entries->each(function (GuestEntry $entry) {
+                $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
+            });
+        });
+
+        $emails = $this->guestList->entries()
+            ->whereNotNull('email')
+            ->distinct()
+            ->pluck('email');
+
+        foreach ($emails as $email) {
+            SendGuestInvitationsJob::dispatch($this->guestList, $email);
+        }
+    }
+}

--- a/app/Jobs/SendGuestInvitationsJob.php
+++ b/app/Jobs/SendGuestInvitationsJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\GuestInvitationMail;
+use App\Models\GuestList;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Mail;
+
+class SendGuestInvitationsJob implements ShouldQueue
+{
+    use Queueable;
+
+    /** @var int[] */
+    public array $backoff = [10, 30, 60];
+
+    public int $tries = 3;
+
+    public int $timeout = 60;
+
+    public function __construct(
+        public GuestList $guestList,
+        public string $email,
+    ) {}
+
+    public function handle(): void
+    {
+        $entries = $this->guestList->entries()
+            ->where('email', $this->email)
+            ->whereNotNull('qr_token')
+            ->get();
+
+        if ($entries->isEmpty()) {
+            return;
+        }
+
+        Mail::to($this->email)
+            ->send(new GuestInvitationMail($this->guestList, $entries));
+    }
+}

--- a/app/Livewire/Projects/GuestListIndex.php
+++ b/app/Livewire/Projects/GuestListIndex.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Livewire\Projects;
+
+use App\Actions\CreateGuestList;
+use App\Actions\DeleteGuestList;
+use App\Enums\ScannerType;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Guest Lists')]
+class GuestListIndex extends Component
+{
+    #[Locked]
+    public int $projectId;
+
+    public ?Project $project = null;
+
+    public bool $showCreateModal = false;
+
+    // Form fields
+    public string $name = '';
+
+    public ?int $scannerId = null;
+
+    public array $gearItemIds = [];
+
+    public function mount(int $projectId): void
+    {
+        $this->project = currentOrganization()->projects()->findOrFail($projectId);
+        $this->projectId = $projectId;
+
+        Gate::authorize('manageGuestLists', $this->project);
+    }
+
+    /** @return Collection<int, GuestList> */
+    #[Computed]
+    public function guestLists(): Collection
+    {
+        return GuestList::forProject($this->projectId)
+            ->with('scanner', 'groups')
+            ->withCount([
+                'entries as total_entries',
+                'entries as checked_in_entries' => fn ($q) => $q->whereNotNull('checked_in_at'),
+            ])
+            ->latest()
+            ->get();
+    }
+
+    /** @return Collection<int, ProjectScanner> */
+    #[Computed]
+    public function entryStaffScanners(): Collection
+    {
+        return ProjectScanner::where('project_id', $this->projectId)
+            ->where('type', ScannerType::EntryStaff)
+            ->get();
+    }
+
+    /** @return Collection<int, ProjectGearItem> */
+    #[Computed]
+    public function projectGearItems(): Collection
+    {
+        return ProjectGearItem::where('project_id', $this->projectId)
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    public function createGuestList(): void
+    {
+        $this->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'scannerId' => ['required', Rule::exists('project_scanners', 'id')->where('project_id', $this->projectId)],
+            'gearItemIds' => ['nullable', 'array'],
+            'gearItemIds.*' => ['integer', Rule::exists('project_gear_items', 'id')->where('project_id', $this->projectId)],
+        ]);
+
+        $action = new CreateGuestList;
+        $guestList = $action->execute($this->project, [
+            'name' => $this->name,
+            'scanner_id' => $this->scannerId,
+            'gear_items' => ! empty($this->gearItemIds) ? $this->gearItemIds : null,
+        ]);
+
+        $this->resetForm();
+        $this->showCreateModal = false;
+
+        $this->redirect(route('guest-lists.show', [
+            'projectId' => $this->projectId,
+            'guestListId' => $guestList->id,
+        ]), navigate: true);
+    }
+
+    public function deleteGuestList(int $guestListId): void
+    {
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($guestListId);
+
+        Gate::authorize('manageGuestLists', $this->project);
+
+        $action = new DeleteGuestList;
+        $action->execute($guestList);
+
+        session()->flash('message', 'Guest list deleted.');
+        unset($this->guestLists);
+    }
+
+    private function resetForm(): void
+    {
+        $this->name = '';
+        $this->scannerId = null;
+        $this->gearItemIds = [];
+    }
+}

--- a/app/Livewire/Projects/GuestListShow.php
+++ b/app/Livewire/Projects/GuestListShow.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Livewire\Projects;
+
+use App\Actions\AddGuestEntry;
+use App\Actions\AddGuestGroup;
+use App\Actions\ConfirmGuestList;
+use App\Actions\RemoveGuestEntry;
+use App\Actions\RemoveGuestGroup;
+use App\Actions\UpdateGuestEntry;
+use App\Actions\UpdateGuestList;
+use App\Enums\ScannerType;
+use App\Exceptions\DomainException;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Guest List')]
+class GuestListShow extends Component
+{
+    #[Locked]
+    public int $projectId;
+
+    #[Locked]
+    public int $guestListId;
+
+    public ?Project $project = null;
+
+    public bool $showEditModal = false;
+
+    // Edit form fields
+    public string $editName = '';
+
+    public ?int $editScannerId = null;
+
+    public array $editGearItemIds = [];
+
+    // Add group form fields
+    public string $newGroupLabel = '';
+
+    public int $newGroupCount = 1;
+
+    // Entry editing fields
+    #[Locked]
+    public ?int $editingEntryId = null;
+
+    public string $entryName = '';
+
+    public string $entryEmail = '';
+
+    public array $entryGear = [];
+
+    public function mount(int $projectId, int $guestListId): void
+    {
+        $this->project = currentOrganization()->projects()->findOrFail($projectId);
+        $this->projectId = $projectId;
+        $this->guestListId = $guestListId;
+
+        Gate::authorize('manageGuestLists', $this->project);
+
+        // Verify guest list belongs to project
+        GuestList::where('project_id', $this->projectId)->findOrFail($guestListId);
+    }
+
+    #[Computed]
+    public function guestList(): GuestList
+    {
+        return GuestList::where('project_id', $this->projectId)
+            ->with('scanner', 'groups.entries.gear')
+            ->withCount([
+                'entries as total_entries',
+                'entries as checked_in_entries' => fn ($q) => $q->whereNotNull('checked_in_at'),
+            ])
+            ->findOrFail($this->guestListId);
+    }
+
+    /** @return Collection<int, ProjectScanner> */
+    #[Computed]
+    public function entryStaffScanners(): Collection
+    {
+        return ProjectScanner::where('project_id', $this->projectId)
+            ->where('type', ScannerType::EntryStaff)
+            ->get();
+    }
+
+    /** @return Collection<int, ProjectGearItem> */
+    #[Computed]
+    public function projectGearItems(): Collection
+    {
+        return ProjectGearItem::where('project_id', $this->projectId)
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    public function openEditModal(): void
+    {
+        $guestList = $this->guestList;
+
+        $this->editName = $guestList->name;
+        $this->editScannerId = $guestList->scanner_id;
+        $this->editGearItemIds = $guestList->gear_items ?? [];
+        $this->showEditModal = true;
+    }
+
+    public function updateGuestList(): void
+    {
+        $this->validate([
+            'editName' => ['required', 'string', 'max:255'],
+            'editScannerId' => ['required', Rule::exists('project_scanners', 'id')->where('project_id', $this->projectId)],
+            'editGearItemIds' => ['nullable', 'array'],
+            'editGearItemIds.*' => ['integer', Rule::exists('project_gear_items', 'id')->where('project_id', $this->projectId)],
+        ]);
+
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
+
+        $action = new UpdateGuestList;
+        $action->execute($guestList, [
+            'name' => $this->editName,
+            'scanner_id' => $this->editScannerId,
+            'gear_items' => ! empty($this->editGearItemIds) ? $this->editGearItemIds : null,
+        ]);
+
+        $this->showEditModal = false;
+        unset($this->guestList);
+    }
+
+    public function confirmGuestList(): void
+    {
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
+
+        try {
+            $action = new ConfirmGuestList;
+            $action->execute($guestList);
+        } catch (DomainException $e) {
+            session()->flash('error', $e->getMessage());
+
+            return;
+        }
+
+        session()->flash('message', 'Guest list confirmed. QR codes are being generated.');
+        unset($this->guestList);
+    }
+
+    public function addGroup(): void
+    {
+        $this->validate([
+            'newGroupLabel' => ['required', 'string', 'max:255'],
+            'newGroupCount' => ['required', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
+
+        $action = new AddGuestGroup;
+        $action->execute($guestList, $this->newGroupLabel, $this->newGroupCount);
+
+        $this->newGroupLabel = '';
+        $this->newGroupCount = 1;
+        unset($this->guestList);
+    }
+
+    public function removeGroup(int $groupId): void
+    {
+        $group = GuestGroup::where('guest_list_id', $this->guestListId)->findOrFail($groupId);
+
+        $action = new RemoveGuestGroup;
+        $action->execute($group);
+
+        unset($this->guestList);
+    }
+
+    public function addEntry(int $groupId): void
+    {
+        $group = GuestGroup::where('guest_list_id', $this->guestListId)->findOrFail($groupId);
+
+        $action = new AddGuestEntry;
+        $action->execute($group);
+
+        unset($this->guestList);
+    }
+
+    public function removeEntry(int $entryId): void
+    {
+        $entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
+            ->findOrFail($entryId);
+
+        $action = new RemoveGuestEntry;
+        $action->execute($entry);
+
+        unset($this->guestList);
+    }
+
+    public function startEditEntry(int $entryId): void
+    {
+        $entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
+            ->findOrFail($entryId);
+
+        $this->editingEntryId = $entryId;
+        $this->entryName = $entry->name ?? '';
+        $this->entryEmail = $entry->email ?? '';
+        $this->entryGear = [];
+    }
+
+    public function saveEntry(): void
+    {
+        $this->validate([
+            'entryName' => ['nullable', 'string', 'max:255'],
+            'entryEmail' => ['nullable', 'email', 'max:255'],
+            'entryGear' => ['nullable', 'array'],
+            'entryGear.*.project_gear_item_id' => ['required', 'integer', Rule::exists('project_gear_items', 'id')->where('project_id', $this->projectId)],
+            'entryGear.*.quantity' => ['required', 'integer', 'min:1', 'max:100'],
+            'entryGear.*.selection' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
+            ->findOrFail($this->editingEntryId);
+
+        $action = new UpdateGuestEntry;
+        $action->execute($entry, [
+            'name' => $this->entryName ?: null,
+            'email' => $this->entryEmail ?: null,
+            'gear' => $this->entryGear,
+        ]);
+
+        $this->cancelEditEntry();
+        unset($this->guestList);
+    }
+
+    public function cancelEditEntry(): void
+    {
+        $this->editingEntryId = null;
+        $this->entryName = '';
+        $this->entryEmail = '';
+        $this->entryGear = [];
+    }
+}

--- a/app/Livewire/ScannerApp.php
+++ b/app/Livewire/ScannerApp.php
@@ -74,4 +74,16 @@ class ScannerApp extends Component
     {
         return '/api/scanner/'.$this->scannerId.'/gear-pickup';
     }
+
+    #[Computed]
+    public function guestSyncUrl(): string
+    {
+        return '/api/scanner/'.$this->scannerId.'/guest-sync';
+    }
+
+    #[Computed]
+    public function guestGearPickupUrl(): string
+    {
+        return '/api/scanner/'.$this->scannerId.'/guest-gear-pickup';
+    }
 }

--- a/app/Mail/GuestInvitationMail.php
+++ b/app/Mail/GuestInvitationMail.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\GuestEntry;
+use App\Models\GuestList;
+use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class GuestInvitationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  Collection<int, GuestEntry>  $entries
+     */
+    public function __construct(
+        public GuestList $guestList,
+        public Collection $entries,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Your Guest Pass — {$this->guestList->name}",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.guest-invitation',
+            with: [
+                'guestListName' => $this->guestList->name,
+                'projectName' => $this->guestList->project->name,
+                'entries' => $this->entries,
+            ],
+        );
+    }
+}

--- a/app/Models/GuestEntry.php
+++ b/app/Models/GuestEntry.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\QrCodeGenerator;
+use Database\Factories\GuestEntryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class GuestEntry extends Model
+{
+    /** @use HasFactory<GuestEntryFactory> */
+    use HasFactory;
+
+    protected $hidden = [
+        'qr_token',
+    ];
+
+    protected $fillable = [
+        'guest_group_id',
+        'number',
+        'name',
+        'email',
+        'qr_token',
+        'checked_in_at',
+        'checked_in_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'number' => 'integer',
+            'checked_in_at' => 'datetime',
+        ];
+    }
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(GuestGroup::class, 'guest_group_id');
+    }
+
+    public function gear(): HasMany
+    {
+        return $this->hasMany(GuestEntryGear::class);
+    }
+
+    public function checkedInByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'checked_in_by');
+    }
+
+    public function isCheckedIn(): bool
+    {
+        return $this->checked_in_at !== null;
+    }
+
+    /**
+     * Display label in "GroupLabel N/Total" format (e.g. "DJ Soundwave 1/3").
+     */
+    public function displayLabel(): string
+    {
+        $group = $this->group;
+
+        return "{$group->label} {$this->number}/{$group->guest_count}";
+    }
+
+    public function qrCodeSvg(): string
+    {
+        return app(QrCodeGenerator::class)->generate($this->qr_token);
+    }
+}

--- a/app/Models/GuestEntryGear.php
+++ b/app/Models/GuestEntryGear.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GuestEntryGearFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GuestEntryGear extends Model
+{
+    /** @use HasFactory<GuestEntryGearFactory> */
+    use HasFactory;
+
+    protected $table = 'guest_entry_gear';
+
+    protected $fillable = [
+        'guest_entry_id',
+        'project_gear_item_id',
+        'quantity',
+        'picked_up_count',
+        'selection',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'integer',
+            'picked_up_count' => 'integer',
+        ];
+    }
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(GuestEntry::class, 'guest_entry_id');
+    }
+
+    public function gearItem(): BelongsTo
+    {
+        return $this->belongsTo(ProjectGearItem::class, 'project_gear_item_id');
+    }
+}

--- a/app/Models/GuestGroup.php
+++ b/app/Models/GuestGroup.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GuestGroupFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class GuestGroup extends Model
+{
+    /** @use HasFactory<GuestGroupFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'guest_list_id',
+        'label',
+        'guest_count',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'guest_count' => 'integer',
+        ];
+    }
+
+    public function guestList(): BelongsTo
+    {
+        return $this->belongsTo(GuestList::class);
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(GuestEntry::class);
+    }
+
+    public function checkedInCount(): int
+    {
+        return $this->entries()->whereNotNull('checked_in_at')->count();
+    }
+}

--- a/app/Models/GuestList.php
+++ b/app/Models/GuestList.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\GuestListStatus;
+use Database\Factories\GuestListFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class GuestList extends Model
+{
+    /** @use HasFactory<GuestListFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'scanner_id',
+        'name',
+        'status',
+        'confirmed_at',
+        'gear_items',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => GuestListStatus::class,
+            'confirmed_at' => 'datetime',
+            'gear_items' => 'array',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function scanner(): BelongsTo
+    {
+        return $this->belongsTo(ProjectScanner::class, 'scanner_id');
+    }
+
+    public function groups(): HasMany
+    {
+        return $this->hasMany(GuestGroup::class);
+    }
+
+    public function entries(): HasManyThrough
+    {
+        return $this->hasManyThrough(GuestEntry::class, GuestGroup::class);
+    }
+
+    public function scopeConfirmed(Builder $query): Builder
+    {
+        return $query->where('status', GuestListStatus::Confirmed);
+    }
+
+    public function scopeForProject(Builder $query, int $projectId): Builder
+    {
+        return $query->where('project_id', $projectId);
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->status === GuestListStatus::Confirmed;
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->status === GuestListStatus::Draft;
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -83,4 +83,9 @@ class Project extends Model
     {
         return $this->hasMany(ProjectScanner::class);
     }
+
+    public function guestLists(): HasMany
+    {
+        return $this->hasMany(GuestList::class);
+    }
 }

--- a/app/Models/ProjectScanner.php
+++ b/app/Models/ProjectScanner.php
@@ -60,6 +60,11 @@ class ProjectScanner extends Model
         return $this->hasMany(ProjectScannerAssignee::class);
     }
 
+    public function guestLists(): HasMany
+    {
+        return $this->hasMany(GuestList::class, 'scanner_id');
+    }
+
     /**
      * Computed status based on time window.
      */

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -66,4 +66,12 @@ class ProjectPolicy
     {
         return $user->projectRoleFor($project) === StaffRole::Organizer;
     }
+
+    /**
+     * Project Organizers (direct or inherited from org) can manage guest lists.
+     */
+    public function manageGuestLists(User $user, Project $project): bool
+    {
+        return $user->projectRoleFor($project) === StaffRole::Organizer;
+    }
 }

--- a/database/factories/GuestEntryFactory.php
+++ b/database/factories/GuestEntryFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<GuestEntry> */
+class GuestEntryFactory extends Factory
+{
+    protected $model = GuestEntry::class;
+
+    public function definition(): array
+    {
+        return [
+            'guest_group_id' => GuestGroup::factory(),
+            'number' => 1,
+            'name' => fake()->optional(0.7)->name(),
+            'email' => fake()->optional(0.6)->safeEmail(),
+            'qr_token' => null,
+            'checked_in_at' => null,
+            'checked_in_by' => null,
+        ];
+    }
+
+    public function withQrToken(): static
+    {
+        return $this->state(fn () => [
+            'qr_token' => bin2hex(random_bytes(32)),
+        ]);
+    }
+
+    public function checkedIn(): static
+    {
+        return $this->state(fn () => [
+            'checked_in_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/GuestEntryGearFactory.php
+++ b/database/factories/GuestEntryGearFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\ProjectGearItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<GuestEntryGear> */
+class GuestEntryGearFactory extends Factory
+{
+    protected $model = GuestEntryGear::class;
+
+    public function definition(): array
+    {
+        return [
+            'guest_entry_id' => GuestEntry::factory(),
+            'project_gear_item_id' => ProjectGearItem::factory(),
+            'quantity' => 1,
+            'picked_up_count' => 0,
+            'selection' => null,
+            'status' => null,
+        ];
+    }
+}

--- a/database/factories/GuestGroupFactory.php
+++ b/database/factories/GuestGroupFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<GuestGroup> */
+class GuestGroupFactory extends Factory
+{
+    protected $model = GuestGroup::class;
+
+    public function definition(): array
+    {
+        return [
+            'guest_list_id' => GuestList::factory(),
+            'label' => fake()->name(),
+            'guest_count' => fake()->numberBetween(1, 5),
+        ];
+    }
+}

--- a/database/factories/GuestListFactory.php
+++ b/database/factories/GuestListFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\GuestListStatus;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<GuestList> */
+class GuestListFactory extends Factory
+{
+    protected $model = GuestList::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'scanner_id' => ProjectScanner::factory(),
+            'name' => fake()->words(3, true),
+            'status' => GuestListStatus::Draft,
+            'confirmed_at' => null,
+            'gear_items' => null,
+        ];
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(fn () => [
+            'status' => GuestListStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_04_01_084420_create_guest_lists_table.php
+++ b/database/migrations/2026_04_01_084420_create_guest_lists_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guest_lists', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('scanner_id')->constrained('project_scanners')->restrictOnDelete();
+            $table->string('name');
+            $table->string('status')->default('draft');
+            $table->dateTime('confirmed_at')->nullable();
+            $table->json('gear_items')->nullable();
+            $table->timestamps();
+
+            $table->index(['project_id', 'status']);
+        });
+    }
+};

--- a/database/migrations/2026_04_01_084426_create_guest_groups_table.php
+++ b/database/migrations/2026_04_01_084426_create_guest_groups_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guest_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('guest_list_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->unsignedInteger('guest_count');
+            $table->timestamps();
+
+            $table->index('guest_list_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_01_084428_create_guest_entries_table.php
+++ b/database/migrations/2026_04_01_084428_create_guest_entries_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guest_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('guest_group_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('number');
+            $table->string('name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('qr_token', 64)->nullable()->unique();
+            $table->dateTime('checked_in_at')->nullable();
+            $table->unsignedBigInteger('checked_in_by')->nullable();
+            $table->timestamps();
+
+            $table->index('guest_group_id');
+            $table->foreign('checked_in_by')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_04_01_084429_create_guest_entry_gear_table.php
+++ b/database/migrations/2026_04_01_084429_create_guest_entry_gear_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guest_entry_gear', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('guest_entry_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('project_gear_item_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('quantity')->default(1);
+            $table->unsignedInteger('picked_up_count')->default(0);
+            $table->string('selection')->nullable();
+            $table->string('status')->nullable();
+            $table->timestamps();
+
+            $table->unique(['guest_entry_id', 'project_gear_item_id']);
+        });
+    }
+};

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -15,15 +15,17 @@ import {
     storeVolunteers,
     storeKeys,
     storeAttendanceRecords,
+    storeGuestEntries,
     getKeys,
     getVolunteers,
+    getGuestEntries,
     addOutboxEntry,
     getOutboxCount,
 } from './idb-store';
 import { validateJwt } from './jwt-validator';
 import { classifyShifts, type ClassifiedShift } from './shift-context';
 import { syncOutbox } from './sync';
-import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear } from './types';
+import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear, GuestEntry } from './types';
 
 type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | 'invalid' | 'confirmed';
 
@@ -44,6 +46,8 @@ interface ScannerAppConfig {
     dataUrl: string;
     syncUrl: string;
     gearPickupUrl: string;
+    guestSyncUrl: string;
+    guestGearPickupUrl: string;
 }
 
 export function scannerApp(config: ScannerAppConfig) {
@@ -71,6 +75,37 @@ export function scannerApp(config: ScannerAppConfig) {
         _dataUrl: config.dataUrl,
         _gearPickupUrl: config.gearPickupUrl,
         _processing: false,
+        _guestEntries: [] as GuestEntry[],
+        _guestSyncUrl: config.guestSyncUrl,
+        _guestGearPickupUrl: config.guestGearPickupUrl,
+        activeTab: 'scanner' as 'scanner' | 'volunteers' | 'guests',
+        guestSearchQuery: '' as string,
+        guestResult: null as GuestEntry | null,
+
+        get filteredGuestGroups(): { label: string; guestCount: number; entries: GuestEntry[] }[] {
+            const groups = new Map<number, { label: string; guestCount: number; entries: GuestEntry[] }>();
+            const lowerQuery = this.guestSearchQuery.toLowerCase();
+
+            for (const entry of this._guestEntries) {
+                if (lowerQuery && !(
+                    (entry.name && entry.name.toLowerCase().includes(lowerQuery)) ||
+                    entry.group_label.toLowerCase().includes(lowerQuery)
+                )) {
+                    continue;
+                }
+
+                if (!groups.has(entry.guest_group_id)) {
+                    groups.set(entry.guest_group_id, {
+                        label: entry.group_label,
+                        guestCount: entry.group_guest_count,
+                        entries: [],
+                    });
+                }
+                groups.get(entry.guest_group_id)!.entries.push(entry);
+            }
+
+            return Array.from(groups.values());
+        },
 
         get canConfirmArrival(): boolean {
             return config.scannerType === 'entry_staff' || config.modes.includes('checkin');
@@ -135,6 +170,8 @@ export function scannerApp(config: ScannerAppConfig) {
                         // Persist to IndexedDB for offline use
                         await storeVolunteers(this._scannerId, data.volunteers);
                         await storeKeys(this._scannerId, data.keys);
+                        this._guestEntries = data.guest_entries ?? [];
+                        await storeGuestEntries(this._scannerId, this._guestEntries);
                         if (data.attendance_records) {
                             await storeAttendanceRecords(this._scannerId, data.attendance_records);
                         }
@@ -147,6 +184,9 @@ export function scannerApp(config: ScannerAppConfig) {
             // Fallback: load from IndexedDB
             if (this._volunteers.length === 0) {
                 this._volunteers = await getVolunteers(this._scannerId);
+            }
+            if (this._guestEntries.length === 0) {
+                this._guestEntries = await getGuestEntries(this._scannerId);
             }
 
             this.outboxCount = await getOutboxCount(this._scannerId);
@@ -171,6 +211,13 @@ export function scannerApp(config: ScannerAppConfig) {
                 const jwtResult = await validateJwt(jwtToken, keys);
 
                 if (!jwtResult.valid || !jwtResult.volunteerId) {
+                    // Dual-path: try guest token lookup (D8)
+                    const guestEntry = this._guestEntries.find((e) => e.qr_token === jwtToken);
+                    if (guestEntry) {
+                        this._handleGuestQr(guestEntry);
+                        return;
+                    }
+
                     this.state = 'invalid';
                     this.errorMessage = jwtResult.error ?? 'Invalid QR code';
                     return;
@@ -355,16 +402,97 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         async _sync() {
-            await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken);
+            await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken, this._guestSyncUrl);
             this.outboxCount = await getOutboxCount(this._scannerId);
         },
 
         dismiss() {
             this.state = 'scanning';
             this.result = null;
+            this.guestResult = null;
             this.selectedVolunteer = null;
             this.resultMessage = '';
             this.errorMessage = '';
+        },
+
+        _handleGuestQr(entry: GuestEntry) {
+            const alreadyCheckedIn = entry.checked_in_at !== null;
+            this.guestResult = entry;
+
+            const label = `${entry.group_label} ${entry.number}/${entry.group_guest_count}`;
+
+            if (alreadyCheckedIn) {
+                this.state = 'duplicate';
+                this.resultMessage = `Gast — ${label} already checked in.`;
+            } else {
+                this.state = 'result';
+                this.resultMessage = `Gast — ${label}${entry.name ? ` (${entry.name})` : ''} — ready to check in.`;
+            }
+        },
+
+        async confirmGuestCheckin(guestEntryId: number) {
+            const entry = this._guestEntries.find((e) => e.id === guestEntryId);
+            if (!entry) {
+                return;
+            }
+
+            const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+
+            // Mark locally
+            entry.checked_in_at = now;
+
+            // Save to outbox
+            await addOutboxEntry(this._scannerId, {
+                type: 'guest_checkin',
+                guest_entry_id: guestEntryId,
+                scanned_at: now,
+            });
+            this.outboxCount = await getOutboxCount(this._scannerId);
+
+            this.state = 'confirmed';
+            this.resultMessage = `${entry.group_label} ${entry.number}/${entry.group_guest_count} checked in.`;
+
+            if (this.isOnline) {
+                await this._sync();
+            }
+
+            setTimeout(() => this.dismiss(), 2000);
+        },
+
+        async _postGuestGear(guestEntryGearId: number, payload: Record<string, unknown>) {
+            if (!this.isOnline) {
+                return;
+            }
+
+            try {
+                const response = await fetch(this._guestGearPickupUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                        'X-Scanner-Token': this._scannerToken,
+                    },
+                    body: JSON.stringify({ guest_entry_gear_id: guestEntryGearId, ...payload }),
+                });
+
+                if (!response.ok) {
+                    console.error('Guest gear pickup failed:', await response.text());
+                }
+            } catch (error) {
+                console.error('Guest gear pickup network error:', error);
+            }
+        },
+
+        async selectGuestGearState(guestEntryGearId: number, state: string) {
+            await this._postGuestGear(guestEntryGearId, { status: state });
+        },
+
+        async selectGuestGearSelection(guestEntryGearId: number, selection: string) {
+            await this._postGuestGear(guestEntryGearId, { selection });
+        },
+
+        async incrementGuestGearPickup(guestEntryGearId: number) {
+            await this._postGuestGear(guestEntryGearId, { quantity: 1 });
         },
 
         destroy() {

--- a/resources/js/scanner/idb-store.ts
+++ b/resources/js/scanner/idb-store.ts
@@ -1,7 +1,7 @@
-import type { Volunteer, ScannerKeys, OutboxEntry, AttendanceRecord } from './types';
+import type { Volunteer, ScannerKeys, OutboxEntry, AttendanceRecord, GuestEntry } from './types';
 
 const DB_NAME = 'voluntify-scanner';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 let dbInstance: IDBDatabase | null = null;
 
@@ -14,25 +14,34 @@ export function openScannerDb(): Promise<IDBDatabase> {
 
         const request = indexedDB.open(DB_NAME, DB_VERSION);
 
-        request.onupgradeneeded = () => {
+        request.onupgradeneeded = (event) => {
             const db = request.result;
+            const oldVersion = (event as IDBVersionChangeEvent).oldVersion;
 
-            // Drop old v2 stores on upgrade from v2 → v3
-            for (const name of Array.from(db.objectStoreNames)) {
-                db.deleteObjectStore(name);
+            if (oldVersion < 3) {
+                // Full rebuild for versions before 3
+                for (const name of Array.from(db.objectStoreNames)) {
+                    db.deleteObjectStore(name);
+                }
+
+                const volStore = db.createObjectStore('volunteers', { keyPath: ['scannerId', 'id'] });
+                volStore.createIndex('byScanner', 'scannerId', { unique: false });
+
+                const outboxStore = db.createObjectStore('outbox', { keyPath: 'localId', autoIncrement: true });
+                outboxStore.createIndex('byScanner', 'scannerId', { unique: false });
+
+                db.createObjectStore('keys', { keyPath: 'scannerId' });
+
+                const attStore = db.createObjectStore('attendance', { keyPath: ['scannerId', 'id'] });
+                attStore.createIndex('byScanner', 'scannerId', { unique: false });
             }
 
-            // Recreate with scannerId-based keys
-            const volStore = db.createObjectStore('volunteers', { keyPath: ['scannerId', 'id'] });
-            volStore.createIndex('byScanner', 'scannerId', { unique: false });
-
-            const outboxStore = db.createObjectStore('outbox', { keyPath: 'localId', autoIncrement: true });
-            outboxStore.createIndex('byScanner', 'scannerId', { unique: false });
-
-            db.createObjectStore('keys', { keyPath: 'scannerId' });
-
-            const attStore = db.createObjectStore('attendance', { keyPath: ['scannerId', 'id'] });
-            attStore.createIndex('byScanner', 'scannerId', { unique: false });
+            if (oldVersion < 4) {
+                if (!db.objectStoreNames.contains('guest_entries')) {
+                    const guestStore = db.createObjectStore('guest_entries', { keyPath: ['scannerId', 'id'] });
+                    guestStore.createIndex('byScanner', 'scannerId', { unique: false });
+                }
+            }
         };
 
         request.onsuccess = () => {
@@ -110,7 +119,7 @@ export async function addOutboxEntry(scannerId: number, entry: OutboxEntry): Pro
     await reqToPromise(store.add({ ...entry, scannerId }));
 }
 
-export async function getOutboxEntries(scannerId: number): Promise<OutboxEntry[]> {
+export async function getOutboxEntries(scannerId: number): Promise<(OutboxEntry & { localId: number })[]> {
     const store = await tx('outbox', 'readonly');
     const index = store.index('byScanner');
     return reqToPromise(index.getAll(scannerId));
@@ -142,6 +151,42 @@ export async function storeAttendanceRecords(scannerId: number, records: Attenda
 
     for (const r of records) {
         store.put({ ...r, scannerId });
+    }
+}
+
+export async function storeGuestEntries(scannerId: number, entries: GuestEntry[]): Promise<void> {
+    const store = await tx('guest_entries', 'readwrite');
+    const index = store.index('byScanner');
+    const existingKeys = await reqToPromise(index.getAllKeys(scannerId));
+    for (const key of existingKeys) {
+        store.delete(key);
+    }
+    for (const entry of entries) {
+        store.put({ ...entry, scannerId });
+    }
+}
+
+export async function getGuestEntries(scannerId: number): Promise<GuestEntry[]> {
+    const store = await tx('guest_entries', 'readonly');
+    const index = store.index('byScanner');
+    const results = await reqToPromise(index.getAll(scannerId));
+    return results.map(({ scannerId: _, ...entry }) => entry as GuestEntry);
+}
+
+export async function searchGuestEntries(scannerId: number, query: string): Promise<GuestEntry[]> {
+    const entries = await getGuestEntries(scannerId);
+    const lowerQuery = query.toLowerCase();
+    return entries.filter(
+        (e) =>
+            (e.name && e.name.toLowerCase().includes(lowerQuery)) ||
+            e.group_label.toLowerCase().includes(lowerQuery)
+    );
+}
+
+export async function deleteOutboxEntries(localIds: number[]): Promise<void> {
+    const store = await tx('outbox', 'readwrite');
+    for (const id of localIds) {
+        store.delete(id);
     }
 }
 

--- a/resources/js/scanner/sync.ts
+++ b/resources/js/scanner/sync.ts
@@ -1,4 +1,4 @@
-import { getOutboxEntries, clearOutbox } from './idb-store';
+import { getOutboxEntries, deleteOutboxEntries } from './idb-store';
 
 function getHeaders(scannerToken: string): Record<string, string> {
     return {
@@ -8,18 +8,22 @@ function getHeaders(scannerToken: string): Record<string, string> {
     };
 }
 
-export async function syncOutbox(scannerId: number, syncUrl: string, scannerToken: string): Promise<void> {
+export async function syncOutbox(
+    scannerId: number,
+    syncUrl: string,
+    scannerToken: string,
+    guestSyncUrl?: string,
+): Promise<void> {
     const entries = await getOutboxEntries(scannerId);
 
     if (entries.length === 0) {
         return;
     }
 
-    const arrivals = entries.filter((e) => !e.type || e.type === 'arrival');
-
     const headers = getHeaders(scannerToken);
-    let allSynced = true;
 
+    // Sync arrivals
+    const arrivals = entries.filter((e) => !e.type || e.type === 'arrival');
     if (arrivals.length > 0) {
         try {
             const response = await fetch(syncUrl, {
@@ -35,15 +39,34 @@ export async function syncOutbox(scannerId: number, syncUrl: string, scannerToke
                 }),
             });
 
-            if (!response.ok) {
-                allSynced = false;
+            if (response.ok) {
+                await deleteOutboxEntries(arrivals.map((e) => e.localId));
             }
         } catch {
-            allSynced = false;
+            // Network error — will retry next sync
         }
     }
 
-    if (allSynced) {
-        await clearOutbox(scannerId);
+    // Sync guest check-ins
+    const guestCheckins = entries.filter((e) => e.type === 'guest_checkin');
+    if (guestCheckins.length > 0 && guestSyncUrl) {
+        try {
+            const response = await fetch(guestSyncUrl, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    guest_checkins: guestCheckins.map((e) => ({
+                        guest_entry_id: e.guest_entry_id,
+                        checked_in_at: e.scanned_at,
+                    })),
+                }),
+            });
+
+            if (response.ok) {
+                await deleteOutboxEntries(guestCheckins.map((e) => e.localId));
+            }
+        } catch {
+            // Network error — will retry next sync
+        }
     }
 }

--- a/resources/js/scanner/types.ts
+++ b/resources/js/scanner/types.ts
@@ -75,9 +75,33 @@ export interface ScannerKeys {
     previous: string;
 }
 
+export interface GuestEntryGearItem {
+    id: number;
+    gear_item_name: string;
+    gear_item_type: 'size_selection' | 'quantity';
+    available_sizes?: string[] | null;
+    available_states?: string[] | null;
+    quantity: number;
+    picked_up_count: number;
+    selection: string | null;
+    status: string | null;
+}
+
+export interface GuestEntry {
+    id: number;
+    guest_group_id: number;
+    group_label: string;
+    group_guest_count: number;
+    number: number;
+    name: string | null;
+    qr_token?: string | null;
+    checked_in_at: string | null;
+    gear: GuestEntryGearItem[];
+}
+
 export interface OutboxEntry {
     id?: number;
-    type: 'arrival' | 'attendance';
+    type: 'arrival' | 'attendance' | 'guest_checkin';
     ticket_id?: number;
     volunteer_id?: number;
     event_id?: number;
@@ -85,5 +109,6 @@ export interface OutboxEntry {
     scanned_at: string;
     shift_signup_id?: number;
     status?: 'on_time' | 'late' | 'no_show';
+    guest_entry_id?: number;
 }
 

--- a/resources/views/livewire/projects/guest-list-index.blade.php
+++ b/resources/views/livewire/projects/guest-list-index.blade.php
@@ -1,0 +1,96 @@
+<div class="mx-auto max-w-7xl p-6">
+    <div class="flex items-center gap-3 mb-6">
+        <flux:button variant="ghost" icon="arrow-left" :href="route('projects.show', $project)" wire:navigate aria-label="{{ __('Back to project') }}" />
+        <flux:heading size="xl">{{ __('Guest Lists') }} &mdash; {{ $project->name }}</flux:heading>
+        <div class="ml-auto">
+            <flux:button variant="primary" icon="plus" wire:click="$set('showCreateModal', true)">
+                {{ __('New Guest List') }}
+            </flux:button>
+        </div>
+    </div>
+
+    @if (session('message'))
+        <flux:callout variant="success" class="mb-4">{{ session('message') }}</flux:callout>
+    @endif
+
+    {{-- Guest list cards --}}
+    @if ($this->guestLists->isEmpty())
+        <flux:card>
+            <flux:text class="text-center text-zinc-500 dark:text-zinc-400">
+                {{ __('No guest lists yet. Create one to get started.') }}
+            </flux:text>
+        </flux:card>
+    @else
+        <div class="space-y-4">
+            @foreach ($this->guestLists as $guestList)
+                <flux:card wire:key="guest-list-{{ $guestList->id }}">
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-2 mb-1">
+                                <a href="{{ route('guest-lists.show', ['projectId' => $projectId, 'guestListId' => $guestList->id]) }}" wire:navigate class="hover:underline">
+                                    <flux:heading size="lg">{{ $guestList->name }}</flux:heading>
+                                </a>
+                                <flux:badge size="sm" :color="$guestList->status === \App\Enums\GuestListStatus::Confirmed ? 'emerald' : 'zinc'">
+                                    {{ $guestList->status->label() }}
+                                </flux:badge>
+                            </div>
+                            <flux:text size="sm" class="text-zinc-500">
+                                {{ __('Scanner:') }} {{ $guestList->scanner?->name ?? __('None') }}
+                            </flux:text>
+                            <div class="flex gap-4 mt-2">
+                                <flux:text size="sm">{{ __(':count groups', ['count' => $guestList->groups->count()]) }}</flux:text>
+                                <flux:text size="sm">{{ __(':count entries', ['count' => $guestList->total_entries]) }}</flux:text>
+                                <flux:text size="sm">{{ __(':count checked in', ['count' => $guestList->checked_in_entries]) }}</flux:text>
+                            </div>
+                        </div>
+
+                        <div class="flex gap-2">
+                            <flux:button size="sm" variant="ghost" icon="eye" :href="route('guest-lists.show', ['projectId' => $projectId, 'guestListId' => $guestList->id])" wire:navigate title="{{ __('View') }}" />
+                            <flux:button size="sm" variant="ghost" icon="trash" wire:click="deleteGuestList({{ $guestList->id }})" wire:confirm="{{ __('Are you sure you want to delete this guest list?') }}" title="{{ __('Delete') }}" />
+                        </div>
+                    </div>
+                </flux:card>
+            @endforeach
+        </div>
+    @endif
+
+    {{-- Create Modal --}}
+    <flux:modal wire:model="showCreateModal">
+        <flux:heading>{{ __('New Guest List') }}</flux:heading>
+
+        <div class="mt-4 space-y-4">
+            <flux:field>
+                <flux:label>{{ __('Name') }}</flux:label>
+                <flux:input wire:model="name" placeholder="{{ __('e.g. VIP Guest List') }}" />
+                <flux:error name="name" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Scanner') }}</flux:label>
+                <flux:select wire:model="scannerId">
+                    <flux:select.option value="">{{ __('Select a scanner...') }}</flux:select.option>
+                    @foreach ($this->entryStaffScanners as $scanner)
+                        <flux:select.option :value="$scanner->id">{{ $scanner->name }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+                <flux:error name="scannerId" />
+            </flux:field>
+
+            @if ($this->projectGearItems->isNotEmpty())
+                <flux:field>
+                    <flux:label>{{ __('Gear Items') }}</flux:label>
+                    <div class="flex flex-col gap-2">
+                        @foreach ($this->projectGearItems as $gearItem)
+                            <flux:checkbox wire:model="gearItemIds" :value="$gearItem->id" :label="$gearItem->name" />
+                        @endforeach
+                    </div>
+                </flux:field>
+            @endif
+        </div>
+
+        <div class="mt-6 flex justify-end gap-2">
+            <flux:button variant="ghost" wire:click="$set('showCreateModal', false)">{{ __('Cancel') }}</flux:button>
+            <flux:button variant="primary" wire:click="createGuestList">{{ __('Create') }}</flux:button>
+        </div>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/projects/guest-list-show.blade.php
+++ b/resources/views/livewire/projects/guest-list-show.blade.php
@@ -1,0 +1,208 @@
+<div class="mx-auto max-w-7xl p-6">
+    <div class="flex items-center gap-3 mb-6">
+        <flux:button variant="ghost" icon="arrow-left" :href="route('guest-lists.index', ['projectId' => $projectId])" wire:navigate aria-label="{{ __('Back to guest lists') }}" />
+        <flux:heading size="xl">{{ $this->guestList->name }}</flux:heading>
+        <flux:badge size="sm" :color="$this->guestList->status === \App\Enums\GuestListStatus::Confirmed ? 'emerald' : 'zinc'">
+            {{ $this->guestList->status->label() }}
+        </flux:badge>
+        <div class="ml-auto flex gap-2">
+            @if ($this->guestList->isDraft())
+                <flux:button variant="primary" wire:click="confirmGuestList" wire:confirm="{{ __('Confirm this guest list? QR codes will be generated for all entries.') }}">
+                    {{ __('Confirm') }}
+                </flux:button>
+            @endif
+            <flux:button variant="ghost" icon="pencil" wire:click="openEditModal">
+                {{ __('Edit') }}
+            </flux:button>
+        </div>
+    </div>
+
+    @if (session('message'))
+        <flux:callout variant="success" class="mb-4">{{ session('message') }}</flux:callout>
+    @endif
+
+    @if (session('error'))
+        <flux:callout variant="danger" class="mb-4">{{ session('error') }}</flux:callout>
+    @endif
+
+    {{-- Summary bar --}}
+    <div class="grid grid-cols-3 gap-4 mb-6">
+        <flux:card>
+            <flux:text size="sm" class="text-zinc-500">{{ __('Groups') }}</flux:text>
+            <flux:heading size="lg">{{ $this->guestList->groups->count() }}</flux:heading>
+        </flux:card>
+        <flux:card>
+            <flux:text size="sm" class="text-zinc-500">{{ __('Total Entries') }}</flux:text>
+            <flux:heading size="lg">{{ $this->guestList->total_entries }}</flux:heading>
+        </flux:card>
+        <flux:card>
+            <flux:text size="sm" class="text-zinc-500">{{ __('Checked In') }}</flux:text>
+            <flux:heading size="lg">{{ $this->guestList->checked_in_entries }}</flux:heading>
+        </flux:card>
+    </div>
+
+    {{-- Add group form --}}
+    <flux:card class="mb-6">
+        <flux:heading size="lg" class="mb-3">{{ __('Add Group') }}</flux:heading>
+        <div class="flex items-end gap-3">
+            <flux:field class="flex-1">
+                <flux:label>{{ __('Label') }}</flux:label>
+                <flux:input wire:model="newGroupLabel" placeholder="{{ __('e.g. DJ Soundwave') }}" />
+                <flux:error name="newGroupLabel" />
+            </flux:field>
+            <flux:field>
+                <flux:label>{{ __('Guest Count') }}</flux:label>
+                <flux:input type="number" wire:model="newGroupCount" min="1" max="100" class="w-24" />
+                <flux:error name="newGroupCount" />
+            </flux:field>
+            <flux:button variant="primary" wire:click="addGroup">{{ __('Add') }}</flux:button>
+        </div>
+    </flux:card>
+
+    {{-- Groups --}}
+    @if ($this->guestList->groups->isEmpty())
+        <flux:card>
+            <flux:text class="text-center text-zinc-500 dark:text-zinc-400">
+                {{ __('No groups yet. Add one above.') }}
+            </flux:text>
+        </flux:card>
+    @else
+        <div class="space-y-4">
+            @foreach ($this->guestList->groups as $group)
+                <flux:card wire:key="group-{{ $group->id }}">
+                    <div class="flex items-center justify-between mb-3">
+                        <div class="flex items-center gap-2">
+                            <flux:heading size="lg">{{ $group->label }}</flux:heading>
+                            <flux:badge size="sm">
+                                {{ $group->entries->where('checked_in_at', '!=', null)->count() }}/{{ $group->entries->count() }} {{ __('checked in') }}
+                            </flux:badge>
+                        </div>
+                        <div class="flex gap-2">
+                            <flux:button size="sm" variant="ghost" icon="plus" wire:click="addEntry({{ $group->id }})" title="{{ __('Add entry') }}">
+                                {{ __('Add Entry') }}
+                            </flux:button>
+                            <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeGroup({{ $group->id }})" wire:confirm="{{ __('Delete this group and all its entries?') }}" title="{{ __('Delete group') }}" />
+                        </div>
+                    </div>
+
+                    @if ($group->entries->isNotEmpty())
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="border-b border-zinc-200 dark:border-zinc-700 text-left">
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">#</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Name') }}</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Email') }}</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Gear') }}</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('QR') }}</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Status') }}</th>
+                                        <th scope="col" class="sr-only py-2 font-medium text-zinc-500">{{ __('Actions') }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach ($group->entries as $entry)
+                                        <tr wire:key="entry-{{ $entry->id }}" class="border-b border-zinc-100 dark:border-zinc-800">
+                                            @if ($editingEntryId === $entry->id)
+                                                {{-- Inline edit mode --}}
+                                                <td class="py-2 pr-4">{{ $entry->number }}</td>
+                                                <td class="py-2 pr-4">
+                                                    <flux:input wire:model="entryName" size="sm" placeholder="{{ __('Name') }}" />
+                                                    <flux:error name="entryName" />
+                                                </td>
+                                                <td class="py-2 pr-4">
+                                                    <flux:input wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" />
+                                                    <flux:error name="entryEmail" />
+                                                </td>
+                                                <td class="py-2 pr-4">&mdash;</td>
+                                                <td class="py-2 pr-4">&mdash;</td>
+                                                <td class="py-2 pr-4">&mdash;</td>
+                                                <td class="py-2 text-right">
+                                                    <div class="flex gap-1 justify-end">
+                                                        <flux:button size="sm" variant="primary" wire:click="saveEntry">{{ __('Save') }}</flux:button>
+                                                        <flux:button size="sm" variant="ghost" wire:click="cancelEditEntry">{{ __('Cancel') }}</flux:button>
+                                                    </div>
+                                                </td>
+                                            @else
+                                                {{-- Display mode --}}
+                                                <td class="py-2 pr-4 text-zinc-500">{{ $entry->number }}</td>
+                                                <td class="py-2 pr-4">{{ $entry->name ?? '—' }}</td>
+                                                <td class="py-2 pr-4">{{ $entry->email ?? '—' }}</td>
+                                                <td class="py-2 pr-4">
+                                                    @if ($entry->gear->isNotEmpty())
+                                                        {{ $entry->gear->count() }} {{ __('items') }}
+                                                    @else
+                                                        —
+                                                    @endif
+                                                </td>
+                                                <td class="py-2 pr-4">
+                                                    @if ($entry->qr_token)
+                                                        <flux:icon name="qr-code" class="size-4 text-emerald-500" />
+                                                    @else
+                                                        <flux:icon name="minus" class="size-4 text-zinc-300" />
+                                                    @endif
+                                                </td>
+                                                <td class="py-2 pr-4">
+                                                    @if ($entry->isCheckedIn())
+                                                        <flux:badge size="sm" color="emerald">{{ __('Checked in') }}</flux:badge>
+                                                    @else
+                                                        <flux:badge size="sm" color="zinc">{{ __('Pending') }}</flux:badge>
+                                                    @endif
+                                                </td>
+                                                <td class="py-2 text-right">
+                                                    <div class="flex gap-1 justify-end">
+                                                        <flux:button size="sm" variant="ghost" icon="pencil" wire:click="startEditEntry({{ $entry->id }})" title="{{ __('Edit') }}" />
+                                                        <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeEntry({{ $entry->id }})" wire:confirm="{{ __('Remove this entry?') }}" title="{{ __('Remove') }}" />
+                                                    </div>
+                                                </td>
+                                            @endif
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </flux:card>
+            @endforeach
+        </div>
+    @endif
+
+    {{-- Edit Modal --}}
+    <flux:modal wire:model="showEditModal">
+        <flux:heading>{{ __('Edit Guest List') }}</flux:heading>
+
+        <div class="mt-4 space-y-4">
+            <flux:field>
+                <flux:label>{{ __('Name') }}</flux:label>
+                <flux:input wire:model="editName" />
+                <flux:error name="editName" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Scanner') }}</flux:label>
+                <flux:select wire:model="editScannerId">
+                    <flux:select.option value="">{{ __('Select a scanner...') }}</flux:select.option>
+                    @foreach ($this->entryStaffScanners as $scanner)
+                        <flux:select.option :value="$scanner->id">{{ $scanner->name }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+                <flux:error name="editScannerId" />
+            </flux:field>
+
+            @if ($this->projectGearItems->isNotEmpty())
+                <flux:field>
+                    <flux:label>{{ __('Gear Items') }}</flux:label>
+                    <div class="flex flex-col gap-2">
+                        @foreach ($this->projectGearItems as $gearItem)
+                            <flux:checkbox wire:model="editGearItemIds" :value="$gearItem->id" :label="$gearItem->name" />
+                        @endforeach
+                    </div>
+                </flux:field>
+            @endif
+        </div>
+
+        <div class="mt-6 flex justify-end gap-2">
+            <flux:button variant="ghost" wire:click="$set('showEditModal', false)">{{ __('Cancel') }}</flux:button>
+            <flux:button variant="primary" wire:click="updateGuestList">{{ __('Update') }}</flux:button>
+        </div>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -6,7 +6,9 @@
         scannerToken: '{{ $scannerToken }}',
         dataUrl: '{{ $this->dataUrl }}',
         syncUrl: '{{ $this->syncUrl }}',
-        gearPickupUrl: '{{ $this->gearPickupUrl }}'
+        gearPickupUrl: '{{ $this->gearPickupUrl }}',
+        guestSyncUrl: '{{ $this->guestSyncUrl }}',
+        guestGearPickupUrl: '{{ $this->guestGearPickupUrl }}'
     })"
     class="flex min-h-screen flex-col"
 >
@@ -31,15 +33,57 @@
     {{-- Scanner content --}}
     <main class="flex flex-1 flex-col p-4">
         @if ($scannerType === 'entry_staff')
-            {{-- Entry Staff: QR viewfinder + result panel --}}
-            <div class="flex flex-1 flex-col items-center justify-center space-y-4">
+            {{-- Entry Staff: Tabbed layout — Scanner / Volunteers / Gastliste --}}
+
+            {{-- Tab bar (WAI-ARIA Tabs pattern) --}}
+            <div role="tablist" class="mb-4 flex border-b border-zinc-700">
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-scanner"
+                    :aria-selected="activeTab === 'scanner'"
+                    aria-controls="tabpanel-scanner"
+                    class="flex-1 px-4 py-2 text-sm font-medium transition-colors"
+                    :class="activeTab === 'scanner' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="activeTab = 'scanner'"
+                >
+                    Scanner
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-volunteers"
+                    :aria-selected="activeTab === 'volunteers'"
+                    aria-controls="tabpanel-volunteers"
+                    class="flex-1 px-4 py-2 text-sm font-medium transition-colors"
+                    :class="activeTab === 'volunteers' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="activeTab = 'volunteers'"
+                >
+                    Volunteers
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-guests"
+                    :aria-selected="activeTab === 'guests'"
+                    aria-controls="tabpanel-guests"
+                    class="flex-1 px-4 py-2 text-sm font-medium transition-colors"
+                    :class="activeTab === 'guests' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="activeTab = 'guests'"
+                >
+                    Gastliste
+                </button>
+            </div>
+
+            {{-- Scanner tab --}}
+            <div id="tabpanel-scanner" role="tabpanel" aria-labelledby="tab-scanner" x-show="activeTab === 'scanner'" class="flex flex-1 flex-col items-center justify-center space-y-4">
                 <div id="scanner-viewfinder" class="aspect-square w-full max-w-sm overflow-hidden rounded-xl bg-black">
                     <video id="scanner-video" class="h-full w-full object-cover" aria-label="{{ __('QR code camera viewfinder') }}" playsinline></video>
                 </div>
 
-                {{-- Result panel --}}
+                {{-- Result panel (volunteer) --}}
                 <div
-                    x-show="state !== 'idle' && state !== 'scanning'"
+                    x-show="(state !== 'idle' && state !== 'scanning') && !guestResult"
                     x-transition
                     role="alert"
                     aria-live="assertive"
@@ -53,6 +97,94 @@
                     x-cloak
                 >
                     <p class="text-center text-sm text-white" x-text="resultMessage"></p>
+                </div>
+
+                {{-- Result panel (guest) --}}
+                <div
+                    x-show="guestResult && (state === 'result' || state === 'duplicate' || state === 'confirmed')"
+                    x-transition
+                    role="alert"
+                    aria-live="assertive"
+                    class="w-full max-w-sm rounded-xl p-4"
+                    :class="{
+                        'bg-emerald-500/10 border border-emerald-500/30': state === 'confirmed',
+                        'bg-amber-500/10 border border-amber-500/30': state === 'duplicate',
+                        'bg-zinc-800 border border-zinc-700': state === 'result'
+                    }"
+                    x-cloak
+                >
+                    <p class="text-center text-sm text-white" x-text="resultMessage"></p>
+                    <template x-if="guestResult && state === 'result'">
+                        <div class="mt-3 flex justify-center">
+                            <button
+                                type="button"
+                                class="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+                                @click="confirmGuestCheckin(guestResult.id)"
+                                :aria-label="'Check in ' + guestResult.group_label + ' #' + guestResult.number"
+                            >
+                                Check In
+                            </button>
+                        </div>
+                    </template>
+                </div>
+            </div>
+
+            {{-- Volunteers tab (placeholder) --}}
+            <div id="tabpanel-volunteers" role="tabpanel" aria-labelledby="tab-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col items-center justify-center">
+                <p class="text-sm text-zinc-400">{{ __('Use QR scanner or manual lookup for volunteer check-in.') }}</p>
+            </div>
+
+            {{-- Gastliste tab --}}
+            <div id="tabpanel-guests" role="tabpanel" aria-labelledby="tab-guests" x-show="activeTab === 'guests'" x-cloak class="flex flex-1 flex-col space-y-4">
+                {{-- Search --}}
+                <div class="px-1">
+                    <input
+                        type="text"
+                        x-model.debounce.300ms="guestSearchQuery"
+                        placeholder="{{ __('Search guests...') }}"
+                        aria-label="{{ __('Search guests') }}"
+                        class="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+                </div>
+
+                {{-- Guest groups --}}
+                <div class="space-y-3 overflow-y-auto px-1">
+                    <template x-for="group in filteredGuestGroups" :key="group.label">
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-3">
+                            <div class="mb-2 flex items-center justify-between">
+                                <span class="text-sm font-semibold text-white" x-text="group.label"></span>
+                                <span class="text-xs text-zinc-400" x-text="group.guestCount + ' Guests'"></span>
+                            </div>
+                            <div class="space-y-2">
+                                <template x-for="entry in group.entries" :key="entry.id">
+                                    <div class="flex items-center justify-between rounded-lg bg-zinc-900 px-3 py-2" aria-live="polite">
+                                        <div>
+                                            <span class="text-sm text-white" x-text="'#' + entry.number + (entry.name ? ' — ' + entry.name : '')"></span>
+                                        </div>
+                                        <div>
+                                            <template x-if="entry.checked_in_at">
+                                                <span class="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs text-emerald-300">{{ __('Checked in') }}</span>
+                                            </template>
+                                            <template x-if="!entry.checked_in_at">
+                                                <button
+                                                    type="button"
+                                                    class="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-500"
+                                                    @click="confirmGuestCheckin(entry.id)"
+                                                    :aria-label="'Check in #' + entry.number + (entry.name ? ' ' + entry.name : '')"
+                                                >
+                                                    Check In
+                                                </button>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template x-if="filteredGuestGroups.length === 0">
+                        <p class="py-8 text-center text-sm text-zinc-500">{{ __('No guests found.') }}</p>
+                    </template>
                 </div>
             </div>
         @else

--- a/resources/views/mail/guest-invitation.blade.php
+++ b/resources/views/mail/guest-invitation.blade.php
@@ -1,0 +1,22 @@
+<x-mail::message>
+# Your Guest Pass — {{ $guestListName }}
+
+You have been invited as a guest to **{{ $projectName }}**.
+
+@foreach ($entries as $entry)
+---
+
+**{{ $entry->displayLabel() }}**
+@if ($entry->name)
+Name: {{ $entry->name }}
+@endif
+
+{!! $entry->qrCodeSvg() !!}
+
+@endforeach
+
+Please present your QR code at the entrance.
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,4 +12,7 @@ Route::prefix('scanner')->middleware(['scanner-api', 'throttle:60,1'])->group(fu
     Route::get('/{scannerId}/data', [ScannerDataController::class, 'data'])->name('scanner-api.data');
     Route::post('/{scannerId}/sync', [ScannerDataController::class, 'sync'])->name('scanner-api.sync');
     Route::post('/{scannerId}/gear-pickup', [ScannerDataController::class, 'gearPickup'])->name('scanner-api.gear-pickup');
+    Route::post('/{scannerId}/guest-checkin', [ScannerDataController::class, 'guestCheckin'])->name('scanner-api.guest-checkin');
+    Route::post('/{scannerId}/guest-gear-pickup', [ScannerDataController::class, 'guestGearPickup'])->name('scanner-api.guest-gear-pickup');
+    Route::post('/{scannerId}/guest-sync', [ScannerDataController::class, 'guestSync'])->name('scanner-api.guest-sync');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ use App\Livewire\Events\ProjectList;
 use App\Livewire\Events\ProjectShow;
 use App\Livewire\Events\VolunteerDetail;
 use App\Livewire\Events\VolunteerList;
+use App\Livewire\Projects\GuestListIndex;
+use App\Livewire\Projects\GuestListShow;
 use App\Livewire\Projects\ProjectMembers;
 use App\Livewire\Projects\ScannerManagement;
 use App\Livewire\Public\EmailVerificationPage;
@@ -75,6 +77,8 @@ Route::prefix('admin')->middleware(['auth', 'verified', 'resolve-org'])->group(f
     Route::livewire('projects/{projectId}', ProjectShow::class)->name('projects.show');
     Route::livewire('projects/{projectId}/members', ProjectMembers::class)->name('projects.members');
     Route::livewire('projects/{projectId}/scanners', ScannerManagement::class)->name('projects.scanners');
+    Route::livewire('projects/{projectId}/guest-lists', GuestListIndex::class)->name('guest-lists.index');
+    Route::livewire('projects/{projectId}/guest-lists/{guestListId}', GuestListShow::class)->name('guest-lists.show');
     Route::livewire('events/{eventId}', EventShow::class)->name('events.show');
     Route::livewire('events/{eventId}/jobs', JobsAndShiftsManager::class)->name('events.jobs');
     Route::livewire('events/{eventId}/emails', EmailTemplateEditor::class)->name('events.emails');

--- a/tests/Feature/Actions/AddGuestEntryTest.php
+++ b/tests/Feature/Actions/AddGuestEntryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Actions\AddGuestEntry;
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\ProjectGearItem;
+use Illuminate\Support\Facades\Queue;
+
+it('adds entry to draft list without QR token', function () {
+    $group = GuestGroup::factory()->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1]);
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'DJ Soundwave', 'dj@example.com');
+
+    expect($entry->number)->toBe(2)
+        ->and($entry->name)->toBe('DJ Soundwave')
+        ->and($entry->email)->toBe('dj@example.com')
+        ->and($entry->qr_token)->toBeNull();
+});
+
+it('adds entry to confirmed list and generates QR token and dispatches email', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'VIP Guest', 'vip@example.com');
+
+    expect($entry->qr_token)->not->toBeNull()
+        ->and(strlen($entry->qr_token))->toBe(64);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'vip@example.com';
+    });
+});
+
+it('adds entry to confirmed list without email and skips email dispatch', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'Companion');
+
+    expect($entry->qr_token)->not->toBeNull();
+
+    Queue::assertNothingPushed();
+});
+
+it('assigns gear to entry', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $gearItem = ProjectGearItem::factory()->create();
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'Guest', null, [
+        ['project_gear_item_id' => $gearItem->id, 'quantity' => 3],
+    ]);
+
+    expect($entry->gear)->toHaveCount(1)
+        ->and($entry->gear->first()->project_gear_item_id)->toBe($gearItem->id)
+        ->and($entry->gear->first()->quantity)->toBe(3);
+});
+
+it('assigns gear with selection', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $gearItem = ProjectGearItem::factory()->create();
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'Guest', null, [
+        ['project_gear_item_id' => $gearItem->id, 'quantity' => 1, 'selection' => 'XL'],
+    ]);
+
+    expect($entry->gear->first()->selection)->toBe('XL');
+});
+
+it('adds entry with no name and no email', function () {
+    $group = GuestGroup::factory()->create();
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group);
+
+    expect($entry->name)->toBeNull()
+        ->and($entry->email)->toBeNull()
+        ->and($entry->number)->toBe(1);
+});
+
+it('auto-increments number correctly with gaps', function () {
+    $group = GuestGroup::factory()->create();
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 3]); // gap at 2
+
+    $action = new AddGuestEntry;
+    $entry = $action->execute($group, 'New Guest');
+
+    // Should use max+1, not fill gaps
+    expect($entry->number)->toBe(4);
+});

--- a/tests/Feature/Actions/AddGuestGroupTest.php
+++ b/tests/Feature/Actions/AddGuestGroupTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Actions\AddGuestGroup;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+
+it('creates group with N empty entries', function () {
+    $guestList = GuestList::factory()->create();
+    $action = new AddGuestGroup;
+
+    $group = $action->execute($guestList, 'DJ Soundwave', 3);
+
+    expect($group)->toBeInstanceOf(GuestGroup::class)
+        ->and($group->label)->toBe('DJ Soundwave')
+        ->and($group->guest_count)->toBe(3)
+        ->and($group->entries)->toHaveCount(3);
+
+    $numbers = $group->entries->pluck('number')->sort()->values()->all();
+    expect($numbers)->toBe([1, 2, 3]);
+});
+
+it('creates entries with no name or email by default', function () {
+    $guestList = GuestList::factory()->create();
+    $action = new AddGuestGroup;
+
+    $group = $action->execute($guestList, 'VIP', 2);
+
+    $group->entries->each(function (GuestEntry $entry) {
+        expect($entry->name)->toBeNull()
+            ->and($entry->email)->toBeNull()
+            ->and($entry->qr_token)->toBeNull();
+    });
+});
+
+it('requires guest count of at least 1', function () {
+    $guestList = GuestList::factory()->create();
+    $action = new AddGuestGroup;
+
+    $group = $action->execute($guestList, 'Solo', 1);
+
+    expect($group->entries)->toHaveCount(1)
+        ->and($group->entries->first()->number)->toBe(1);
+});

--- a/tests/Feature/Actions/CheckInGuestTest.php
+++ b/tests/Feature/Actions/CheckInGuestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Actions\CheckInGuest;
+use App\Exceptions\DomainException;
+use App\Models\GuestEntry;
+use App\Models\User;
+
+it('sets checked_in_at and checked_in_by', function () {
+    $user = User::factory()->create();
+    $entry = GuestEntry::factory()->create();
+
+    $action = new CheckInGuest;
+    $result = $action->execute($entry, $user->id);
+
+    expect($result->checked_in_at)->not->toBeNull()
+        ->and($result->checked_in_by)->toBe($user->id);
+});
+
+it('rejects already checked-in guest to prevent duplicate check-ins', function () {
+    $entry = GuestEntry::factory()->checkedIn()->create();
+
+    $action = new CheckInGuest;
+
+    expect(fn () => $action->execute($entry))->toThrow(DomainException::class, 'Guest is already checked in.');
+});
+
+it('accepts null checked_in_by for anonymous check-in', function () {
+    $entry = GuestEntry::factory()->create();
+
+    $action = new CheckInGuest;
+    $result = $action->execute($entry);
+
+    expect($result->checked_in_at)->not->toBeNull()
+        ->and($result->checked_in_by)->toBeNull();
+});

--- a/tests/Feature/Actions/ConfirmGuestListTest.php
+++ b/tests/Feature/Actions/ConfirmGuestListTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Actions\ConfirmGuestList;
+use App\Enums\GuestListStatus;
+use App\Exceptions\DomainException;
+use App\Jobs\ConfirmGuestListJob;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\Queue;
+
+it('sets status to confirmed and confirmed_at', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->create(['status' => GuestListStatus::Draft]);
+
+    $action = new ConfirmGuestList;
+    $result = $action->execute($guestList);
+
+    expect($result->status)->toBe(GuestListStatus::Confirmed)
+        ->and($result->confirmed_at)->not->toBeNull();
+});
+
+it('dispatches ConfirmGuestListJob', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->create();
+
+    $action = new ConfirmGuestList;
+    $action->execute($guestList);
+
+    Queue::assertPushed(ConfirmGuestListJob::class, function ($job) use ($guestList) {
+        return $job->guestList->id === $guestList->id;
+    });
+});
+
+it('rejects already-confirmed list to prevent duplicate invitation emails', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+
+    $action = new ConfirmGuestList;
+
+    expect(fn () => $action->execute($guestList))->toThrow(DomainException::class, 'Guest list is already confirmed.');
+});
+
+it('dispatches exactly one job regardless of entry count', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->create();
+
+    $action = new ConfirmGuestList;
+    $action->execute($guestList);
+
+    Queue::assertPushed(ConfirmGuestListJob::class, 1);
+});

--- a/tests/Feature/Actions/CreateGuestListTest.php
+++ b/tests/Feature/Actions/CreateGuestListTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Actions\CreateGuestList;
+use App\Enums\GuestListStatus;
+use App\Enums\ScannerType;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+
+beforeEach(function () {
+    $this->project = Project::factory()->create();
+    $this->scanner = ProjectScanner::factory()->for($this->project)->create(['type' => ScannerType::EntryStaff]);
+});
+
+it('creates a guest list in draft status', function () {
+    $action = new CreateGuestList;
+
+    $result = $action->execute($this->project, [
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Kuenstler Hauptabend',
+    ]);
+
+    expect($result)->toBeInstanceOf(GuestList::class)
+        ->and($result->exists)->toBeTrue()
+        ->and($result->project_id)->toBe($this->project->id)
+        ->and($result->scanner_id)->toBe($this->scanner->id)
+        ->and($result->name)->toBe('Kuenstler Hauptabend')
+        ->and($result->status)->toBe(GuestListStatus::Draft)
+        ->and($result->confirmed_at)->toBeNull();
+});
+
+it('accepts gear_items array', function () {
+    $gearItem = ProjectGearItem::factory()->for($this->project)->create();
+    $action = new CreateGuestList;
+
+    $result = $action->execute($this->project, [
+        'scanner_id' => $this->scanner->id,
+        'name' => 'With Gear',
+        'gear_items' => [$gearItem->id],
+    ]);
+
+    expect($result->gear_items)->toBe([$gearItem->id]);
+});
+
+it('creates with null gear_items when not provided', function () {
+    $action = new CreateGuestList;
+
+    $result = $action->execute($this->project, [
+        'scanner_id' => $this->scanner->id,
+        'name' => 'No Gear',
+    ]);
+
+    expect($result->gear_items)->toBeNull();
+});

--- a/tests/Feature/Actions/DeleteGuestListTest.php
+++ b/tests/Feature/Actions/DeleteGuestListTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Actions\DeleteGuestList;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+
+it('deletes guest list and cascades to groups and entries', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    GuestEntry::factory()->for($group, 'group')->create();
+
+    $action = new DeleteGuestList;
+    $action->execute($guestList);
+
+    expect(GuestList::count())->toBe(0)
+        ->and(GuestGroup::count())->toBe(0)
+        ->and(GuestEntry::count())->toBe(0);
+});
+
+it('handles empty guest list deletion', function () {
+    $guestList = GuestList::factory()->create();
+
+    $action = new DeleteGuestList;
+    $action->execute($guestList);
+
+    expect(GuestList::count())->toBe(0);
+});

--- a/tests/Feature/Actions/RecordGuestGearPickupTest.php
+++ b/tests/Feature/Actions/RecordGuestGearPickupTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Actions\RecordGuestGearPickup;
+use App\Exceptions\DomainException;
+use App\Models\GuestEntryGear;
+
+it('sets selection and status for Typ-1 gear', function () {
+    $gear = GuestEntryGear::factory()->create([
+        'quantity' => 1,
+        'selection' => null,
+        'status' => null,
+    ]);
+
+    $action = new RecordGuestGearPickup;
+    $result = $action->execute($gear, ['selection' => 'L', 'status' => 'issued']);
+
+    expect($result->selection)->toBe('L')
+        ->and($result->status)->toBe('issued');
+});
+
+it('increments picked_up_count for Typ-2 gear', function () {
+    $gear = GuestEntryGear::factory()->create([
+        'quantity' => 3,
+        'picked_up_count' => 1,
+    ]);
+
+    $action = new RecordGuestGearPickup;
+    $result = $action->execute($gear, ['quantity' => 1]);
+
+    expect($result->picked_up_count)->toBe(2);
+});
+
+it('rejects pickup that would exceed quantity', function () {
+    $gear = GuestEntryGear::factory()->create([
+        'quantity' => 3,
+        'picked_up_count' => 3,
+    ]);
+
+    $action = new RecordGuestGearPickup;
+
+    expect(fn () => $action->execute($gear, ['quantity' => 1]))
+        ->toThrow(DomainException::class, 'Pickup count would exceed available quantity.');
+});
+
+it('allows pickup at exact boundary', function () {
+    $gear = GuestEntryGear::factory()->create([
+        'quantity' => 3,
+        'picked_up_count' => 2,
+    ]);
+
+    $action = new RecordGuestGearPickup;
+    $result = $action->execute($gear, ['quantity' => 1]);
+
+    expect($result->picked_up_count)->toBe(3);
+});
+
+it('handles update with no data gracefully', function () {
+    $gear = GuestEntryGear::factory()->create([
+        'quantity' => 2,
+        'picked_up_count' => 0,
+        'selection' => null,
+        'status' => null,
+    ]);
+
+    $action = new RecordGuestGearPickup;
+    $result = $action->execute($gear, []);
+
+    expect($result->picked_up_count)->toBe(0)
+        ->and($result->selection)->toBeNull()
+        ->and($result->status)->toBeNull();
+});

--- a/tests/Feature/Actions/RemoveGuestEntryTest.php
+++ b/tests/Feature/Actions/RemoveGuestEntryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Actions\RemoveGuestEntry;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+
+it('deletes entry', function () {
+    $entry = GuestEntry::factory()->create();
+
+    $action = new RemoveGuestEntry;
+    $action->execute($entry);
+
+    expect(GuestEntry::count())->toBe(0);
+});
+
+it('does not renumber remaining entries because changing displayed labels would confuse guests who already received QR codes', function () {
+    $group = GuestGroup::factory()->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1]);
+    $entryToRemove = GuestEntry::factory()->for($group, 'group')->create(['number' => 2]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 3]);
+
+    $action = new RemoveGuestEntry;
+    $action->execute($entryToRemove);
+
+    $remaining = GuestEntry::orderBy('number')->pluck('number')->all();
+    expect($remaining)->toBe([1, 3]);
+});

--- a/tests/Feature/Actions/RemoveGuestGroupTest.php
+++ b/tests/Feature/Actions/RemoveGuestGroupTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Actions\RemoveGuestGroup;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+
+it('deletes group and cascades entries', function () {
+    $group = GuestGroup::factory()->create();
+    GuestEntry::factory()->count(3)->for($group, 'group')->create();
+
+    $action = new RemoveGuestGroup;
+    $action->execute($group);
+
+    expect(GuestGroup::count())->toBe(0)
+        ->and(GuestEntry::count())->toBe(0);
+});
+
+it('works on confirmed list groups', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create();
+
+    $action = new RemoveGuestGroup;
+    $action->execute($group);
+
+    expect(GuestGroup::count())->toBe(0);
+});

--- a/tests/Feature/Actions/UpdateGuestEntryTest.php
+++ b/tests/Feature/Actions/UpdateGuestEntryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Actions\UpdateGuestEntry;
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\ProjectGearItem;
+
+it('updates name and email while preserving QR token', function () {
+    $entry = GuestEntry::factory()->withQrToken()->create([
+        'name' => 'Old Name',
+        'email' => 'old@example.com',
+    ]);
+
+    $originalToken = $entry->qr_token;
+    $action = new UpdateGuestEntry;
+
+    $result = $action->execute($entry, [
+        'name' => 'New Name',
+        'email' => 'new@example.com',
+    ]);
+
+    expect($result->name)->toBe('New Name')
+        ->and($result->email)->toBe('new@example.com')
+        ->and($result->qr_token)->toBe($originalToken);
+});
+
+it('updates gear selections via upsert', function () {
+    $entry = GuestEntry::factory()->create();
+    $gearItem = ProjectGearItem::factory()->create();
+
+    GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+        'quantity' => 1,
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $result = $action->execute($entry, [
+        'gear' => [
+            ['project_gear_item_id' => $gearItem->id, 'quantity' => 5],
+        ],
+    ]);
+
+    expect($result->gear)->toHaveCount(1)
+        ->and($result->gear->first()->quantity)->toBe(5);
+});
+
+it('allows setting name to null', function () {
+    $entry = GuestEntry::factory()->create(['name' => 'Some Name']);
+
+    $action = new UpdateGuestEntry;
+    $result = $action->execute($entry, ['name' => null]);
+
+    expect($result->name)->toBeNull();
+});
+
+it('preserves email when only name is updated', function () {
+    $entry = GuestEntry::factory()->create([
+        'name' => 'Old Name',
+        'email' => 'keep@example.com',
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $result = $action->execute($entry, ['name' => 'New Name']);
+
+    expect($result->name)->toBe('New Name')
+        ->and($result->email)->toBe('keep@example.com');
+});
+
+it('adds new gear to entry without removing existing gear', function () {
+    $entry = GuestEntry::factory()->create();
+    $gearItem1 = ProjectGearItem::factory()->create();
+    $gearItem2 = ProjectGearItem::factory()->create();
+
+    GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem1->id,
+        'quantity' => 1,
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $result = $action->execute($entry, [
+        'gear' => [
+            ['project_gear_item_id' => $gearItem2->id, 'quantity' => 2],
+        ],
+    ]);
+
+    // Should now have both gear items
+    expect($result->gear)->toHaveCount(2);
+});

--- a/tests/Feature/Actions/UpdateGuestListTest.php
+++ b/tests/Feature/Actions/UpdateGuestListTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Actions\UpdateGuestList;
+use App\Enums\ScannerType;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+
+beforeEach(function () {
+    $this->project = Project::factory()->create();
+    $this->scanner = ProjectScanner::factory()->for($this->project)->create(['type' => ScannerType::EntryStaff]);
+    $this->guestList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Original Name',
+        'gear_items' => [1, 2],
+    ]);
+});
+
+it('updates name', function () {
+    $action = new UpdateGuestList;
+
+    $result = $action->execute($this->guestList, ['name' => 'Updated Name']);
+
+    expect($result->name)->toBe('Updated Name');
+});
+
+it('updates scanner assignment', function () {
+    $newScanner = ProjectScanner::factory()->for($this->project)->create(['type' => ScannerType::EntryStaff]);
+    $action = new UpdateGuestList;
+
+    $result = $action->execute($this->guestList, ['scanner_id' => $newScanner->id]);
+
+    expect($result->scanner_id)->toBe($newScanner->id);
+});
+
+it('updates gear_items to null', function () {
+    $action = new UpdateGuestList;
+
+    $result = $action->execute($this->guestList, ['gear_items' => null]);
+
+    expect($result->gear_items)->toBeNull();
+});

--- a/tests/Feature/GuestListLifecycleTest.php
+++ b/tests/Feature/GuestListLifecycleTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Actions\AddGuestEntry;
+use App\Actions\AddGuestGroup;
+use App\Actions\CheckInGuest;
+use App\Actions\ConfirmGuestList;
+use App\Actions\CreateGuestList;
+use App\Actions\RecordGuestGearPickup;
+use App\Actions\RemoveGuestEntry;
+use App\Enums\GuestListStatus;
+use App\Enums\ScannerType;
+use App\Jobs\ConfirmGuestListJob;
+use App\Jobs\SendGuestInvitationsJob;
+use App\Mail\GuestInvitationMail;
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+
+it('completes full lifecycle: create list -> add groups -> add entries with gear -> confirm -> QR generated -> emails grouped -> check-in -> gear pickup', function () {
+    // Setup
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create(['type' => ScannerType::EntryStaff]);
+    $gearItem = ProjectGearItem::factory()->for($project)->create();
+
+    // 1. Create guest list
+    $guestList = (new CreateGuestList)->execute($project, [
+        'scanner_id' => $scanner->id,
+        'name' => 'Artist Guest List',
+        'gear_items' => [$gearItem->id],
+    ]);
+
+    expect($guestList->status)->toBe(GuestListStatus::Draft);
+
+    // 2. Add groups
+    $group = (new AddGuestGroup)->execute($guestList, 'DJ Soundwave', 2);
+    expect($group->entries)->toHaveCount(2);
+
+    // 3. Add entry with gear and email
+    $entry = (new AddGuestEntry)->execute($group, 'Manager', 'manager@example.com', [
+        ['project_gear_item_id' => $gearItem->id, 'quantity' => 1],
+    ]);
+    expect($entry->gear)->toHaveCount(1)
+        ->and($entry->qr_token)->toBeNull(); // draft list, no QR yet
+
+    // 4. Confirm guest list
+    Queue::fake();
+    $guestList = (new ConfirmGuestList)->execute($guestList);
+    expect($guestList->status)->toBe(GuestListStatus::Confirmed);
+    Queue::assertPushed(ConfirmGuestListJob::class);
+
+    // 5. Run the confirmation job to generate QR tokens and dispatch email jobs
+    Mail::fake();
+    Queue::fake([SendGuestInvitationsJob::class]);
+    (new ConfirmGuestListJob($guestList->fresh()))->handle();
+
+    // All 3 entries (2 from group + 1 added) should have QR tokens
+    $allEntries = $guestList->entries()->get();
+    expect($allEntries)->toHaveCount(3);
+    $allEntries->each(fn ($e) => expect($e->qr_token)->not->toBeNull());
+
+    // Only 1 unique email, so 1 invitation job
+    Queue::assertPushed(SendGuestInvitationsJob::class, 1);
+
+    // 6. Run the invitation job to send email
+    Queue::fake();
+    (new SendGuestInvitationsJob($guestList, 'manager@example.com'))->handle();
+    Mail::assertSent(GuestInvitationMail::class, function (GuestInvitationMail $mail) {
+        return $mail->hasTo('manager@example.com')
+            && $mail->entries->count() === 1;
+    });
+
+    // 7. Check in a guest
+    $entryToCheckIn = $allEntries->first();
+    $staff = User::factory()->create();
+    $result = (new CheckInGuest)->execute($entryToCheckIn, $staff->id);
+    expect($result->checked_in_at)->not->toBeNull()
+        ->and($result->checked_in_by)->toBe($staff->id);
+
+    // 8. Record gear pickup
+    $gearRecord = GuestEntryGear::where('guest_entry_id', $entry->id)->first();
+    $pickupResult = (new RecordGuestGearPickup)->execute($gearRecord, ['selection' => 'M', 'status' => 'issued']);
+    expect($pickupResult->selection)->toBe('M')
+        ->and($pickupResult->status)->toBe('issued');
+});
+
+it('post-confirm: adding entry generates QR immediately and dispatches email', function () {
+    Queue::fake();
+
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create(['type' => ScannerType::EntryStaff]);
+
+    $guestList = (new CreateGuestList)->execute($project, [
+        'scanner_id' => $scanner->id,
+        'name' => 'VIP List',
+    ]);
+
+    $group = (new AddGuestGroup)->execute($guestList, 'VIP', 1);
+    (new ConfirmGuestList)->execute($guestList);
+
+    // Run confirmation job
+    (new ConfirmGuestListJob($guestList->fresh()))->handle();
+
+    // Now add a new entry to the confirmed list
+    Queue::fake();
+    $newEntry = (new AddGuestEntry)->execute($group, 'Late Addition', 'late@example.com');
+
+    expect($newEntry->qr_token)->not->toBeNull()
+        ->and(strlen($newEntry->qr_token))->toBe(64);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'late@example.com';
+    });
+});
+
+it('post-confirm removal: removed entry QR becomes invalid for check-in via API', function () {
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $guestList = (new CreateGuestList)->execute($project, [
+        'scanner_id' => $scanner->id,
+        'name' => 'Removal Test',
+    ]);
+    $group = (new AddGuestGroup)->execute($guestList, 'Test Group', 2);
+
+    Queue::fake();
+    (new ConfirmGuestList)->execute($guestList);
+    (new ConfirmGuestListJob($guestList->fresh()))->handle();
+
+    $entries = $guestList->entries()->get();
+    $entryToRemove = $entries->first();
+    $entryId = $entryToRemove->id;
+
+    // Remove the entry
+    (new RemoveGuestEntry)->execute($entryToRemove);
+
+    // Entry no longer exists
+    expect(GuestEntry::find($entryId))->toBeNull();
+
+    // Remaining entry still works
+    $remainingEntry = $entries->last()->fresh();
+    expect($remainingEntry->qr_token)->not->toBeNull();
+});
+
+it('email grouping: two entries with same email in one list produce one invitation job', function () {
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create(['type' => ScannerType::EntryStaff]);
+
+    $guestList = (new CreateGuestList)->execute($project, [
+        'scanner_id' => $scanner->id,
+        'name' => 'Grouping Test',
+    ]);
+    $group = (new AddGuestGroup)->execute($guestList, 'Band', 1);
+
+    // Add two more entries with same email
+    (new AddGuestEntry)->execute($group, 'Member 1', 'band@example.com');
+    (new AddGuestEntry)->execute($group, 'Member 2', 'band@example.com');
+
+    // Confirm (fake only the job it dispatches)
+    Queue::fake([ConfirmGuestListJob::class]);
+    (new ConfirmGuestList)->execute($guestList);
+    Queue::assertPushed(ConfirmGuestListJob::class);
+
+    // Now manually run the confirm job with SendGuestInvitationsJob faked
+    Queue::fake([SendGuestInvitationsJob::class]);
+    (new ConfirmGuestListJob($guestList->fresh()))->handle();
+
+    // Only one invitation job for the shared email
+    Queue::assertPushed(SendGuestInvitationsJob::class, 1);
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'band@example.com';
+    });
+});
+
+it('GuestEntry qr_token is hidden from serialization', function () {
+    $entry = GuestEntry::factory()->withQrToken()->create();
+
+    $array = $entry->toArray();
+
+    expect($array)->not->toHaveKey('qr_token')
+        ->and($entry->qr_token)->not->toBeNull();
+});

--- a/tests/Feature/Http/GuestCheckinApiTest.php
+++ b/tests/Feature/Http/GuestCheckinApiTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use App\Enums\ScannerType;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-01 12:00:00');
+    $this->project = Project::factory()->create();
+    $this->scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $this->guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $this->group = GuestGroup::factory()->for($this->guestList)->create();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('checks in a guest entry', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+
+    $response = $this->postJson(route('scanner-api.guest-checkin', $this->scanner->id), [
+        'guest_entry_id' => $entry->id,
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('already_checked_in', false);
+
+    expect($entry->fresh()->checked_in_at)->not->toBeNull();
+});
+
+it('returns already_checked_in for duplicate check-in', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->checkedIn()->create();
+
+    $response = $this->postJson(route('scanner-api.guest-checkin', $this->scanner->id), [
+        'guest_entry_id' => $entry->id,
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('already_checked_in', true);
+});
+
+it('rejects check-in from wrong scanner', function () {
+    $otherScanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $otherList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $otherScanner->id,
+    ]);
+    $otherGroup = GuestGroup::factory()->for($otherList)->create();
+    $entry = GuestEntry::factory()->for($otherGroup, 'group')->withQrToken()->create();
+
+    $response = $this->postJson(route('scanner-api.guest-checkin', $this->scanner->id), [
+        'guest_entry_id' => $entry->id,
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertNotFound();
+});
+
+it('rejects check-in from volunteer admin scanner type', function () {
+    $vaScanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+
+    $response = $this->postJson(route('scanner-api.guest-checkin', $vaScanner->id), [
+        'guest_entry_id' => $entry->id,
+    ], [
+        'X-Scanner-Token' => $vaScanner->scanner_token,
+    ]);
+
+    $response->assertForbidden()
+        ->assertJsonPath('error', 'Only entry staff scanners can check in guests.');
+});
+
+it('rejects check-in for entry from draft list', function () {
+    $draftList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $draftGroup = GuestGroup::factory()->for($draftList)->create();
+    $entry = GuestEntry::factory()->for($draftGroup, 'group')->create();
+
+    $response = $this->postJson(route('scanner-api.guest-checkin', $this->scanner->id), [
+        'guest_entry_id' => $entry->id,
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertNotFound();
+});

--- a/tests/Feature/Http/GuestGearPickupApiTest.php
+++ b/tests/Feature/Http/GuestGearPickupApiTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Enums\ScannerType;
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-01 12:00:00');
+    $this->project = Project::factory()->create();
+    $this->entryStaffScanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $this->vaScanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $this->guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->entryStaffScanner->id,
+    ]);
+    $this->group = GuestGroup::factory()->for($this->guestList)->create();
+    $this->gearItem = ProjectGearItem::factory()->for($this->project)->create();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('records Typ-1 selection and status', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $this->vaScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'selection' => 'L',
+        'status' => 'issued',
+    ], [
+        'X-Scanner-Token' => $this->vaScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('guest_entry_gear.selection', 'L')
+        ->assertJsonPath('guest_entry_gear.status', 'issued');
+});
+
+it('increments Typ-2 picked_up_count', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+        'quantity' => 3,
+        'picked_up_count' => 1,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $this->vaScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'quantity' => 1,
+    ], [
+        'X-Scanner-Token' => $this->vaScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('guest_entry_gear.picked_up_count', 2);
+});
+
+it('rejects pickup exceeding quantity', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+        'quantity' => 3,
+        'picked_up_count' => 3,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $this->vaScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'quantity' => 1,
+    ], [
+        'X-Scanner-Token' => $this->vaScanner->scanner_token,
+    ]);
+
+    $response->assertStatus(500);
+});
+
+it('rejects gear pickup from entry staff scanner type', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $this->entryStaffScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'selection' => 'M',
+    ], [
+        'X-Scanner-Token' => $this->entryStaffScanner->scanner_token,
+    ]);
+
+    $response->assertForbidden()
+        ->assertJsonPath('error', 'Only volunteer admin scanners can record guest gear pickups.');
+});
+
+it('rejects gear pickup for entry from draft list', function () {
+    $draftList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->entryStaffScanner->id,
+    ]);
+    $draftGroup = GuestGroup::factory()->for($draftList)->create();
+    $entry = GuestEntry::factory()->for($draftGroup, 'group')->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $this->vaScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'selection' => 'L',
+    ], [
+        'X-Scanner-Token' => $this->vaScanner->scanner_token,
+    ]);
+
+    $response->assertNotFound();
+});

--- a/tests/Feature/Http/GuestSyncApiTest.php
+++ b/tests/Feature/Http/GuestSyncApiTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\ScannerType;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-01 12:00:00');
+    $this->project = Project::factory()->create();
+    $this->scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $this->guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $this->group = GuestGroup::factory()->for($this->guestList)->create();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('batch syncs guest check-ins', function () {
+    $entry1 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create(['number' => 1]);
+    $entry2 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create(['number' => 2]);
+
+    $response = $this->postJson(route('scanner-api.guest-sync', $this->scanner->id), [
+        'guest_checkins' => [
+            ['guest_entry_id' => $entry1->id, 'checked_in_at' => '2026-07-01 19:30:00'],
+            ['guest_entry_id' => $entry2->id, 'checked_in_at' => '2026-07-01 19:31:00'],
+        ],
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['guest_entries']);
+
+    expect($entry1->fresh()->checked_in_at)->not->toBeNull()
+        ->and($entry2->fresh()->checked_in_at)->not->toBeNull();
+});
+
+it('handles empty guest_checkins array', function () {
+    $response = $this->postJson(route('scanner-api.guest-sync', $this->scanner->id), [
+        'guest_checkins' => [],
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['guest_entries']);
+});
+
+it('skips already checked-in entries during sync', function () {
+    $originalTime = Carbon::parse('2026-07-01 18:00:00');
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'checked_in_at' => $originalTime,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-sync', $this->scanner->id), [
+        'guest_checkins' => [
+            ['guest_entry_id' => $entry->id, 'checked_in_at' => '2026-07-01 19:30:00'],
+        ],
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk();
+
+    // Original check-in time should be preserved
+    expect($entry->fresh()->checked_in_at->toDateTimeString())->toBe('2026-07-01 18:00:00');
+});
+
+it('rejects sync from volunteer admin scanner type', function () {
+    $vaScanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-sync', $vaScanner->id), [
+        'guest_checkins' => [],
+    ], [
+        'X-Scanner-Token' => $vaScanner->scanner_token,
+    ]);
+
+    $response->assertForbidden()
+        ->assertJsonPath('error', 'Only entry staff scanners can sync guest check-ins.');
+});
+
+it('silently skips entries belonging to another scanner during sync', function () {
+    $otherScanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+    $otherList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $otherScanner->id,
+    ]);
+    $otherGroup = GuestGroup::factory()->for($otherList)->create();
+    $otherEntry = GuestEntry::factory()->for($otherGroup, 'group')->withQrToken()->create(['number' => 1]);
+
+    $response = $this->postJson(route('scanner-api.guest-sync', $this->scanner->id), [
+        'guest_checkins' => [
+            ['guest_entry_id' => $otherEntry->id, 'checked_in_at' => '2026-07-01 19:30:00'],
+        ],
+    ], [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk();
+
+    // Entry should NOT be checked in because it belongs to another scanner
+    expect($otherEntry->fresh()->checked_in_at)->toBeNull();
+});

--- a/tests/Feature/Http/ScannerDataControllerGuestTest.php
+++ b/tests/Feature/Http/ScannerDataControllerGuestTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Enums\GuestListStatus;
+use App\Enums\ScannerType;
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\ProjectScanner;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-01 12:00:00');
+    $this->project = Project::factory()->create();
+    $this->scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('includes guest entries in data response for entry staff scanner', function () {
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create(['label' => 'DJ Soundwave', 'guest_count' => 2]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1, 'name' => 'DJ']);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 2]);
+
+    $response = $this->getJson(route('scanner-api.data', $this->scanner->id), [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'guest_entries')
+        ->assertJsonPath('guest_entries.0.group_label', 'DJ Soundwave')
+        ->assertJsonPath('guest_entries.0.name', 'DJ');
+
+    expect($response->json('guest_entries.0.qr_token'))->not->toBeNull();
+});
+
+it('excludes draft guest lists from data response', function () {
+    $guestList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'status' => GuestListStatus::Draft,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    GuestEntry::factory()->for($group, 'group')->create();
+
+    $response = $this->getJson(route('scanner-api.data', $this->scanner->id), [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(0, 'guest_entries');
+});
+
+it('only includes guest entries from this scanner for entry staff', function () {
+    $otherScanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $myList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $myGroup = GuestGroup::factory()->for($myList)->create();
+    GuestEntry::factory()->for($myGroup, 'group')->withQrToken()->create();
+
+    $otherList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $otherScanner->id,
+    ]);
+    $otherGroup = GuestGroup::factory()->for($otherList)->create();
+    GuestEntry::factory()->for($otherGroup, 'group')->withQrToken()->create();
+
+    $response = $this->getJson(route('scanner-api.data', $this->scanner->id), [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'guest_entries');
+});
+
+it('includes guest entries with gear for volunteer admin scanner', function () {
+    $vaScanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id, // linked to entry staff scanner
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entryWithGear = GuestEntry::factory()->for($group, 'group')->withQrToken()->create();
+    $gearItem = ProjectGearItem::factory()->for($this->project)->create();
+    GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entryWithGear->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(); // no gear
+
+    $response = $this->getJson(route('scanner-api.data', $vaScanner->id), [
+        'X-Scanner-Token' => $vaScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'guest_entries');
+
+    // Volunteer Admin should NOT have qr_token in response
+    expect($response->json('guest_entries.0'))->not->toHaveKey('qr_token');
+});
+
+it('returns empty guest entries when no guest lists exist', function () {
+    $response = $this->getJson(route('scanner-api.data', $this->scanner->id), [
+        'X-Scanner-Token' => $this->scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(0, 'guest_entries');
+});
+
+it('includes available_sizes and available_states in VA scanner gear data', function () {
+    $vaScanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create();
+    $gearItem = ProjectGearItem::factory()->for($this->project)->create([
+        'available_sizes' => ['S', 'M', 'L', 'XL'],
+        'available_states' => ['issued', 'returned'],
+    ]);
+    GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $vaScanner->id), [
+        'X-Scanner-Token' => $vaScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'guest_entries');
+
+    $gearData = $response->json('guest_entries.0.gear.0');
+    expect($gearData['available_sizes'])->toBe(['S', 'M', 'L', 'XL'])
+        ->and($gearData['available_states'])->toBe(['issued', 'returned']);
+});

--- a/tests/Feature/Jobs/ConfirmGuestListJobTest.php
+++ b/tests/Feature/Jobs/ConfirmGuestListJobTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Jobs\ConfirmGuestListJob;
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\Queue;
+
+it('generates qr_token for all entries without tokens', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1, 'qr_token' => null]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 2, 'qr_token' => null]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 3, 'qr_token' => null]);
+
+    Queue::fake([SendGuestInvitationsJob::class]);
+
+    $job = new ConfirmGuestListJob($guestList);
+    $job->handle();
+
+    $entries = GuestEntry::whereNotNull('qr_token')->get();
+    expect($entries)->toHaveCount(3);
+
+    $tokens = $entries->pluck('qr_token')->unique();
+    expect($tokens)->toHaveCount(3);
+    $tokens->each(fn ($token) => expect(strlen($token))->toBe(64));
+});
+
+it('dispatches one SendGuestInvitationsJob per unique email', function () {
+    Queue::fake([SendGuestInvitationsJob::class]);
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1, 'email' => 'dj@example.com']);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 2, 'email' => 'dj@example.com']);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 3, 'email' => null]);
+
+    $job = new ConfirmGuestListJob($guestList);
+    $job->handle();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, 1);
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'dj@example.com';
+    });
+});
+
+it('is idempotent and skips entries that already have tokens', function () {
+    Queue::fake([SendGuestInvitationsJob::class]);
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+    $existing = GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1, 'email' => 'a@example.com']);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 2, 'email' => 'b@example.com']);
+
+    $originalToken = $existing->qr_token;
+
+    $job = new ConfirmGuestListJob($guestList);
+    $job->handle();
+
+    expect($existing->fresh()->qr_token)->toBe($originalToken);
+    expect(GuestEntry::whereNotNull('qr_token')->count())->toBe(2);
+});
+
+it('skips if guest list is not confirmed', function () {
+    Queue::fake([SendGuestInvitationsJob::class]);
+
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1]);
+
+    $job = new ConfirmGuestListJob($guestList);
+    $job->handle();
+
+    expect(GuestEntry::whereNotNull('qr_token')->count())->toBe(0);
+    Queue::assertNothingPushed();
+});

--- a/tests/Feature/Jobs/SendGuestInvitationsJobTest.php
+++ b/tests/Feature/Jobs/SendGuestInvitationsJobTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Jobs\SendGuestInvitationsJob;
+use App\Mail\GuestInvitationMail;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\Mail;
+
+it('sends grouped email with all QR codes for matching entries', function () {
+    Mail::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1, 'email' => 'dj@example.com']);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 2, 'email' => 'dj@example.com']);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 3, 'email' => null]);
+
+    $job = new SendGuestInvitationsJob($guestList, 'dj@example.com');
+    $job->handle();
+
+    Mail::assertSent(GuestInvitationMail::class, function (GuestInvitationMail $mail) {
+        return $mail->hasTo('dj@example.com')
+            && $mail->entries->count() === 2;
+    });
+});
+
+it('skips when no entries match the email', function () {
+    Mail::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+
+    $job = new SendGuestInvitationsJob($guestList, 'nobody@example.com');
+    $job->handle();
+
+    Mail::assertNothingSent();
+});
+
+it('skips entries without qr_token', function () {
+    Mail::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1, 'email' => 'test@example.com', 'qr_token' => null]);
+
+    $job = new SendGuestInvitationsJob($guestList, 'test@example.com');
+    $job->handle();
+
+    Mail::assertNothingSent();
+});

--- a/tests/Feature/Livewire/GuestListIndexTest.php
+++ b/tests/Feature/Livewire/GuestListIndexTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Enums\StaffRole;
+use App\Livewire\Projects\GuestListIndex;
+use App\Models\GuestList;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    ['user' => $this->organizer, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->scanner = ProjectScanner::factory()->create(['project_id' => $this->project->id]);
+    app()->instance(Organization::class, $this->org);
+});
+
+it('renders for org organizer', function () {
+    $this->actingAs($this->organizer)
+        ->get(route('guest-lists.index', $this->project))
+        ->assertOk()
+        ->assertSeeLivewire(GuestListIndex::class);
+});
+
+it('denies access to non-member', function () {
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->get(route('guest-lists.index', $this->project))
+        ->assertForbidden();
+});
+
+it('creates guest list and redirects to show page', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->set('name', 'VIP Guest List')
+        ->set('scannerId', $this->scanner->id)
+        ->call('createGuestList')
+        ->assertHasNoErrors()
+        ->assertRedirect();
+
+    expect(GuestList::where('project_id', $this->project->id)->count())->toBe(1);
+
+    $guestList = GuestList::where('project_id', $this->project->id)->first();
+    expect($guestList->name)->toBe('VIP Guest List')
+        ->and($guestList->scanner_id)->toBe($this->scanner->id);
+});
+
+it('displays guest lists', function () {
+    $listA = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Alpha List',
+    ]);
+    $listB = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Beta List',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->assertSee('Alpha List')
+        ->assertSee('Beta List');
+});
+
+it('shows empty state when no guest lists', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->assertSee('No guest lists');
+});
+
+it('validates required name when creating guest list', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->set('name', '')
+        ->set('scannerId', $this->scanner->id)
+        ->call('createGuestList')
+        ->assertHasErrors(['name' => 'required']);
+});
+
+it('validates required scanner when creating guest list', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->set('name', 'Test List')
+        ->set('scannerId', null)
+        ->call('createGuestList')
+        ->assertHasErrors(['scannerId' => 'required']);
+});
+
+it('validates scanner belongs to project', function () {
+    $otherProject = Project::factory()->for($this->org)->create();
+    $otherScanner = ProjectScanner::factory()->create(['project_id' => $otherProject->id]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->set('name', 'Test List')
+        ->set('scannerId', $otherScanner->id)
+        ->call('createGuestList')
+        ->assertHasErrors(['scannerId']);
+});
+
+it('deletes a guest list', function () {
+    $guestList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'To Delete',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->call('deleteGuestList', $guestList->id)
+        ->assertHasNoErrors();
+
+    expect(GuestList::find($guestList->id))->toBeNull();
+});
+
+it('denies access to volunteer admin role', function () {
+    ['user' => $va, 'organization' => $org] = createUserWithOrganization(StaffRole::VolunteerAdmin);
+    $project = Project::factory()->for($org)->create();
+    app()->instance(Organization::class, $org);
+
+    $this->actingAs($va)
+        ->get(route('guest-lists.index', $project))
+        ->assertForbidden();
+});

--- a/tests/Feature/Livewire/GuestListShowTest.php
+++ b/tests/Feature/Livewire/GuestListShowTest.php
@@ -1,0 +1,306 @@
+<?php
+
+use App\Enums\GuestListStatus;
+use App\Enums\StaffRole;
+use App\Jobs\ConfirmGuestListJob;
+use App\Livewire\Projects\GuestListShow;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    ['user' => $this->organizer, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->scanner = ProjectScanner::factory()->create(['project_id' => $this->project->id]);
+    $this->guestList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    app()->instance(Organization::class, $this->org);
+});
+
+it('renders guest list with groups and entries', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+        'label' => 'DJ Soundwave',
+        'guest_count' => 2,
+    ]);
+    GuestEntry::factory()->create(['guest_group_id' => $group->id, 'number' => 1]);
+    GuestEntry::factory()->create(['guest_group_id' => $group->id, 'number' => 2]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertSee($this->guestList->name)
+        ->assertSee('DJ Soundwave');
+});
+
+it('adds a group', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->set('newGroupLabel', 'Band Members')
+        ->set('newGroupCount', 3)
+        ->call('addGroup')
+        ->assertHasNoErrors();
+
+    $group = GuestGroup::where('guest_list_id', $this->guestList->id)->first();
+    expect($group)->not->toBeNull()
+        ->and($group->label)->toBe('Band Members')
+        ->and($group->guest_count)->toBe(3)
+        ->and($group->entries()->count())->toBe(3);
+});
+
+it('removes a group', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+        'label' => 'To Remove',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('removeGroup', $group->id)
+        ->assertHasNoErrors();
+
+    expect(GuestGroup::find($group->id))->toBeNull();
+});
+
+it('adds entry to group', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+        'guest_count' => 1,
+    ]);
+    GuestEntry::factory()->create(['guest_group_id' => $group->id, 'number' => 1]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('addEntry', $group->id)
+        ->assertHasNoErrors();
+
+    expect($group->entries()->count())->toBe(2)
+        ->and($group->entries()->orderByDesc('number')->first()->number)->toBe(2);
+});
+
+it('removes an entry', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+    ]);
+    $entry = GuestEntry::factory()->create(['guest_group_id' => $group->id, 'number' => 1]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('removeEntry', $entry->id)
+        ->assertHasNoErrors();
+
+    expect(GuestEntry::find($entry->id))->toBeNull();
+});
+
+it('updates entry name and email', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+    ]);
+    $entry = GuestEntry::factory()->create([
+        'guest_group_id' => $group->id,
+        'number' => 1,
+        'name' => 'Old Name',
+        'email' => 'old@example.com',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('startEditEntry', $entry->id)
+        ->set('entryName', 'New Name')
+        ->set('entryEmail', 'new@example.com')
+        ->call('saveEntry')
+        ->assertHasNoErrors();
+
+    $entry->refresh();
+    expect($entry->name)->toBe('New Name')
+        ->and($entry->email)->toBe('new@example.com');
+});
+
+it('confirms guest list and dispatches job', function () {
+    Queue::fake();
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('confirmGuestList')
+        ->assertHasNoErrors();
+
+    $this->guestList->refresh();
+    expect($this->guestList->status)->toBe(GuestListStatus::Confirmed)
+        ->and($this->guestList->confirmed_at)->not->toBeNull();
+
+    Queue::assertPushed(ConfirmGuestListJob::class);
+});
+
+it('rejects confirming already-confirmed list', function () {
+    Queue::fake();
+
+    $confirmedAt = now()->subHour();
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => $confirmedAt,
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('confirmGuestList')
+        ->assertSee('Guest list is already confirmed.');
+
+    // Confirm no additional job was dispatched
+    Queue::assertNotPushed(ConfirmGuestListJob::class);
+});
+
+it('updates guest list name and scanner', function () {
+    $newScanner = ProjectScanner::factory()->create(['project_id' => $this->project->id]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('openEditModal')
+        ->set('editName', 'Updated Name')
+        ->set('editScannerId', $newScanner->id)
+        ->call('updateGuestList')
+        ->assertHasNoErrors();
+
+    $this->guestList->refresh();
+    expect($this->guestList->name)->toBe('Updated Name')
+        ->and($this->guestList->scanner_id)->toBe($newScanner->id);
+});
+
+it('validates required fields when updating guest list', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('openEditModal')
+        ->set('editName', '')
+        ->call('updateGuestList')
+        ->assertHasErrors(['editName' => 'required']);
+});
+
+it('validates group label is required', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->set('newGroupLabel', '')
+        ->set('newGroupCount', 2)
+        ->call('addGroup')
+        ->assertHasErrors(['newGroupLabel' => 'required']);
+});
+
+it('validates group count minimum', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->set('newGroupLabel', 'Test Group')
+        ->set('newGroupCount', 0)
+        ->call('addGroup')
+        ->assertHasErrors(['newGroupCount' => 'min']);
+});
+
+it('cancels entry editing', function () {
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+    ]);
+    $entry = GuestEntry::factory()->create([
+        'guest_group_id' => $group->id,
+        'number' => 1,
+        'name' => 'Test Name',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('startEditEntry', $entry->id)
+        ->assertSet('editingEntryId', $entry->id)
+        ->call('cancelEditEntry')
+        ->assertSet('editingEntryId', null)
+        ->assertSet('entryName', '')
+        ->assertSet('entryEmail', '');
+});
+
+it('denies access to non-member', function () {
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->get(route('guest-lists.show', [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ]))
+        ->assertForbidden();
+});
+
+it('prevents removing group from another guest list', function () {
+    $otherList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $otherGroup = GuestGroup::factory()->for($otherList)->create();
+
+    $this->expectException(ModelNotFoundException::class);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('removeGroup', $otherGroup->id);
+});
+
+it('prevents removing entry from another guest list', function () {
+    $otherList = GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $otherGroup = GuestGroup::factory()->for($otherList)->create();
+    $otherEntry = GuestEntry::factory()->create(['guest_group_id' => $otherGroup->id]);
+
+    $this->expectException(ModelNotFoundException::class);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('removeEntry', $otherEntry->id);
+});

--- a/tests/Feature/Mail/GuestInvitationMailTest.php
+++ b/tests/Feature/Mail/GuestInvitationMailTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Mail\GuestInvitationMail;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Collection;
+
+beforeEach(function () {
+    $this->project = Project::factory()->create(['name' => 'Summer Festival']);
+    $this->guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'name' => 'Artist Guest List',
+    ]);
+    $this->group = GuestGroup::factory()->for($this->guestList)->create([
+        'label' => 'DJ Soundwave',
+        'guest_count' => 2,
+    ]);
+});
+
+it('has correct subject line', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'name' => 'DJ Soundwave',
+        'email' => 'dj@example.com',
+    ]);
+
+    $mail = new GuestInvitationMail($this->guestList, new Collection([$entry]));
+
+    expect($mail->envelope()->subject)->toBe('Your Guest Pass — Artist Guest List');
+});
+
+it('renders markdown with project name and entry labels', function () {
+    $entry1 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'name' => 'DJ Soundwave',
+        'email' => 'dj@example.com',
+    ]);
+    $entry2 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 2,
+        'email' => 'dj@example.com',
+    ]);
+
+    $entries = new Collection([$entry1, $entry2]);
+    $mail = new GuestInvitationMail($this->guestList, $entries);
+
+    $mail->assertSeeInHtml('Summer Festival')
+        ->assertSeeInHtml('DJ Soundwave 1/2')
+        ->assertSeeInHtml('DJ Soundwave 2/2')
+        ->assertSeeInHtml('present your QR code');
+});
+
+it('renders entry name when present', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+    ]);
+
+    $mail = new GuestInvitationMail($this->guestList, new Collection([$entry]));
+
+    $mail->assertSeeInHtml('John Doe');
+});
+
+it('is sendable with valid data', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'test@example.com',
+    ]);
+
+    $mail = new GuestInvitationMail($this->guestList, new Collection([$entry]));
+
+    expect($mail)->not->toBeNull();
+    $mail->assertHasSubject('Your Guest Pass — Artist Guest List');
+});

--- a/tests/Feature/Models/GuestEntryGearTest.php
+++ b/tests/Feature/Models/GuestEntryGearTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\ProjectGearItem;
+use Illuminate\Database\UniqueConstraintViolationException;
+
+it('creates guest entry gear with correct attributes', function () {
+    $entry = GuestEntry::factory()->create();
+    $gearItem = ProjectGearItem::factory()->create();
+
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+        'quantity' => 3,
+        'picked_up_count' => 1,
+        'selection' => 'L',
+        'status' => 'issued',
+    ]);
+
+    expect($gear->exists)->toBeTrue()
+        ->and($gear->quantity)->toBe(3)
+        ->and($gear->picked_up_count)->toBe(1)
+        ->and($gear->selection)->toBe('L')
+        ->and($gear->status)->toBe('issued');
+});
+
+it('belongs to a guest entry', function () {
+    $entry = GuestEntry::factory()->create();
+    $gear = GuestEntryGear::factory()->create(['guest_entry_id' => $entry->id]);
+
+    expect($gear->entry->id)->toBe($entry->id);
+});
+
+it('belongs to a project gear item', function () {
+    $gearItem = ProjectGearItem::factory()->create();
+    $gear = GuestEntryGear::factory()->create(['project_gear_item_id' => $gearItem->id]);
+
+    expect($gear->gearItem->id)->toBe($gearItem->id);
+});
+
+it('enforces unique constraint on entry and gear item', function () {
+    $entry = GuestEntry::factory()->create();
+    $gearItem = ProjectGearItem::factory()->create();
+
+    GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]);
+
+    expect(fn () => GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]))->toThrow(UniqueConstraintViolationException::class);
+});
+
+it('cascades delete from guest entry', function () {
+    $entry = GuestEntry::factory()->create();
+    GuestEntryGear::factory()->create(['guest_entry_id' => $entry->id]);
+
+    expect(GuestEntryGear::count())->toBe(1);
+
+    $entry->delete();
+
+    expect(GuestEntryGear::count())->toBe(0);
+});

--- a/tests/Feature/Models/GuestEntryTest.php
+++ b/tests/Feature/Models/GuestEntryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Models\GuestEntry;
+use App\Models\GuestEntryGear;
+use App\Models\GuestGroup;
+use App\Models\User;
+
+it('creates a guest entry with correct attributes', function () {
+    $group = GuestGroup::factory()->create(['label' => 'DJ Soundwave', 'guest_count' => 3]);
+    $entry = GuestEntry::factory()->create([
+        'guest_group_id' => $group->id,
+        'number' => 1,
+        'name' => 'DJ Soundwave',
+        'email' => 'dj@example.com',
+    ]);
+
+    expect($entry->exists)->toBeTrue()
+        ->and($entry->number)->toBe(1)
+        ->and($entry->name)->toBe('DJ Soundwave')
+        ->and($entry->email)->toBe('dj@example.com');
+});
+
+it('belongs to a group', function () {
+    $group = GuestGroup::factory()->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->create();
+
+    expect($entry->group->id)->toBe($group->id);
+});
+
+it('has many gear items', function () {
+    $entry = GuestEntry::factory()->create();
+    GuestEntryGear::factory()->count(2)->create(['guest_entry_id' => $entry->id]);
+
+    expect($entry->gear)->toHaveCount(2);
+});
+
+it('tracks checked-in-by user', function () {
+    $user = User::factory()->create();
+    $entry = GuestEntry::factory()->checkedIn()->create(['checked_in_by' => $user->id]);
+
+    expect($entry->checkedInByUser->id)->toBe($user->id);
+});
+
+it('reports check-in status', function () {
+    $notCheckedIn = GuestEntry::factory()->create();
+    $checkedIn = GuestEntry::factory()->checkedIn()->create();
+
+    expect($notCheckedIn->isCheckedIn())->toBeFalse()
+        ->and($checkedIn->isCheckedIn())->toBeTrue();
+});
+
+it('generates display label in GroupLabel N/Total format', function () {
+    $group = GuestGroup::factory()->create(['label' => 'DJ Soundwave', 'guest_count' => 3]);
+    $entry = GuestEntry::factory()->for($group, 'group')->create(['number' => 2]);
+
+    expect($entry->displayLabel())->toBe('DJ Soundwave 2/3');
+});
+
+it('cascades delete from group', function () {
+    $group = GuestGroup::factory()->create();
+    GuestEntry::factory()->for($group, 'group')->create();
+
+    expect(GuestEntry::count())->toBe(1);
+
+    $group->delete();
+
+    expect(GuestEntry::count())->toBe(0);
+});
+
+it('nullifies checked_in_by when user is deleted', function () {
+    $user = User::factory()->create();
+    $entry = GuestEntry::factory()->checkedIn()->create(['checked_in_by' => $user->id]);
+
+    $user->delete();
+
+    expect($entry->fresh()->checked_in_by)->toBeNull();
+});

--- a/tests/Feature/Models/GuestGroupTest.php
+++ b/tests/Feature/Models/GuestGroupTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+
+it('creates a guest group with correct attributes', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $guestList->id,
+        'label' => 'DJ Soundwave',
+        'guest_count' => 3,
+    ]);
+
+    expect($group->exists)->toBeTrue()
+        ->and($group->label)->toBe('DJ Soundwave')
+        ->and($group->guest_count)->toBe(3);
+});
+
+it('belongs to a guest list', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+
+    expect($group->guestList->id)->toBe($guestList->id);
+});
+
+it('has many entries', function () {
+    $group = GuestGroup::factory()->create();
+    GuestEntry::factory()->count(3)->for($group, 'group')->create();
+
+    expect($group->entries)->toHaveCount(3);
+});
+
+it('counts checked-in entries', function () {
+    $group = GuestGroup::factory()->create(['guest_count' => 3]);
+    GuestEntry::factory()->for($group, 'group')->checkedIn()->create(['number' => 1]);
+    GuestEntry::factory()->for($group, 'group')->checkedIn()->create(['number' => 2]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 3]);
+
+    expect($group->checkedInCount())->toBe(2);
+});
+
+it('cascades delete from guest list', function () {
+    $guestList = GuestList::factory()->create();
+    GuestGroup::factory()->for($guestList)->create();
+
+    expect(GuestGroup::count())->toBe(1);
+
+    $guestList->delete();
+
+    expect(GuestGroup::count())->toBe(0);
+});

--- a/tests/Feature/Models/GuestListRelationshipsTest.php
+++ b/tests/Feature/Models/GuestListRelationshipsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Enums\ScannerType;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use Illuminate\Database\QueryException;
+
+it('project has many guest lists', function () {
+    $project = Project::factory()->create();
+    GuestList::factory()->count(2)->create(['project_id' => $project->id]);
+
+    expect($project->guestLists)->toHaveCount(2);
+});
+
+it('scanner has many guest lists', function () {
+    $scanner = ProjectScanner::factory()->create(['type' => ScannerType::EntryStaff]);
+    GuestList::factory()->count(2)->create(['scanner_id' => $scanner->id]);
+
+    expect($scanner->guestLists)->toHaveCount(2);
+});
+
+it('prevents deleting a scanner that has guest lists', function () {
+    $scanner = ProjectScanner::factory()->create(['type' => ScannerType::EntryStaff]);
+    GuestList::factory()->create(['scanner_id' => $scanner->id]);
+
+    expect(fn () => $scanner->delete())->toThrow(QueryException::class);
+});
+
+it('cascades delete when project is deleted', function () {
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create();
+    GuestList::factory()->create([
+        'project_id' => $project->id,
+        'scanner_id' => $scanner->id,
+    ]);
+
+    expect(GuestList::count())->toBe(1);
+
+    $project->delete();
+
+    expect(GuestList::count())->toBe(0);
+});

--- a/tests/Feature/Models/GuestListTest.php
+++ b/tests/Feature/Models/GuestListTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Enums\GuestListStatus;
+use App\Enums\ScannerType;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+
+it('creates a guest list with correct attributes', function () {
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create(['type' => ScannerType::EntryStaff]);
+
+    $guestList = GuestList::factory()->create([
+        'project_id' => $project->id,
+        'scanner_id' => $scanner->id,
+        'name' => 'Kuenstler Hauptabend',
+        'status' => GuestListStatus::Draft,
+        'gear_items' => [1, 2, 3],
+    ]);
+
+    expect($guestList->exists)->toBeTrue()
+        ->and($guestList->name)->toBe('Kuenstler Hauptabend')
+        ->and($guestList->status)->toBe(GuestListStatus::Draft)
+        ->and($guestList->gear_items)->toBe([1, 2, 3])
+        ->and($guestList->confirmed_at)->toBeNull();
+});
+
+it('belongs to a project', function () {
+    $project = Project::factory()->create();
+    $guestList = GuestList::factory()->create(['project_id' => $project->id]);
+
+    expect($guestList->project->id)->toBe($project->id);
+});
+
+it('belongs to a scanner', function () {
+    $scanner = ProjectScanner::factory()->create();
+    $guestList = GuestList::factory()->create(['scanner_id' => $scanner->id]);
+
+    expect($guestList->scanner->id)->toBe($scanner->id);
+});
+
+it('has many groups', function () {
+    $guestList = GuestList::factory()->create();
+    GuestGroup::factory()->count(3)->for($guestList)->create();
+
+    expect($guestList->groups)->toHaveCount(3);
+});
+
+it('has many entries through groups', function () {
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    GuestEntry::factory()->count(2)->for($group, 'group')->create();
+
+    expect($guestList->entries)->toHaveCount(2);
+});
+
+it('scopes confirmed guest lists', function () {
+    GuestList::factory()->create(['status' => GuestListStatus::Draft]);
+    GuestList::factory()->confirmed()->create();
+
+    expect(GuestList::confirmed()->count())->toBe(1);
+});
+
+it('scopes by project', function () {
+    $project = Project::factory()->create();
+    GuestList::factory()->create(['project_id' => $project->id]);
+    GuestList::factory()->create(); // different project
+
+    expect(GuestList::forProject($project->id)->count())->toBe(1);
+});
+
+it('reports confirmed and draft status correctly', function () {
+    $draft = GuestList::factory()->create(['status' => GuestListStatus::Draft]);
+    $confirmed = GuestList::factory()->confirmed()->create();
+
+    expect($draft->isDraft())->toBeTrue()
+        ->and($draft->isConfirmed())->toBeFalse()
+        ->and($confirmed->isDraft())->toBeFalse()
+        ->and($confirmed->isConfirmed())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Add non-volunteer guest management (VIPs, artists, companions) with QR codes and scanner integration
- Organizers create guest lists linked to Entry Staff scanners, manage groups/entries, confirm to generate QR codes and send grouped invitation emails
- Entry Staff scanners support offline guest check-in via QR or manual lookup with 3-tab UI (Scanner/Volunteers/Gastliste)
- Volunteer Admin scanners handle guest gear pickup (online-only) with direct Typ-1 size selection for guests (no portal)

### What's included

**Schema:** 4 new tables (guest_lists, guest_groups, guest_entries, guest_entry_gear)

**Backend:** 4 models, 11 actions, GuestListStatus enum, ConfirmGuestListJob orchestrator (ShouldBeUnique), SendGuestInvitationsJob (grouped emails), GuestInvitationMail, ProjectPolicy::manageGuestLists

**Admin UI:** GuestListIndex + GuestListShow Livewire components with Flux UI

**Scanner API:** 3 new endpoints (guest-checkin, guest-gear-pickup, guest-sync) + data endpoint extended with guest entries (qr_token stripped from Volunteer Admin payload)

**Frontend:** IDB v4 with guest_entries store, dual-path QR detection (JWT then guest token), selective outbox sync (per-type deletion), Alpine guest check-in/gear methods, WAI-ARIA tab pattern

**Security:** restrictOnDelete on scanner FK, lockForUpdate on confirm, project-scoped gear item validation, #[Locked] on all IDs, qr_token in $hidden

### Key design decisions

- Guest QR = 64-char hex random string (not JWT) — simple IDB string lookup
- Offline check-in via outbox (same pattern as volunteer arrivals)
- Gear pickup online-only (same as volunteer gear — D4/D10)
- Single ConfirmGuestListJob orchestrator avoids queue burst
- Volunteer Admin loads guest entries project-wide (not scanner-scoped) per D7

## Test plan

- [x] 102 new tests (1258 total, 2761 assertions) — all green
- [x] 31 TypeScript tests — all green
- [x] Full lifecycle test: create → add groups → entries with gear → confirm → QR → emails → scan → check-in → gear pickup
- [x] Post-confirm mutations: add entry (QR + email), remove entry (QR invalid)
- [x] Scanner scoping: Entry Staff sees only linked lists; VA sees project-wide with gear
- [x] Authorization: Organizer-only admin, scanner type enforcement on API
- [x] Security audit: 0 critical, all high/medium findings fixed
- [x] Pint clean, Vite build clean, migrate:fresh --seed clean

Resolves #90