### PR TITLE
fix(enrollment): use full_name accessor and live checkbox binding

### DIFF
--- a/resources/views/livewire/events/manual-enrollment.blade.php
+++ b/resources/views/livewire/events/manual-enrollment.blade.php
@@ -92,7 +92,7 @@
                         <div>
                             <flux:heading size="lg">{{ __('Select Shifts') }}</flux:heading>
                             <flux:text size="sm" class="text-zinc-500">
-                                {{ __('Enrolling: :name', ['name' => $this->selectedVolunteer->name]) }}
+                                {{ __('Enrolling: :name', ['name' => $this->selectedVolunteer->full_name]) }}
                             </flux:text>
                         </div>
                         <flux:button variant="ghost" size="sm" wire:click="clearSelection">{{ __('Change') }}</flux:button>
@@ -111,7 +111,7 @@
                                         <label class="flex items-center gap-3 rounded-lg border p-3
                                             {{ $isFull ? 'border-zinc-200 opacity-50 dark:border-zinc-700' : 'border-zinc-200 dark:border-zinc-700' }}">
                                             <flux:checkbox
-                                                wire:model="selectedShifts"
+                                                wire:model.live="selectedShifts"
                                                 value="{{ $shift->id }}"
                                                 :disabled="$isFull"
                                             />

--- a/tests/Feature/Livewire/ManualEnrollmentTest.php
+++ b/tests/Feature/Livewire/ManualEnrollmentTest.php
@@ -232,3 +232,27 @@ it('can create volunteer and then enroll them into shifts', function () {
     $volunteer = Volunteer::where('email', 'enrollme@test.com')->first();
     expect(ShiftSignup::where('volunteer_id', $volunteer->id)->where('shift_id', $shift->id)->exists())->toBeTrue();
 });
+
+it('displays the selected volunteer full name in the shift selection heading', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'first_name' => 'Alice',
+        'last_name' => 'Tester',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ManualEnrollment::class, ['eventId' => $this->event->id])
+        ->call('selectVolunteer', $volunteer->id)
+        ->assertSee('Enrolling: Alice Tester');
+});
+
+it('renders shift checkboxes with live wire:model binding', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create();
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create(['capacity' => 5]);
+    ShiftSignup::factory()->create(['volunteer_id' => $volunteer->id, 'shift_id' => $shift->id]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ManualEnrollment::class, ['eventId' => $this->event->id])
+        ->call('selectVolunteer', $volunteer->id)
+        ->assertSeeHtml('wire:model.live="selectedShifts"');
+});


### PR DESCRIPTION
## Summary

- Fix volunteer name not displaying in the shift selection heading — `->name` (non-existent) replaced with `->full_name` accessor
- Fix Enroll button staying permanently disabled — `wire:model` (deferred) replaced with `wire:model.live` so checkbox state syncs to server immediately

## Test plan

- [x] New test: asserts `Enrolling: Alice Tester` renders after selecting a volunteer
- [x] New test: asserts `wire:model.live="selectedShifts"` in rendered HTML
- [x] Full ManualEnrollment suite passes (16 tests)
- [x] Full test suite passes (1614 tests)

Resolves #116