### PR TITLE
fix(ui): add guest list nav item and consistent layout

### DIFF
--- a/resources/views/components/projects/tab-nav.blade.php
+++ b/resources/views/components/projects/tab-nav.blade.php
@@ -29,6 +29,16 @@
             {{ __('Scanners') }}
         </flux:navlist.item>
     @endcan
+    @can('manageGuestLists', $project)
+        <flux:navlist.item
+            :href="route('guest-lists.index', $project)"
+            :current="request()->routeIs('guest-lists.*')"
+            icon="clipboard-document-list"
+            wire:navigate
+        >
+            {{ __('Gästelisten') }}
+        </flux:navlist.item>
+    @endcan
     @can('view', $project)
         <flux:navlist.item
             :href="route('projects.gear-summary', $project)"

--- a/resources/views/livewire/projects/guest-list-index.blade.php
+++ b/resources/views/livewire/projects/guest-list-index.blade.php
@@ -1,13 +1,15 @@
 <div class="mx-auto max-w-7xl p-6">
-    <div class="flex items-center gap-3 mb-6">
-        <flux:button variant="ghost" icon="arrow-left" :href="route('projects.show', $project)" wire:navigate aria-label="{{ __('Back to project') }}" />
-        <flux:heading size="xl">{{ __('Guest Lists') }} &mdash; {{ $project->name }}</flux:heading>
-        <div class="ml-auto">
-            <flux:button variant="primary" icon="plus" wire:click="$set('showCreateModal', true)">
-                {{ __('New Guest List') }}
-            </flux:button>
+    <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center gap-3">
+            <flux:button variant="ghost" icon="arrow-left" :href="route('projects.index')" wire:navigate aria-label="{{ __('Back to projects') }}" />
+            <flux:heading size="xl">{{ $project->name }}</flux:heading>
         </div>
+        <flux:button variant="primary" icon="plus" wire:click="$set('showCreateModal', true)">
+            {{ __('New Guest List') }}
+        </flux:button>
     </div>
+
+    <x-projects.layout :project="$project">
 
     @if (session('message'))
         <flux:callout variant="success" class="mb-4">{{ session('message') }}</flux:callout>
@@ -53,6 +55,8 @@
             @endforeach
         </div>
     @endif
+
+    </x-projects.layout>
 
     {{-- Create Modal --}}
     <flux:modal wire:model="showCreateModal">

--- a/resources/views/livewire/projects/guest-list-show.blade.php
+++ b/resources/views/livewire/projects/guest-list-show.blade.php
@@ -1,11 +1,13 @@
 <div class="mx-auto max-w-7xl p-6">
-    <div class="flex items-center gap-3 mb-6">
-        <flux:button variant="ghost" icon="arrow-left" :href="route('guest-lists.index', ['projectId' => $projectId])" wire:navigate aria-label="{{ __('Back to guest lists') }}" />
-        <flux:heading size="xl">{{ $this->guestList->name }}</flux:heading>
-        <flux:badge size="sm" :color="$this->guestList->status === \App\Enums\GuestListStatus::Confirmed ? 'emerald' : 'zinc'">
-            {{ $this->guestList->status->label() }}
-        </flux:badge>
-        <div class="ml-auto flex gap-2">
+    <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center gap-3">
+            <flux:button variant="ghost" icon="arrow-left" :href="route('guest-lists.index', ['projectId' => $projectId])" wire:navigate aria-label="{{ __('Back to guest lists') }}" />
+            <flux:heading size="xl">{{ $this->guestList->name }}</flux:heading>
+            <flux:badge size="sm" :color="$this->guestList->status === \App\Enums\GuestListStatus::Confirmed ? 'emerald' : 'zinc'">
+                {{ $this->guestList->status->label() }}
+            </flux:badge>
+        </div>
+        <div class="flex gap-2">
             @if ($this->guestList->isDraft())
                 <flux:button variant="primary" wire:click="confirmGuestList" wire:confirm="{{ __('Confirm this guest list? QR codes will be generated for all entries.') }}">
                     {{ __('Confirm') }}
@@ -16,6 +18,8 @@
             </flux:button>
         </div>
     </div>
+
+    <x-projects.layout :project="$project">
 
     @if (session('message'))
         <flux:callout variant="success" class="mb-4">{{ session('message') }}</flux:callout>
@@ -165,6 +169,8 @@
             @endforeach
         </div>
     @endif
+
+    </x-projects.layout>
 
     {{-- Edit Modal --}}
     <flux:modal wire:model="showEditModal">

--- a/tests/Feature/Livewire/TabNavGuestListTest.php
+++ b/tests/Feature/Livewire/TabNavGuestListTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Enums\StaffRole;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    app()->instance(Organization::class, $this->org);
+});
+
+it('shows guest list nav item for project organizer', function () {
+    $organizer = User::factory()->create();
+    $this->project->users()->attach($organizer, ['role' => StaffRole::Organizer]);
+
+    $this->actingAs($organizer)
+        ->get(route('projects.show', $this->project))
+        ->assertOk()
+        ->assertSee('Gästelisten');
+});
+
+it('hides guest list nav item from volunteer admin', function () {
+    $volunteerAdmin = User::factory()->create();
+    $this->project->users()->attach($volunteerAdmin, ['role' => StaffRole::VolunteerAdmin]);
+
+    $this->actingAs($volunteerAdmin)
+        ->get(route('projects.show', $this->project))
+        ->assertOk()
+        ->assertDontSee('Gästelisten');
+});
+
+it('hides guest list nav item from entrance staff', function () {
+    $entranceStaff = User::factory()->create();
+    $this->project->users()->attach($entranceStaff, ['role' => StaffRole::EntranceStaff]);
+
+    $this->actingAs($entranceStaff)
+        ->get(route('projects.show', $this->project))
+        ->assertOk()
+        ->assertDontSee('Gästelisten');
+});


### PR DESCRIPTION
## Summary
- Add missing "Gästelisten" nav item to project tab-nav, gated by `manageGuestLists` policy (Organizer only)
- Wrap `guest-list-index` and `guest-list-show` views in `<x-projects.layout>` to match all sibling project pages
- Add 3 Pest tests verifying nav visibility per role (Organizer, VolunteerAdmin, EntranceStaff)

Resolves #111

## Test plan
- [x] Organizer sees "Gästelisten" in project tab-nav
- [x] VolunteerAdmin does not see "Gästelisten"
- [x] EntranceStaff does not see "Gästelisten"
- [x] All 62 existing guest list tests still pass
- [ ] Visual: nav item appears between Scanners and Gear
- [ ] Visual: guest list pages now show the tab-nav sidebar