### PR TITLE
fix(ui): timezone dropdown styling doesn't match dark theme

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -70,6 +70,19 @@ select:focus[data-flux-control] {
     @apply outline-hidden ring-2 ring-accent ring-offset-2 ring-offset-accent-foreground;
 }
 
+/* Fix dark-mode dropdown popup for <optgroup> in native selects (#121).
+   Flux's dark:[&>option] only targets direct children; options inside
+   <optgroup> are grandchildren and need explicit styling.
+   Note: Mixing <optgroup> with <flux:select.option> is not a documented
+   Flux pattern — monitor on Flux upgrades. */
+select[data-flux-control] optgroup {
+    @apply dark:bg-zinc-700 dark:text-zinc-300;
+}
+
+select[data-flux-control] optgroup option {
+    @apply dark:bg-zinc-700 dark:text-white;
+}
+
 /* Card utility classes */
 .card-accent-emerald {
     @apply border-l-4 border-l-emerald-500;

--- a/tests/Feature/Livewire/ProjectShowTest.php
+++ b/tests/Feature/Livewire/ProjectShowTest.php
@@ -142,6 +142,15 @@ it('loads current timezone into form when editing', function () {
         ->assertSet('projectForm.timezone', 'America/New_York');
 });
 
+it('renders timezone select with optgroup elements in edit mode', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(ProjectShow::class, ['projectId' => $this->project->id])
+        ->call('startEditing')
+        ->assertSeeHtml('<optgroup label="Europe">')
+        ->assertSeeHtml('<optgroup label="America">')
+        ->assertSeeHtml('<optgroup label="Asia">');
+});
+
 it('validates event name required when creating event', function () {
     Livewire::actingAs($this->organizer)
         ->test(ProjectShow::class, ['projectId' => $this->project->id])


### PR DESCRIPTION
Resolves #121

## Summary

- Add CSS overrides in `app.css` for `<optgroup>` and nested `<option>` dark mode styling in native Flux selects
- Flux's `dark:[&>option]` uses a direct-child combinator that misses options inside `<optgroup>` — the new descendant selectors close that gap
- Add structural regression test verifying optgroup elements render in edit mode

## Browser Compatibility

The fix is best-effort for native `<select>` dropdowns:

| OS / Browser | Expected |
|---|---|
| Windows / Chrome | **Fixed** |
| Linux / Chrome, Firefox | **Fixed** |
| macOS / Chrome, Safari | No change (OS-rendered popup) |

## Related

- #122 — follow-up for searchable timezone picker UX improvement

## Test plan

- [x] `vendor/bin/sail artisan test --compact --filter=ProjectShowTest` — 15/15 pass
- [x] `vendor/bin/sail bin pint --dirty` — pass
- [x] `vendor/bin/sail npm run build` — compiled CSS contains correct `.dark` scoped optgroup rules
- [ ] Visual: open project settings → Edit → timezone dropdown in dark mode on Chrome/Windows or Linux