### PR TITLE
feat(portal): volunteer portal enhancements

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: implement
-current_focus: "H3 — Tests for 8 untested Actions (destructive ops, Fortify, invitation)"
-current_milestone: m14-audit-remediation
+current_focus: "#117 — Admin Manual Arrival + Gear Management on VolunteerDetail"
+current_milestone: m15-volunteer-portal-enhancements
 entry_point: plan
 stages_to_run:
   - plan
@@ -17,7 +17,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-01T23:45:00"
+last_updated: "2026-04-08T15:00:00"
 ---
 
 # TALL Pipeline — Index
@@ -34,6 +34,7 @@ last_updated: "2026-04-01T23:45:00"
 | m12-guest-lists | Guest Lists (#90) | Guest list CRUD, QR generation, grouped emails, scanner integration | m8, m11 | complete |
 | m13-polish | Communication & Polish | Announcements, email templates, remaining features | m8, m9, m11 | complete (all stages) |
 | m14-audit-remediation | Code Quality Audit Remediation | H0-H3: test gaps, Form Objects, auth refactor | m13 | in_progress |
+| m15-volunteer-portal-enhancements | Volunteer Portal Enhancements | #117 arrival+gear, #125 banners, #115 magic link re-request, #126 QR+resend, #127 attendance, #105 self-deletion | m14 | in_progress |
 
 ## Artifacts
 

--- a/.tall-pipeline/m15-volunteer-portal-enhancements.md
+++ b/.tall-pipeline/m15-volunteer-portal-enhancements.md
@@ -1,0 +1,53 @@
+# Milestone: m15-volunteer-portal-enhancements — Volunteer Portal Enhancements
+
+**Features:** #117 arrival+gear admin, #125 banners, #115 magic link re-request, #126 QR+resend, #127 attendance status, #105 self-deletion
+**Dependencies:** m14-audit-remediation
+**Branch:** feat/volunteer-portal-enhancements-m1
+**Plan:** `/home/rweiser/.claude/plans/declarative-mixing-puffin.md`
+
+## Plan
+- **Status:** complete (expert-reviewed, 12 issues resolved in Cycle 1)
+- **Gate summary:** 6 issues, 0 migrations, ~8 new files, ~50 tests. TDD approach per issue.
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Gate summary:** 6 issues implemented via TDD. 1718 tests pass (3729 assertions), 0 failures. Pint clean.
+- **Tasks:**
+  - [x] #117: Admin Manual Arrival + Gear Management
+  - [x] #125: Next Shift Banner + Maintenance Banner
+  - [x] #115: Magic Link Re-request from Project Website
+  - [x] #126: Inline QR Code Display + Resend
+  - [x] #127: Attendance Status per Shift
+  - [x] #105: Volunteer Self-Deletion (GDPR)
+
+## Test
+- **Status:** complete (TDD inline — 42 new tests written during implement)
+
+## Security Audit
+- **Status:** pending
+
+## Decisions
+
+| # | Stage | Decision | Rationale | Affects |
+|---|---|---|---|---|
+| 1 | plan | Inline gear undo (no new action) | Pickups are simple records with no side effects | #117 implement |
+| 2 | plan | Synchronous confirmation email before deletion | GDPR right to erasure takes precedence over courtesy email | #105 implement |
+| 3 | plan | Dual rate limiting (per-email + per-IP) | Matches existing EventSignup pattern; prevents enumeration | #115, #126 implement |
+| 4 | plan | DB::transaction for volunteer delete | Atomicity of cascade; notifications outside transaction | #105 implement |
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Actions | `RequestPortalAccessLink`, `DeleteVolunteerProfile` |
+| Notifications | `PortalAccessLink`, `TicketResendNotification`, `ProfileDeletionConfirmation`, `VolunteerProfileDeletedNotification` |
+| EmailTemplateType | `ProfileDeletion` (new enum case) |
+| Routes | No new routes (all features added to existing portal/detail/project pages) |
+
+## Reviews
+
+## Feedback Loops
+
+| # | Date | Direction | Trigger | Fix | Resolution |
+|---|---|---|---|---|---|

--- a/app/Actions/DeleteVolunteerProfile.php
+++ b/app/Actions/DeleteVolunteerProfile.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\StaffRole;
+use App\Models\ActivityLog;
+use App\Models\Volunteer;
+use App\Notifications\ProfileDeletionConfirmation;
+use App\Notifications\VolunteerProfileDeletedNotification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class DeleteVolunteerProfile
+{
+    public function execute(Volunteer $volunteer): void
+    {
+        $volunteer->loadMissing('project.organization');
+        $volunteerName = $volunteer->full_name;
+        $project = $volunteer->project;
+        $organization = $project->organization;
+
+        // 1. Send confirmation email synchronously (before deletion)
+        try {
+            $volunteer->notifyNow(new ProfileDeletionConfirmation($project));
+        } catch (\Throwable $e) {
+            Log::warning('Failed to send profile deletion confirmation email', [
+                'volunteer_id' => $volunteer->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        // 2. Collect upcoming shift details for organizer notification (before deletion)
+        $shiftSummary = $this->collectUpcomingShiftSummary($volunteer);
+
+        // 3. DB::transaction: clean up activity logs + delete volunteer
+        DB::transaction(function () use ($volunteer, $volunteerName) {
+            // Nullify causer references and preserve name in properties
+            ActivityLog::where('causer_type', Volunteer::class)
+                ->where('causer_id', $volunteer->id)
+                ->each(function (ActivityLog $log) use ($volunteerName) {
+                    $properties = $log->properties ?? [];
+                    $properties['deleted_volunteer_name'] = $volunteerName;
+                    $log->update([
+                        'causer_type' => null,
+                        'causer_id' => null,
+                        'properties' => $properties,
+                    ]);
+                });
+
+            // Preserve name in subject references (subject columns are NOT nullable)
+            ActivityLog::where('subject_type', Volunteer::class)
+                ->where('subject_id', $volunteer->id)
+                ->each(function (ActivityLog $log) use ($volunteerName) {
+                    $properties = $log->properties ?? [];
+                    $properties['deleted_volunteer_name'] = $volunteerName;
+                    $log->update(['properties' => $properties]);
+                });
+
+            // Cascade handles child records (signups, tickets, gear, tokens, etc.)
+            $volunteer->delete();
+        });
+
+        // 4. Notify organizers (outside transaction, after successful delete)
+        $organizers = $organization->users()
+            ->wherePivot('role', StaffRole::Organizer)
+            ->get();
+
+        foreach ($organizers as $organizer) {
+            try {
+                $organizer->notify(new VolunteerProfileDeletedNotification(
+                    $volunteerName,
+                    $project,
+                    $shiftSummary,
+                ));
+            } catch (\Throwable $e) {
+                Log::warning('Failed to notify organizer about volunteer deletion', [
+                    'organizer_id' => $organizer->id,
+                    'volunteer_name' => $volunteerName,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+
+    private function collectUpcomingShiftSummary(Volunteer $volunteer): string
+    {
+        $upcomingSignups = $volunteer->shiftSignups()
+            ->active()
+            ->whereHas('shift', fn ($q) => $q->where(function ($sq) {
+                $sq->where(fn ($inner) => $inner->whereNotNull('starts_at')->where('starts_at', '>', now()))
+                    ->orWhere(fn ($inner) => $inner->whereNull('starts_at')->where('shift_date', '>', now()->toDateString()));
+            }))
+            ->with('shift.volunteerJob.event')
+            ->get();
+
+        if ($upcomingSignups->isEmpty()) {
+            return '';
+        }
+
+        return $upcomingSignups->map(function ($signup) {
+            $shift = $signup->shift;
+            $job = $shift->volunteerJob;
+            $event = $job->event;
+            $tz = $event->project->timezone ?? 'UTC';
+
+            return "- {$job->name} ({$event->name}): {$shift->shift_date->setTimezone($tz)->format('d.m.Y')} {$shift->displayTimeRange($tz)}";
+        })->implode("\n");
+    }
+}

--- a/app/Actions/RequestPortalAccessLink.php
+++ b/app/Actions/RequestPortalAccessLink.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Project;
+use App\Models\Volunteer;
+use App\Notifications\PortalAccessLink;
+
+class RequestPortalAccessLink
+{
+    public function __construct(private GenerateMagicLink $generateMagicLink) {}
+
+    public function execute(string $email, Project $project): void
+    {
+        $volunteer = Volunteer::where('email', $email)
+            ->where('project_id', $project->id)
+            ->first();
+
+        if (! $volunteer) {
+            return;
+        }
+
+        $result = $this->generateMagicLink->execute($volunteer);
+        $volunteer->notify(new PortalAccessLink($project, $result['plainToken']));
+    }
+}

--- a/app/Enums/EmailTemplateType.php
+++ b/app/Enums/EmailTemplateType.php
@@ -16,6 +16,7 @@ enum EmailTemplateType: string
     case EventAnnouncement = 'event_announcement';
     case EventUpdated = 'event_updated';
     case CancellationConfirmation = 'cancellation_confirmation';
+    case ProfileDeletion = 'profile_deletion';
 
     /**
      * Human-readable German label for the template type.
@@ -33,6 +34,7 @@ enum EmailTemplateType: string
             self::EventAnnouncement => 'Event-Ankündigung',
             self::EventUpdated => 'Event-Aktualisierung',
             self::CancellationConfirmation => 'Stornierungsbestätigung',
+            self::ProfileDeletion => 'Profil-Löschung',
         };
     }
 }

--- a/app/Livewire/Events/VolunteerDetail.php
+++ b/app/Livewire/Events/VolunteerDetail.php
@@ -3,6 +3,9 @@
 namespace App\Livewire\Events;
 
 use App\Actions\PromoteVolunteer;
+use App\Actions\RecordArrival;
+use App\Actions\RecordGearPickup;
+use App\Enums\ArrivalMethod;
 use App\Enums\ScannerType;
 use App\Enums\StaffRole;
 use App\Exceptions\DomainException;
@@ -10,7 +13,9 @@ use App\Models\CustomRegistrationField;
 use App\Models\Event;
 use App\Models\EventArrival;
 use App\Models\ProjectScanner;
+use App\Models\Ticket;
 use App\Models\Volunteer;
+use App\Models\VolunteerGear;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
@@ -87,6 +92,26 @@ class VolunteerDetail extends Component
         return (bool) $this->volunteer->user_id;
     }
 
+    #[Computed]
+    public function ticket(): ?Ticket
+    {
+        return $this->volunteer->tickets()
+            ->where('project_id', $this->event->project_id)
+            ->first();
+    }
+
+    /**
+     * @return Collection<int, VolunteerGear>
+     */
+    #[Computed]
+    public function volunteerGear(): Collection
+    {
+        return $this->volunteer->volunteerGear()
+            ->whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id))
+            ->with(['gearItem', 'pickups'])
+            ->get();
+    }
+
     /**
      * @return Collection<int, ProjectScanner>
      */
@@ -129,5 +154,55 @@ class VolunteerDetail extends Component
         } catch (DomainException $e) {
             $this->addError('promote', $e->getMessage());
         }
+    }
+
+    public function markAsArrived(): void
+    {
+        Gate::authorize('scan', $this->event);
+
+        $ticket = $this->ticket;
+
+        if (! $ticket) {
+            $this->addError('arrival', __('Kein Ticket für diesen Volunteer vorhanden.'));
+
+            return;
+        }
+
+        app(RecordArrival::class)->execute(
+            ticket: $ticket,
+            event: $this->event,
+            scannedBy: auth()->user(),
+            method: ArrivalMethod::ManualLookup,
+        );
+
+        unset($this->arrival, $this->ticket);
+    }
+
+    public function recordGearPickup(int $gearId): void
+    {
+        Gate::authorize('trackGearPickup', $this->event);
+
+        $gear = VolunteerGear::whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id))
+            ->findOrFail($gearId);
+
+        try {
+            app(RecordGearPickup::class)->execute($gear, auth()->user());
+        } catch (DomainException $e) {
+            $this->addError('gear', $e->getMessage());
+        }
+
+        unset($this->volunteerGear);
+    }
+
+    public function undoGearPickup(int $gearId): void
+    {
+        Gate::authorize('trackGearPickup', $this->event);
+
+        $gear = VolunteerGear::whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id))
+            ->findOrFail($gearId);
+
+        $gear->pickups()->latest('picked_up_at')->first()?->delete();
+
+        unset($this->volunteerGear);
     }
 }

--- a/app/Livewire/Public/ProjectWebsite.php
+++ b/app/Livewire/Public/ProjectWebsite.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\Public;
 
+use App\Actions\RequestPortalAccessLink;
 use App\Models\Project;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -16,6 +18,10 @@ class ProjectWebsite extends Component
     #[Locked]
     public Project $project;
 
+    public string $requestEmail = '';
+
+    public string $accessLinkMessage = '';
+
     public function mount(string $publicToken): void
     {
         $this->project = Project::where('public_token', $publicToken)
@@ -24,6 +30,35 @@ class ProjectWebsite extends Component
         if (! $this->project->website_published) {
             abort(404);
         }
+    }
+
+    public function requestAccessLink(): void
+    {
+        $this->validate([
+            'requestEmail' => ['required', 'email'],
+        ]);
+
+        $emailKey = 'access-link:'.strtolower(trim($this->requestEmail));
+        if (RateLimiter::tooManyAttempts($emailKey, 3)) {
+            $this->addError('requestEmail', 'Zu viele Anfragen. Bitte warte eine Stunde.');
+
+            return;
+        }
+
+        $ipKey = 'access-link-ip:'.request()->ip();
+        if (RateLimiter::tooManyAttempts($ipKey, 10)) {
+            $this->addError('requestEmail', 'Zu viele Anfragen. Bitte versuche es später erneut.');
+
+            return;
+        }
+
+        RateLimiter::hit($emailKey, 3600);
+        RateLimiter::hit($ipKey, 60);
+
+        app(RequestPortalAccessLink::class)->execute($this->requestEmail, $this->project);
+
+        $this->accessLinkMessage = 'Falls ein Konto mit dieser E-Mail existiert, wurde ein Zugangslink versendet.';
+        $this->requestEmail = '';
     }
 
     public function renderedDescription(): ?string

--- a/app/Livewire/Public/VolunteerPortal.php
+++ b/app/Livewire/Public/VolunteerPortal.php
@@ -3,17 +3,23 @@
 namespace App\Livewire\Public;
 
 use App\Actions\CancelShiftSignup;
+use App\Actions\DeleteVolunteerProfile;
+use App\Actions\GenerateMagicLink;
 use App\Actions\VerifyMagicLink;
 use App\Enums\HintLocation;
 use App\Exceptions\InvalidMagicLinkException;
 use App\Models\Announcement;
 use App\Models\CustomFieldResponse;
+use App\Models\MagicLinkToken;
 use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
+use App\Notifications\TicketResendNotification;
 use App\Services\HintTextResolver;
+use App\ValueObjects\HashedToken;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
@@ -36,6 +42,12 @@ class VolunteerPortal extends Component
 
     public string $successMessage = '';
 
+    public ?string $projectPublicToken = null;
+
+    public bool $showDeleteModal = false;
+
+    public bool $deleteConfirmed = false;
+
     public function mount(string $magicToken): void
     {
         $this->magicToken = $magicToken;
@@ -48,12 +60,39 @@ class VolunteerPortal extends Component
         } catch (InvalidMagicLinkException $e) {
             if (str_contains($e->getMessage(), 'expired')) {
                 $this->expired = true;
+                $this->resolveProjectFromExpiredToken($magicToken);
 
                 return;
             }
 
             throw new NotFoundHttpException;
         }
+    }
+
+    private function resolveProjectFromExpiredToken(string $plainToken): void
+    {
+        $hash = HashedToken::fromPlaintext($plainToken)->hash;
+        $token = MagicLinkToken::where('token_hash', $hash)->with('volunteer.project')->first();
+
+        $this->projectPublicToken = $token?->volunteer?->project?->public_token;
+    }
+
+    #[Computed]
+    public function ticket(): ?Ticket
+    {
+        if (! $this->volunteer) {
+            return null;
+        }
+
+        return Ticket::where('volunteer_id', $this->volunteer->id)
+            ->where('project_id', $this->volunteer->project_id)
+            ->first();
+    }
+
+    #[Computed]
+    public function nextShift(): ?ShiftSignup
+    {
+        return $this->upcomingSignups->first();
     }
 
     #[Computed]
@@ -69,7 +108,7 @@ class VolunteerPortal extends Component
                 $sq->where(fn ($inner) => $inner->whereNotNull('starts_at')->where('starts_at', '>', now()))
                     ->orWhere(fn ($inner) => $inner->whereNull('starts_at')->where('shift_date', '>', now()->toDateString()));
             }))
-            ->with('shift.volunteerJob.event.project')
+            ->with(['shift.volunteerJob.event.project', 'attendanceRecord'])
             ->get()
             ->sortBy('shift.shift_date')
             ->values();
@@ -88,7 +127,7 @@ class VolunteerPortal extends Component
                 $sq->where(fn ($inner) => $inner->whereNotNull('ends_at')->where('ends_at', '<=', now()))
                     ->orWhere(fn ($inner) => $inner->whereNull('ends_at')->where('shift_date', '<', now()->toDateString()));
             }))
-            ->with('shift.volunteerJob.event')
+            ->with(['shift.volunteerJob.event.project', 'attendanceRecord'])
             ->get()
             ->sortByDesc('shift.shift_date')
             ->values();
@@ -197,5 +236,47 @@ class VolunteerPortal extends Component
         $this->successMessage = 'Signup cancelled successfully.';
 
         unset($this->upcomingSignups, $this->pastSignups);
+    }
+
+    public function resendTicketEmail(): void
+    {
+        $volunteerKey = 'qr-resend:'.$this->volunteer->id;
+        if (RateLimiter::tooManyAttempts($volunteerKey, 1)) {
+            $this->addError('resend', 'Bitte warte einige Minuten, bevor du es erneut versuchst.');
+
+            return;
+        }
+
+        $ipKey = 'qr-resend-ip:'.request()->ip();
+        if (RateLimiter::tooManyAttempts($ipKey, 10)) {
+            $this->addError('resend', 'Zu viele Anfragen. Bitte versuche es später erneut.');
+
+            return;
+        }
+
+        RateLimiter::hit($volunteerKey, 300);
+        RateLimiter::hit($ipKey, 3600);
+
+        $result = app(GenerateMagicLink::class)->execute($this->volunteer);
+
+        $this->volunteer->notify(new TicketResendNotification(
+            $this->volunteer->project,
+            $result['plainToken'],
+        ));
+
+        $this->successMessage = 'QR-Code wurde erneut gesendet.';
+    }
+
+    public function deleteProfile(): void
+    {
+        if (! $this->deleteConfirmed) {
+            return;
+        }
+
+        $publicToken = $this->volunteer->project->public_token;
+
+        app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+        $this->redirect(route('projects.public', $publicToken));
     }
 }

--- a/app/Notifications/PortalAccessLink.php
+++ b/app/Notifications/PortalAccessLink.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Project;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PortalAccessLink extends Notification implements ShouldQueue
+{
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Project $project,
+        public string $plainToken,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $portalUrl = route('volunteer.portal', $this->plainToken);
+        $projectName = $this->project->name;
+
+        $mail = (new MailMessage)
+            ->subject("Dein Zugangslink für {$projectName}")
+            ->greeting("Hallo {$notifiable->first_name}!")
+            ->line("Du hast einen neuen Zugangslink für **{$projectName}** angefordert.")
+            ->line('Klicke auf den Button, um dein Volunteer-Portal zu öffnen.')
+            ->action('Portal öffnen', $portalUrl)
+            ->line('Dieser Link ist 72 Stunden gültig.')
+            ->line('Falls du keinen Zugangslink angefordert hast, kannst du diese E-Mail ignorieren.');
+
+        return $this->applyOrgMailer($mail, $this->project->organization, $this->project);
+    }
+}

--- a/app/Notifications/ProfileDeletionConfirmation.php
+++ b/app/Notifications/ProfileDeletionConfirmation.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Project;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProfileDeletionConfirmation extends Notification
+{
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Project $project,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject('Dein Profil wurde gelöscht')
+            ->greeting("Hallo {$notifiable->first_name}!")
+            ->line('Dein Volunteer-Profil und alle zugehörigen Daten wurden auf deine Anfrage hin gelöscht.')
+            ->line('**Folgende Daten wurden unwiderruflich entfernt:**')
+            ->line('- Alle Schicht-Anmeldungen')
+            ->line('- Eventuelle Tickets und QR-Codes')
+            ->line('- Gear-Zuweisungen')
+            ->line('- Persönliche Daten (Name, E-Mail, Telefon)')
+            ->line('Dieser Vorgang kann nicht rückgängig gemacht werden. Falls du erneut als Volunteer teilnehmen möchtest, musst du dich neu registrieren.')
+            ->line('Vielen Dank für dein Engagement!');
+
+        return $this->applyOrgMailer($mail, $this->project->organization, $this->project);
+    }
+}

--- a/app/Notifications/TicketResendNotification.php
+++ b/app/Notifications/TicketResendNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Project;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TicketResendNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Project $project,
+        public string $plainToken,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $portalUrl = route('volunteer.portal', $this->plainToken);
+        $ticketUrl = route('volunteer.ticket', $this->plainToken);
+        $projectName = $this->project->name;
+
+        $mail = (new MailMessage)
+            ->subject("Dein QR-Code für {$projectName}")
+            ->greeting("Hallo {$notifiable->first_name}!")
+            ->line("Hier ist dein QR-Code-Zugang für **{$projectName}**.")
+            ->line('Klicke auf den Button, um dein Ticket mit QR-Code anzuzeigen.')
+            ->action('Ticket anzeigen', $ticketUrl)
+            ->line('Du kannst auch dein Volunteer-Portal über folgenden Link erreichen:')
+            ->line("[Portal öffnen]({$portalUrl})")
+            ->line('Dieser Link ist 72 Stunden gültig.');
+
+        return $this->applyOrgMailer($mail, $this->project->organization, $this->project);
+    }
+}

--- a/app/Notifications/VolunteerProfileDeletedNotification.php
+++ b/app/Notifications/VolunteerProfileDeletedNotification.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Project;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class VolunteerProfileDeletedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public string $volunteerName,
+        public Project $project,
+        public string $shiftSummary,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject("Volunteer-Profil gelöscht: {$this->volunteerName}")
+            ->greeting("Hallo {$notifiable->name}!")
+            ->line("**{$this->volunteerName}** hat sein Volunteer-Profil im Projekt **{$this->project->name}** gelöscht.")
+            ->line('Alle zugehörigen Daten (Anmeldungen, Tickets, Gear) wurden unwiderruflich entfernt.');
+
+        if ($this->shiftSummary !== '') {
+            $mail->line('**Betroffene kommende Schichten (jetzt unterbesetzt):**');
+            foreach (explode("\n", $this->shiftSummary) as $line) {
+                $trimmed = trim($line);
+                if ($trimmed !== '') {
+                    $mail->line($trimmed);
+                }
+            }
+        }
+
+        $mail->line('Bitte prüfe, ob eine Nachbesetzung erforderlich ist.');
+
+        return $this->applyOrgMailer($mail, $this->project->organization, $this->project);
+    }
+}

--- a/app/Services/EmailTemplateRenderer.php
+++ b/app/Services/EmailTemplateRenderer.php
@@ -54,6 +54,10 @@ class EmailTemplateRenderer
             'subject' => 'Stornierungsbestätigung für {{event_name}}',
             'body' => "Hallo {{vorname}}!\n\nDeine folgende Schicht bei **{{event_name}}** wurde storniert:\n{{cancelled_shift_summary}}\n\n{{remaining_shifts_section}}\n\nDu kannst dein Ticket jederzeit über den folgenden Link einsehen: {{portal_link}}\n\nVielen Dank!",
         ],
+        'profile_deletion' => [
+            'subject' => 'Dein Profil wurde gelöscht',
+            'body' => "Hallo {{vorname}}!\n\nDein Volunteer-Profil und alle zugehörigen Daten wurden auf deine Anfrage hin gelöscht.\n\n**Folgende Daten wurden unwiderruflich entfernt:**\n- Alle Schicht-Anmeldungen\n- Eventuelle Tickets und QR-Codes\n- Gear-Zuweisungen\n- Persönliche Daten (Name, E-Mail, Telefon)\n\nDieser Vorgang kann nicht rückgängig gemacht werden. Falls du erneut als Volunteer teilnehmen möchtest, musst du dich neu registrieren.\n\nVielen Dank für dein Engagement!",
+        ],
     ];
 
     /**
@@ -172,6 +176,11 @@ class EmailTemplateRenderer
                 'remaining_shifts_section',
                 'portal_link',
                 'kontakt_email',
+                'project_name',
+            ],
+            EmailTemplateType::ProfileDeletion => [
+                'vorname',
+                'nachname',
                 'project_name',
             ],
         };

--- a/resources/views/livewire/events/volunteer-detail.blade.php
+++ b/resources/views/livewire/events/volunteer-detail.blade.php
@@ -43,7 +43,15 @@
                             <flux:text size="sm">{{ $this->arrival->scanned_at->format('M d, Y g:i A') }}</flux:text>
                         </div>
                     @else
-                        <flux:badge size="sm" color="zinc">{{ __('Not arrived') }}</flux:badge>
+                        <div class="flex items-center gap-2">
+                            <flux:badge size="sm" color="zinc">{{ __('Not arrived') }}</flux:badge>
+                            @can('scan', $event)
+                                <flux:button size="xs" variant="primary" wire:click="markAsArrived" wire:confirm="{{ __('Volunteer als angekommen markieren?') }}">
+                                    {{ __('Als angekommen markieren') }}
+                                </flux:button>
+                            @endcan
+                        </div>
+                        <flux:error name="arrival" />
                     @endif
                 </div>
             </div>
@@ -112,6 +120,73 @@
                 </flux:table.rows>
             </flux:table>
             </div>
+        @endif
+
+        {{-- Gear assignments --}}
+        @if ($this->volunteerGear->isNotEmpty())
+            <flux:heading size="lg" class="mt-6 mb-4">{{ __('Gear') }}</flux:heading>
+
+            <div class="overflow-x-auto">
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>{{ __('Item') }}</flux:table.column>
+                    <flux:table.column>{{ __('Size') }}</flux:table.column>
+                    <flux:table.column>{{ __('Status') }}</flux:table.column>
+                    <flux:table.column>{{ __('Actions') }}</flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach ($this->volunteerGear as $gear)
+                        <flux:table.row :key="'gear-'.$gear->id">
+                            <flux:table.cell>{{ $gear->gearItem->name }}</flux:table.cell>
+                            <flux:table.cell>
+                                @if ($gear->size)
+                                    <flux:badge size="sm" color="zinc">{{ $gear->size }}</flux:badge>
+                                @else
+                                    —
+                                @endif
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                @if ($gear->quantity_entitled !== null)
+                                    <span class="text-sm font-medium">{{ $gear->totalPickedUp() }} / {{ $gear->quantity_entitled }}</span>
+                                @elseif ($gear->isPickedUp())
+                                    <flux:badge size="sm" color="emerald">{{ __('Picked up') }}</flux:badge>
+                                @else
+                                    <flux:badge size="sm" color="zinc">{{ __('Not picked up') }}</flux:badge>
+                                @endif
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                @can('trackGearPickup', $event)
+                                    @if ($gear->quantity_entitled !== null)
+                                        @if ($gear->remainingQuantity() > 0)
+                                            <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Record pickup') }}">
+                                                <flux:icon name="plus" class="size-4" />
+                                            </flux:button>
+                                        @endif
+                                        @if ($gear->totalPickedUp() > 0)
+                                            <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo last pickup') }}">
+                                                <flux:icon name="minus" class="size-4" />
+                                            </flux:button>
+                                        @endif
+                                    @else
+                                        @if ($gear->isPickedUp())
+                                            <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo pickup') }}">
+                                                <flux:icon name="arrow-uturn-left" class="size-4" />
+                                            </flux:button>
+                                        @else
+                                            <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Mark as picked up') }}">
+                                                <flux:icon name="hand-raised" class="size-4" />
+                                            </flux:button>
+                                        @endif
+                                    @endif
+                                @endcan
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+            </div>
+
+            <flux:error name="gear" />
         @endif
 
         {{-- Promote modal --}}

--- a/resources/views/livewire/public/project-website.blade.php
+++ b/resources/views/livewire/public/project-website.blade.php
@@ -141,4 +141,40 @@
             @endforeach
         </div>
     @endif
+
+    {{-- Access link request form --}}
+    <div class="mt-12 rounded-lg p-6" style="background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);">
+        <h2 class="font-bebas text-white mb-1" style="font-size: 1.4rem; letter-spacing: 0.06em;">{{ __('Zugang erhalten') }}</h2>
+        <p class="mb-4 text-sm" style="color: #a1a1aa;">{{ __('Gib deine E-Mail-Adresse ein, um einen neuen Zugangslink zu deinem Volunteer-Portal zu erhalten.') }}</p>
+
+        @if ($accessLinkMessage)
+            <div class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(5,150,105,0.1); border: 1px solid rgba(5,150,105,0.2); color: #6ee7b7;">
+                {{ $accessLinkMessage }}
+            </div>
+        @endif
+
+        <form wire:submit="requestAccessLink" class="flex flex-col sm:flex-row gap-3">
+            <div class="flex-1">
+                <input
+                    type="email"
+                    wire:model="requestEmail"
+                    placeholder="{{ __('E-Mail-Adresse') }}"
+                    class="w-full rounded-lg px-4 py-2.5 text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-2"
+                    style="background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.15); focus-ring-color: var(--brand);"
+                />
+                @error('requestEmail')
+                    <p class="mt-1 text-sm" style="color: #fca5a5;">{{ $message }}</p>
+                @enderror
+            </div>
+            <button
+                type="submit"
+                wire:loading.attr="disabled"
+                class="shrink-0 rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity"
+                style="background: var(--brand); letter-spacing: 0.03em;"
+            >
+                <span wire:loading.remove wire:target="requestAccessLink">{{ __('Zugangslink senden') }}</span>
+                <span wire:loading wire:target="requestAccessLink">{{ __('Wird gesendet...') }}</span>
+            </button>
+        </form>
+    </div>
 </div>

--- a/resources/views/livewire/public/volunteer-portal.blade.php
+++ b/resources/views/livewire/public/volunteer-portal.blade.php
@@ -3,7 +3,15 @@
         <div class="text-center py-12">
             <flux:icon name="clock" class="mx-auto size-12 mb-4" style="color: #9a9a9a;" />
             <h2 class="font-bebas text-white text-2xl" style="letter-spacing: 0.04em;">{{ __('Link Expired') }}</h2>
-            <p class="mt-2" style="color: #a1a1aa;">{{ __('This magic link has expired. Please request a new one from the event organizer.') }}</p>
+            <p class="mt-2" style="color: #a1a1aa;">{{ __('This magic link has expired.') }}</p>
+            @if ($projectPublicToken)
+                <a href="{{ route('projects.public', $projectPublicToken) }}"
+                   style="display: inline-flex; align-items: center; gap: 0.5rem; margin-top: 1rem; padding: 0.5rem 1.25rem; background: var(--brand); color: white; border-radius: 4px; font-size: 0.875rem; font-weight: 600; letter-spacing: 0.05em; text-decoration: none; transition: opacity 0.2s;">
+                    {{ __('Neuen Zugangslink anfordern') }}
+                </a>
+            @else
+                <p class="mt-2" style="color: #a1a1aa;">{{ __('Please request a new one from the event organizer.') }}</p>
+            @endif
         </div>
     @elseif ($volunteer)
         {{-- Identity banner --}}
@@ -13,13 +21,40 @@
             <p class="mt-3" style="color: #a1a1aa;">{{ __('Welcome back, :name', ['name' => $volunteer->full_name]) }}</p>
         </div>
 
-        {{-- Back to ticket --}}
-        @if ($hasTicket)
+        {{-- QR Code + Ticket --}}
+        @if ($hasTicket && $this->ticket)
             <div class="mb-6">
-                <a href="{{ route('volunteer.ticket', $magicToken) }}" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1.25rem; border: 2px solid rgba(255,255,255,0.2); color: rgba(255,255,255,0.7); border-radius: 4px; font-size: 0.875rem; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; text-decoration: none; transition: border-color 0.2s, color 0.2s;">
-                    <flux:icon name="ticket" variant="mini" class="size-4" />
-                    {{ __('View Your Ticket') }}
-                </a>
+                {{-- QR Code --}}
+                <div class="flex justify-center mb-4">
+                    <div class="rounded-lg p-4" style="background: #ffffff; box-shadow: 0 4px 16px rgba(0,0,0,0.3);">
+                        <div class="size-48">
+                            {!! $this->ticket->qrCodeSvg() !!}
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Ticket page link --}}
+                <div class="text-center mb-3">
+                    <a href="{{ route('volunteer.ticket', $magicToken) }}" style="color: rgba(255,255,255,0.5); font-size: 0.8125rem; text-decoration: underline; text-underline-offset: 2px;">
+                        {{ __('Ticket-Seite anzeigen') }}
+                    </a>
+                </div>
+
+                {{-- Resend button --}}
+                <div class="text-center">
+                    <button wire:click="resendTicketEmail" wire:loading.attr="disabled" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1.25rem; border: 2px solid rgba(255,255,255,0.2); color: rgba(255,255,255,0.7); border-radius: 4px; font-size: 0.875rem; font-weight: 600; letter-spacing: 0.05em; background: transparent; cursor: pointer; transition: border-color 0.2s, color 0.2s;">
+                        <flux:icon name="envelope" variant="mini" class="size-4" />
+                        <span wire:loading.remove wire:target="resendTicketEmail">{{ __('QR-Code erneut senden') }}</span>
+                        <span wire:loading wire:target="resendTicketEmail">{{ __('Wird gesendet...') }}</span>
+                    </button>
+                </div>
+
+                {{-- Resend rate limit error --}}
+                @error('resend')
+                    <div class="rounded-lg p-3 mt-3 text-sm text-center" style="background: rgba(230,57,70,0.1); border: 1px solid rgba(230,57,70,0.2); color: #fca5a5;">
+                        {{ $message }}
+                    </div>
+                @enderror
             </div>
         @endif
 
@@ -34,6 +69,23 @@
         @if ($this->hintPortalTopBanner)
             <div class="rounded-lg p-3 mb-6 text-sm" style="background: rgba(59,130,246,0.1); border: 1px solid rgba(59,130,246,0.2); color: #93c5fd;">
                 {{ $this->hintPortalTopBanner }}
+            </div>
+        @endif
+
+        {{-- Next shift banner --}}
+        @if ($this->nextShift)
+            @php
+                $nextEvent = $this->nextShift->shift->volunteerJob->event;
+                $nextProject = $nextEvent->project;
+                $nextTimezone = $nextProject->timezone ?? 'UTC';
+            @endphp
+            <div class="rounded-lg p-4 mb-6" style="background: rgba(5,150,105,0.1); border-left: 4px solid #10b981;">
+                <div class="text-xs font-semibold uppercase mb-1" style="color: #6ee7b7; letter-spacing: 0.05em;">{{ __('Nächste Schicht') }}</div>
+                <div class="font-medium text-white">{{ $this->nextShift->shift->volunteerJob->name }}</div>
+                <div class="mt-1 text-sm" style="color: #a1a1aa;">{{ $nextEvent->name }}</div>
+                <div class="mt-1 text-sm" style="color: #a1a1aa;">
+                    {{ $this->nextShift->shift->shift_date->setTimezone($nextTimezone)->format('M d, Y') }} — {{ $this->nextShift->shift->displayTimeRange($nextTimezone) }}
+                </div>
             </div>
         @endif
 
@@ -53,29 +105,42 @@
                         @php
                             $event = $signup->shift->volunteerJob->event;
                             $project = $event->project;
-                            $canCancel = $project->isCancellationAllowed() && $signup->isCancellable($project->cancellation_cutoff_hours);
+                            $isDraft = $event->status === \App\Enums\EventStatus::Draft;
+                            $canCancel = ! $isDraft && $project->isCancellationAllowed() && $signup->isCancellable($project->cancellation_cutoff_hours);
                         @endphp
-                        <div wire:key="upcoming-{{ $signup->id }}" class="rounded-lg p-4" style="background: rgba(255,255,255,0.05); border-left: 4px solid var(--brand);">
-                            <div class="flex items-start justify-between gap-3">
-                                <div>
-                                    <div class="font-medium text-white">{{ $signup->shift->volunteerJob->name }}</div>
-                                    <div class="mt-1 text-sm" style="color: #a1a1aa;">
-                                        {{ $event->name }}
-                                    </div>
-                                    <div class="mt-1 text-sm" style="color: #a1a1aa;">
-                                        {{ $signup->shift->shift_date->setTimezone($project->timezone ?? 'UTC')->format('M d, Y') }} — {{ $signup->shift->displayTimeRange($project->timezone ?? 'UTC') }}
-                                    </div>
-                                    @if ($project->isCancellationAllowed())
-                                        <div class="mt-2 text-xs" style="color: #9a9a9a;">
-                                            {{ __('Cancellation allowed up to :hours hours before the shift', ['hours' => $project->cancellation_cutoff_hours]) }}
+                        <div wire:key="upcoming-{{ $signup->id }}">
+                            @if ($isDraft)
+                                <div class="rounded-lg p-3 mb-2 text-sm" style="background: rgba(234,179,8,0.1); border: 1px solid rgba(234,179,8,0.2); color: #fbbf24;">
+                                    {{ __('Dieses Event wird gerade aktualisiert.') }}
+                                </div>
+                            @endif
+                            <div class="rounded-lg p-4" style="background: rgba(255,255,255,0.05); border-left: 4px solid var(--brand);{{ $isDraft ? ' opacity: 0.5; pointer-events: none;' : '' }}">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <div class="font-medium text-white">{{ $signup->shift->volunteerJob->name }}</div>
+                                        <div class="mt-1 text-sm" style="color: #a1a1aa;">
+                                            {{ $event->name }}
                                         </div>
+                                        <div class="mt-1 text-sm" style="color: #a1a1aa;">
+                                            {{ $signup->shift->shift_date->setTimezone($project->timezone ?? 'UTC')->format('M d, Y') }} — {{ $signup->shift->displayTimeRange($project->timezone ?? 'UTC') }}
+                                        </div>
+                                        @if ($signup->attendanceRecord)
+                                            <div class="mt-2">
+                                                <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(5,150,105,0.15); color: #6ee7b7;">{{ __('Eingecheckt') }}</span>
+                                            </div>
+                                        @endif
+                                        @if ($project->isCancellationAllowed())
+                                            <div class="mt-2 text-xs" style="color: #9a9a9a;">
+                                                {{ __('Cancellation allowed up to :hours hours before the shift', ['hours' => $project->cancellation_cutoff_hours]) }}
+                                            </div>
+                                        @endif
+                                    </div>
+                                    @if ($canCancel)
+                                        <button wire:click="confirmCancel({{ $signup->id }})" class="shrink-0 text-sm font-medium px-3 py-1.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5; border: none; cursor: pointer; transition: background 0.2s;">
+                                            {{ __('Cancel') }}
+                                        </button>
                                     @endif
                                 </div>
-                                @if ($canCancel)
-                                    <button wire:click="confirmCancel({{ $signup->id }})" class="shrink-0 text-sm font-medium px-3 py-1.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5; border: none; cursor: pointer; transition: background 0.2s;">
-                                        {{ __('Cancel') }}
-                                    </button>
-                                @endif
                             </div>
                         </div>
                     @endforeach
@@ -159,13 +224,38 @@
                 <h2 class="font-bebas text-white text-lg mb-3" style="letter-spacing: 0.04em;">{{ __('Past Shifts') }}</h2>
                 <div class="space-y-3">
                     @foreach ($this->pastSignups as $signup)
+                        @php
+                            $pastEvent = $signup->shift->volunteerJob->event;
+                            $pastTimezone = $pastEvent->project->timezone ?? 'UTC';
+                        @endphp
                         <div wire:key="past-{{ $signup->id }}" class="rounded-lg p-4" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.05); opacity: 0.6;">
-                            <div class="font-medium text-white">{{ $signup->shift->volunteerJob->name }}</div>
-                            <div class="mt-1 text-sm" style="color: #a1a1aa;">
-                                {{ $signup->shift->volunteerJob->event->name }}
-                            </div>
-                            <div class="mt-1 text-sm" style="color: #a1a1aa;">
-                                {{ $signup->shift->shift_date->setTimezone($project->timezone ?? 'UTC')->format('M d, Y') }} — {{ $signup->shift->displayTimeRange($project->timezone ?? 'UTC') }}
+                            <div class="flex items-start justify-between gap-3">
+                                <div>
+                                    <div class="font-medium text-white">{{ $signup->shift->volunteerJob->name }}</div>
+                                    <div class="mt-1 text-sm" style="color: #a1a1aa;">
+                                        {{ $pastEvent->name }}
+                                    </div>
+                                    <div class="mt-1 text-sm" style="color: #a1a1aa;">
+                                        {{ $signup->shift->shift_date->setTimezone($pastTimezone)->format('M d, Y') }} — {{ $signup->shift->displayTimeRange($pastTimezone) }}
+                                    </div>
+                                </div>
+                                <div class="shrink-0">
+                                    @if ($signup->attendanceRecord)
+                                        @switch($signup->attendanceRecord->status)
+                                            @case(\App\Enums\AttendanceStatus::OnTime)
+                                                <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(5,150,105,0.15); color: #6ee7b7;">{{ __('Pünktlich') }}</span>
+                                                @break
+                                            @case(\App\Enums\AttendanceStatus::Late)
+                                                <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(245,158,11,0.15); color: #fbbf24;">{{ __('Verspätet') }}</span>
+                                                @break
+                                            @case(\App\Enums\AttendanceStatus::NoShow)
+                                                <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Nicht erschienen') }}</span>
+                                                @break
+                                        @endswitch
+                                    @else
+                                        <span class="text-xs" style="color: #9a9a9a;">—</span>
+                                    @endif
+                                </div>
                             </div>
                         </div>
                     @endforeach
@@ -186,6 +276,47 @@
                         <button wire:click="cancelSignup" wire:loading.attr="disabled" style="padding: 0.5rem 1rem; background: var(--red); color: white; border-radius: 4px; font-size: 0.875rem; font-weight: 600; border: none; cursor: pointer; transition: opacity 0.2s;">
                             <span wire:loading.remove wire:target="cancelSignup">{{ __('Yes, Cancel Signup') }}</span>
                             <span wire:loading wire:target="cancelSignup">{{ __('Cancelling...') }}</span>
+                        </button>
+                    </div>
+                </div>
+            </flux:modal>
+        @endif
+
+        {{-- Danger zone: Delete profile --}}
+        <div class="mt-8 rounded-lg p-4" style="background: rgba(230,57,70,0.05); border: 1px solid rgba(230,57,70,0.15);">
+            <h2 class="font-bebas text-lg mb-2" style="color: #fca5a5; letter-spacing: 0.04em;">{{ __('Profil löschen') }}</h2>
+            <p class="text-sm mb-3" style="color: #a1a1aa;">
+                {{ __('Lösche dein Volunteer-Profil und alle zugehörigen Daten unwiderruflich. Dieser Vorgang kann nicht rückgängig gemacht werden.') }}
+            </p>
+            <button wire:click="$set('showDeleteModal', true)" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1.25rem; background: rgba(230,57,70,0.15); color: #fca5a5; border: 1px solid rgba(230,57,70,0.3); border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: background 0.2s;">
+                {{ __('Profil löschen') }}
+            </button>
+        </div>
+
+        {{-- Delete confirmation modal --}}
+        @if ($showDeleteModal)
+            <flux:modal wire:model="showDeleteModal" class="max-w-sm">
+                <div class="space-y-4">
+                    <h3 class="font-bebas text-white text-xl" style="letter-spacing: 0.04em;">{{ __('Profil endgültig löschen?') }}</h3>
+                    <div class="space-y-2 text-sm" style="color: #a1a1aa;">
+                        <p>{{ __('Folgende Daten werden unwiderruflich gelöscht:') }}</p>
+                        <ul class="list-disc list-inside space-y-1">
+                            <li>{{ __('Alle Schicht-Anmeldungen werden unwiderruflich storniert') }}</li>
+                            <li>{{ __('Eventuelle Tickets verlieren ihre Gültigkeit') }}</li>
+                            <li>{{ __('Nicht abgeholte Gear-Artikel verfallen unwiderruflich') }}</li>
+                        </ul>
+                    </div>
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input type="checkbox" wire:model="deleteConfirmed" class="rounded" style="accent-color: #e63946;">
+                        <span class="text-sm" style="color: #fca5a5;">{{ __('Ich verstehe, dass dieser Vorgang nicht rückgängig gemacht werden kann.') }}</span>
+                    </label>
+                    <div class="flex gap-2 justify-end">
+                        <button wire:click="$set('showDeleteModal', false)" style="padding: 0.5rem 1rem; background: transparent; color: rgba(255,255,255,0.7); border: 2px solid rgba(255,255,255,0.2); border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer;">
+                            {{ __('Abbrechen') }}
+                        </button>
+                        <button wire:click="deleteProfile" wire:loading.attr="disabled" style="padding: 0.5rem 1rem; background: #e63946; color: white; border-radius: 4px; font-size: 0.875rem; font-weight: 600; border: none; cursor: pointer; transition: opacity 0.2s;">
+                            <span wire:loading.remove wire:target="deleteProfile">{{ __('Profil endgültig löschen') }}</span>
+                            <span wire:loading wire:target="deleteProfile">{{ __('Wird gelöscht...') }}</span>
                         </button>
                     </div>
                 </div>

--- a/tests/Feature/Actions/DeleteVolunteerProfileTest.php
+++ b/tests/Feature/Actions/DeleteVolunteerProfileTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Actions\DeleteVolunteerProfile;
+use App\Enums\StaffRole;
+use App\Models\ActivityLog;
+use App\Models\Event;
+use App\Models\MagicLinkToken;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Models\Volunteer;
+use App\Models\VolunteerGear;
+use App\Models\VolunteerJob;
+use App\Notifications\ProfileDeletionConfirmation;
+use App\Notifications\VolunteerProfileDeletedNotification;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->organizer = User::factory()->create();
+    $this->org->users()->attach($this->organizer, ['role' => StaffRole::Organizer]);
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $this->job = VolunteerJob::factory()->for($this->event)->create(['name' => 'Setup Crew']);
+    $this->futureShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(3),
+        'ends_at' => now()->addDays(3)->addHours(2),
+    ]);
+    $this->volunteer = Volunteer::factory()->for($this->project)->create([
+        'first_name' => 'Test',
+        'last_name' => 'Volunteer',
+    ]);
+});
+
+it('deletes volunteer record from database', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
+});
+
+it('cascades deletion to all related records', function () {
+    Notification::fake();
+
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+    $ticket = Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+    $gearItem = ProjectGearItem::factory()->for($this->project)->create();
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+    $token = MagicLinkToken::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    expect(ShiftSignup::find($signup->id))->toBeNull()
+        ->and(Ticket::find($ticket->id))->toBeNull()
+        ->and(VolunteerGear::find($gear->id))->toBeNull()
+        ->and(MagicLinkToken::find($token->id))->toBeNull();
+});
+
+it('sends confirmation email before deletion', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    Notification::assertSentTo($this->volunteer, ProfileDeletionConfirmation::class);
+});
+
+it('notifies organizer after deletion', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    Notification::assertSentTo($this->organizer, VolunteerProfileDeletedNotification::class);
+});
+
+it('does not affect other volunteers', function () {
+    Notification::fake();
+
+    $otherVolunteer = Volunteer::factory()->for($this->project)->create();
+    $otherSignup = ShiftSignup::factory()->create([
+        'volunteer_id' => $otherVolunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    expect(Volunteer::find($otherVolunteer->id))->not->toBeNull()
+        ->and(ShiftSignup::find($otherSignup->id))->not->toBeNull();
+});
+
+it('handles volunteer with no signups', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
+});
+
+it('preserves volunteer name in activity log properties before deletion', function () {
+    Notification::fake();
+
+    $log = ActivityLog::factory()->create([
+        'organization_id' => $this->org->id,
+        'subject_type' => Volunteer::class,
+        'subject_id' => $this->volunteer->id,
+        'causer_type' => Volunteer::class,
+        'causer_id' => $this->volunteer->id,
+        'properties' => ['some' => 'data'],
+    ]);
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    $log->refresh();
+    expect($log->causer_id)->toBeNull()
+        ->and($log->causer_type)->toBeNull()
+        ->and($log->properties)->toHaveKey('deleted_volunteer_name', 'Test Volunteer')
+        ->and($log->properties)->toHaveKey('some', 'data');
+});
+
+it('includes upcoming shifts in organizer notification', function () {
+    Notification::fake();
+
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    Notification::assertSentTo($this->organizer, VolunteerProfileDeletedNotification::class, function ($notification) {
+        return str_contains($notification->shiftSummary, 'Setup Crew');
+    });
+});

--- a/tests/Feature/Actions/RequestPortalAccessLinkTest.php
+++ b/tests/Feature/Actions/RequestPortalAccessLinkTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Actions\RequestPortalAccessLink;
+use App\Models\MagicLinkToken;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Volunteer;
+use App\Notifications\PortalAccessLink;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'volunteer@example.com',
+    ]);
+});
+
+it('generates magic link and sends notification for existing volunteer', function () {
+    Notification::fake();
+
+    $action = app(RequestPortalAccessLink::class);
+    $action->execute('volunteer@example.com', $this->project);
+
+    expect(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->count())->toBe(1);
+
+    Notification::assertSentTo($this->volunteer, PortalAccessLink::class);
+});
+
+it('does nothing for non-existent email', function () {
+    Notification::fake();
+
+    $action = app(RequestPortalAccessLink::class);
+    $action->execute('nonexistent@example.com', $this->project);
+
+    expect(MagicLinkToken::count())->toBe(0);
+
+    Notification::assertNothingSent();
+});
+
+it('does not invalidate existing tokens', function () {
+    Notification::fake();
+
+    $existingToken = MagicLinkToken::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'expires_at' => now()->addHours(72),
+    ]);
+
+    $action = app(RequestPortalAccessLink::class);
+    $action->execute('volunteer@example.com', $this->project);
+
+    expect($existingToken->fresh()->expires_at->isFuture())->toBeTrue();
+    expect(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->count())->toBe(2);
+});

--- a/tests/Feature/Events/VolunteerDetailTest.php
+++ b/tests/Feature/Events/VolunteerDetailTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Enums\ArrivalMethod;
 use App\Enums\AttendanceStatus;
+use App\Enums\StaffRole;
 use App\Livewire\Events\VolunteerDetail;
 use App\Models\AttendanceRecord;
 use App\Models\CustomFieldResponse;
@@ -9,11 +11,14 @@ use App\Models\Event;
 use App\Models\EventArrival;
 use App\Models\Organization;
 use App\Models\Project;
+use App\Models\ProjectGearItem;
 use App\Models\Shift;
 use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\User;
 use App\Models\Volunteer;
+use App\Models\VolunteerGear;
+use App\Models\VolunteerGearPickup;
 use App\Models\VolunteerJob;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
@@ -185,4 +190,195 @@ it('promotes volunteer and creates user', function () {
 
     expect($this->volunteer->fresh()->user_id)->not->toBeNull();
     expect(User::where('email', $this->volunteer->email)->exists())->toBeTrue();
+});
+
+// --- Arrival management tests ---
+
+it('shows mark as arrived button when not arrived', function () {
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertSee('Als angekommen markieren');
+});
+
+it('hides mark as arrived button when already arrived', function () {
+    $ticket = Ticket::factory()->for($this->volunteer)->for($this->project, 'project')->create();
+
+    EventArrival::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'event_id' => $this->event->id,
+        'ticket_id' => $ticket->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertDontSee('Als angekommen markieren');
+});
+
+it('marks volunteer as arrived via manual lookup', function () {
+    $ticket = Ticket::factory()->for($this->volunteer)->for($this->project, 'project')->create();
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('markAsArrived')
+        ->assertHasNoErrors();
+
+    $arrival = EventArrival::where('volunteer_id', $this->volunteer->id)
+        ->where('event_id', $this->event->id)
+        ->first();
+
+    expect($arrival)->not->toBeNull();
+    expect($arrival->method)->toBe(ArrivalMethod::ManualLookup);
+    expect($arrival->scanned_by)->toBe($this->user->id);
+    expect($arrival->ticket_id)->toBe($ticket->id);
+});
+
+it('handles missing ticket when marking arrival', function () {
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('markAsArrived')
+        ->assertHasErrors('arrival');
+
+    expect(EventArrival::where('volunteer_id', $this->volunteer->id)->exists())->toBeFalse();
+});
+
+it('prevents unauthorized arrival marking', function () {
+    $vaUser = User::factory()->create();
+    $this->project->users()->attach($vaUser, ['role' => StaffRole::VolunteerAdmin]);
+
+    Livewire::actingAs($vaUser)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('markAsArrived')
+        ->assertForbidden();
+});
+
+// --- Gear management tests ---
+
+it('shows gear assignments with size info', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->sized()
+        ->create(['name' => 'T-Shirt']);
+
+    VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => 'L',
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertSee('T-Shirt')
+        ->assertSee('L');
+});
+
+it('shows gear assignments with quantity pickup progress', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->quantity(5)
+        ->create(['name' => 'Meal Voucher']);
+
+    $gear = VolunteerGear::factory()->withQuantity(5)->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+
+    VolunteerGearPickup::factory()->create([
+        'volunteer_gear_id' => $gear->id,
+        'quantity' => 2,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertSee('Meal Voucher')
+        ->assertSee('2 / 5');
+});
+
+it('records gear pickup for quantity gear', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->quantity(5)
+        ->create(['name' => 'Meal Voucher']);
+
+    $gear = VolunteerGear::factory()->withQuantity(5)->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('recordGearPickup', $gear->id)
+        ->assertHasNoErrors();
+
+    expect(VolunteerGearPickup::where('volunteer_gear_id', $gear->id)->count())->toBe(1);
+    expect(VolunteerGearPickup::where('volunteer_gear_id', $gear->id)->first()->picked_up_by)->toBe($this->user->id);
+});
+
+it('records gear pickup for sized gear', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->sized()
+        ->create(['name' => 'T-Shirt']);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => 'M',
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('recordGearPickup', $gear->id)
+        ->assertHasNoErrors();
+
+    expect(VolunteerGearPickup::where('volunteer_gear_id', $gear->id)->count())->toBe(1);
+});
+
+it('undoes last gear pickup', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->quantity(5)
+        ->create(['name' => 'Meal Voucher']);
+
+    $gear = VolunteerGear::factory()->withQuantity(5)->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+
+    VolunteerGearPickup::factory()->create([
+        'volunteer_gear_id' => $gear->id,
+        'picked_up_at' => now()->subMinute(),
+        'quantity' => 1,
+    ]);
+    $latestPickup = VolunteerGearPickup::factory()->create([
+        'volunteer_gear_id' => $gear->id,
+        'picked_up_at' => now(),
+        'quantity' => 1,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('undoGearPickup', $gear->id)
+        ->assertHasNoErrors();
+
+    expect(VolunteerGearPickup::where('volunteer_gear_id', $gear->id)->count())->toBe(1);
+    expect(VolunteerGearPickup::find($latestPickup->id))->toBeNull();
+});
+
+it('prevents unauthorized gear pickup', function () {
+    $vaUser = User::factory()->create();
+    $this->project->users()->attach($vaUser, ['role' => StaffRole::VolunteerAdmin]);
+
+    $gearItem = ProjectGearItem::factory()
+        ->for($this->project)
+        ->create(['name' => 'Badge']);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+    ]);
+
+    Livewire::actingAs($vaUser)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('recordGearPickup', $gear->id)
+        ->assertForbidden();
 });

--- a/tests/Feature/Livewire/ProjectWebsiteAccessLinkTest.php
+++ b/tests/Feature/Livewire/ProjectWebsiteAccessLinkTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Livewire\Public\ProjectWebsite;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Volunteer;
+use App\Notifications\PortalAccessLink;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create([
+        'website_published' => true,
+    ]);
+});
+
+it('shows access link form on project website', function () {
+    Livewire::test(ProjectWebsite::class, ['publicToken' => $this->project->public_token])
+        ->assertSee('Zugang erhalten')
+        ->assertSeeHtml('wire:model="requestEmail"');
+});
+
+it('shows neutral success message for known email', function () {
+    Notification::fake();
+
+    Volunteer::factory()->for($this->project)->create([
+        'email' => 'known@example.com',
+    ]);
+
+    Livewire::test(ProjectWebsite::class, ['publicToken' => $this->project->public_token])
+        ->set('requestEmail', 'known@example.com')
+        ->call('requestAccessLink')
+        ->assertSee('Falls ein Konto mit dieser E-Mail existiert, wurde ein Zugangslink versendet.');
+
+    Notification::assertSentTo(
+        Volunteer::where('email', 'known@example.com')->first(),
+        PortalAccessLink::class,
+    );
+});
+
+it('shows same neutral message for unknown email', function () {
+    Notification::fake();
+
+    Livewire::test(ProjectWebsite::class, ['publicToken' => $this->project->public_token])
+        ->set('requestEmail', 'unknown@example.com')
+        ->call('requestAccessLink')
+        ->assertSee('Falls ein Konto mit dieser E-Mail existiert, wurde ein Zugangslink versendet.');
+
+    Notification::assertNothingSent();
+});
+
+it('validates email format', function () {
+    Livewire::test(ProjectWebsite::class, ['publicToken' => $this->project->public_token])
+        ->set('requestEmail', 'not-an-email')
+        ->call('requestAccessLink')
+        ->assertHasErrors(['requestEmail' => 'email']);
+});
+
+it('rate limits requests per email', function () {
+    Notification::fake();
+
+    Volunteer::factory()->for($this->project)->create([
+        'email' => 'ratelimit@example.com',
+    ]);
+
+    $component = Livewire::test(ProjectWebsite::class, ['publicToken' => $this->project->public_token]);
+
+    // First 3 requests should succeed
+    for ($i = 0; $i < 3; $i++) {
+        $component
+            ->set('requestEmail', 'ratelimit@example.com')
+            ->call('requestAccessLink')
+            ->assertHasNoErrors();
+    }
+
+    // 4th request should be rate limited
+    $component
+        ->set('requestEmail', 'ratelimit@example.com')
+        ->call('requestAccessLink')
+        ->assertSee('Zu viele Anfragen');
+});

--- a/tests/Feature/Livewire/VolunteerPortalTest.php
+++ b/tests/Feature/Livewire/VolunteerPortalTest.php
@@ -1,12 +1,16 @@
 <?php
 
 use App\Actions\VerifyMagicLink;
+use App\Enums\AttendanceStatus;
+use App\Enums\EventStatus;
 use App\Exceptions\InvalidMagicLinkException;
 use App\Livewire\Public\VolunteerPortal;
 use App\Models\Announcement;
+use App\Models\AttendanceRecord;
 use App\Models\CustomFieldResponse;
 use App\Models\CustomRegistrationField;
 use App\Models\Event;
+use App\Models\MagicLinkToken;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
@@ -18,6 +22,9 @@ use App\Models\Volunteer;
 use App\Models\VolunteerGear;
 use App\Models\VolunteerGearPickup;
 use App\Models\VolunteerJob;
+use App\Notifications\TicketResendNotification;
+use App\ValueObjects\HashedToken;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -338,7 +345,7 @@ it('shows back link to ticket page when volunteer has a ticket', function () {
 
     Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
         ->assertSeeHtml(route('volunteer.ticket', 'token'))
-        ->assertSee('View Your Ticket');
+        ->assertSee('Ticket-Seite anzeigen');
 });
 
 it('does not show ticket link when volunteer has no ticket', function () {
@@ -347,7 +354,7 @@ it('does not show ticket link when volunteer has no ticket', function () {
         ->andReturn($this->volunteer);
 
     Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
-        ->assertDontSee('View Your Ticket');
+        ->assertDontSee('Ticket-Seite anzeigen');
 });
 
 it('includes correct magic token in ticket link href', function () {
@@ -362,4 +369,410 @@ it('includes correct magic token in ticket link href', function () {
 
     Livewire::test(VolunteerPortal::class, ['magicToken' => 'my-secret-token'])
         ->assertSeeHtml(route('volunteer.ticket', 'my-secret-token'));
+});
+
+it('shows next shift banner with job event and time', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    $timezone = $this->project->timezone ?? 'UTC';
+    $expectedDate = $this->futureShift->shift_date->setTimezone($timezone)->format('M d, Y');
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Nächste Schicht')
+        ->assertSee('Setup Crew')
+        ->assertSee($this->event->name)
+        ->assertSee($expectedDate);
+});
+
+it('hides next shift banner when no upcoming shifts', function () {
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Nächste Schicht');
+});
+
+it('shows the earliest upcoming shift in banner', function () {
+    $earlierShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(1),
+        'ends_at' => now()->addDays(1)->addHours(2),
+    ]);
+    $laterShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(5),
+        'ends_at' => now()->addDays(5)->addHours(2),
+    ]);
+    $laterJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Later Job']);
+    $laterShift->update(['volunteer_job_id' => $laterJob->id]);
+
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $laterShift->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $earlierShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    $timezone = $this->project->timezone ?? 'UTC';
+    $earlierDate = $earlierShift->shift_date->setTimezone($timezone)->format('M d, Y');
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSeeInOrder(['Nächste Schicht', 'Setup Crew', $earlierDate]);
+});
+
+it('shows maintenance banner for draft event shifts', function () {
+    $draftEvent = Event::factory()->for($this->org)->for($this->project)->create([
+        'status' => EventStatus::Draft,
+    ]);
+    $draftJob = VolunteerJob::factory()->for($draftEvent)->create(['name' => 'Draft Job']);
+    $draftShift = Shift::factory()->for($draftJob, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(2),
+        'ends_at' => now()->addDays(2)->addHours(2),
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $draftShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Dieses Event wird gerade aktualisiert.');
+});
+
+it('hides maintenance banner for published events', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Dieses Event wird gerade aktualisiert.');
+});
+
+it('hides cancel button for draft event shifts', function () {
+    $draftEvent = Event::factory()->for($this->org)->for($this->project)->create([
+        'status' => EventStatus::Draft,
+    ]);
+    $draftJob = VolunteerJob::factory()->for($draftEvent)->create(['name' => 'Draft Job']);
+    $draftShift = Shift::factory()->for($draftJob, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(3),
+        'ends_at' => now()->addDays(3)->addHours(2),
+    ]);
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $draftShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Draft Job')
+        ->assertDontSeeHtml('wire:click="confirmCancel('.$signup->id.')"');
+});
+
+it('shows re-request link on expired state when project is resolvable', function () {
+    $plainToken = 'expired-test-token-abc123';
+    $hash = HashedToken::fromPlaintext($plainToken)->hash;
+
+    MagicLinkToken::create([
+        'volunteer_id' => $this->volunteer->id,
+        'token_hash' => $hash,
+        'expires_at' => now()->subHour(),
+    ]);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => $plainToken])
+        ->assertSee('Link Expired')
+        ->assertSee('Neuen Zugangslink anfordern')
+        ->assertSeeHtml(route('projects.public', $this->project->public_token));
+});
+
+it('shows fallback message on expired state when project is not resolvable', function () {
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->with('unknown-expired-token')
+        ->andThrow(new InvalidMagicLinkException('This magic link has expired.'));
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'unknown-expired-token'])
+        ->assertSee('Link Expired')
+        ->assertSee('Please request a new one from the event organizer.')
+        ->assertDontSee('Neuen Zugangslink anfordern');
+});
+
+it('displays QR code SVG when volunteer has ticket', function () {
+    Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSeeHtml('<svg');
+});
+
+it('hides QR section when no ticket', function () {
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSeeHtml('<svg')
+        ->assertDontSee('QR-Code erneut senden');
+});
+
+it('shows resend button when ticket exists', function () {
+    Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('QR-Code erneut senden');
+});
+
+it('resends ticket email on button click', function () {
+    Notification::fake();
+
+    Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('resendTicketEmail');
+
+    Notification::assertSentTo($this->volunteer, TicketResendNotification::class);
+});
+
+it('rate limits resend to once per 5 minutes', function () {
+    Notification::fake();
+
+    Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    $component = Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('resendTicketEmail')
+        ->assertSee('QR-Code wurde erneut gesendet.');
+
+    $component->call('resendTicketEmail')
+        ->assertSee('Bitte warte einige Minuten, bevor du es erneut versuchst.');
+
+    Notification::assertSentToTimes($this->volunteer, TicketResendNotification::class, 1);
+});
+
+it('shows success message after resend', function () {
+    Notification::fake();
+
+    Ticket::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('resendTicketEmail')
+        ->assertSee('QR-Code wurde erneut gesendet.');
+});
+
+it('shows on-time status for past shift', function () {
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->pastShift->id,
+    ]);
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::OnTime,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Pünktlich');
+});
+
+it('shows late status for past shift', function () {
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->pastShift->id,
+    ]);
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::Late,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Verspätet');
+});
+
+it('shows no-show status for past shift', function () {
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->pastShift->id,
+    ]);
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::NoShow,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Nicht erschienen');
+});
+
+it('shows dash for unrecorded past shift', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->pastShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Past Shifts')
+        ->assertSeeHtml('—');
+});
+
+it('shows check-in indicator on upcoming shift when scanned', function () {
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::OnTime,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Eingecheckt');
+});
+
+it('hides check-in indicator on upcoming shift without attendance', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Eingecheckt');
+});
+
+it('shows delete profile section in portal', function () {
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Profil löschen');
+});
+
+it('requires confirmation checkbox for profile deletion', function () {
+    Notification::fake();
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->set('showDeleteModal', true)
+        ->call('deleteProfile');
+
+    expect(Volunteer::find($this->volunteer->id))->not->toBeNull();
+});
+
+it('deletes profile and redirects to project page', function () {
+    Notification::fake();
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    $expectedUrl = route('projects.public', $this->project->public_token);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->set('showDeleteModal', true)
+        ->set('deleteConfirmed', true)
+        ->call('deleteProfile')
+        ->assertRedirect($expectedUrl);
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
+});
+
+it('cannot delete another volunteers profile', function () {
+    Notification::fake();
+
+    $otherVolunteer = Volunteer::factory()->for($this->project)->create();
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    // The volunteer property is set from the magic link, so even if someone
+    // tries to manipulate, they can only delete their own profile (the one
+    // resolved from the magic link).
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->set('showDeleteModal', true)
+        ->set('deleteConfirmed', true)
+        ->call('deleteProfile');
+
+    // Other volunteer should still exist
+    expect(Volunteer::find($otherVolunteer->id))->not->toBeNull();
 });


### PR DESCRIPTION
## Summary

Implements all 6 issues from the Volunteer Portal Enhancements milestone:

- **#117** — Admin manual arrival check-in and gear pickup management on VolunteerDetail page
- **#125** — "Nächste Schicht" banner and maintenance banner for Draft events on volunteer portal
- **#115** — Magic link re-request form on public project website (with dual rate limiting)
- **#126** — Inline QR code display and "QR-Code erneut senden" button on volunteer portal
- **#127** — Attendance status per shift (past: Pünktlich/Verspätet/Nicht erschienen, upcoming: Eingecheckt)
- **#105** — Volunteer self-deletion with GDPR compliance (synchronous confirmation email, cascade delete, organizer notification with shift details)

### Key design decisions
- Dual rate limiting (per-email + per-IP) for #115 and #126 matching existing EventSignup pattern
- Synchronous confirmation email before deletion (#105) — GDPR right to erasure takes precedence over courtesy email
- DB::transaction for volunteer deletion with activity log cleanup
- Expired portal state now links to project website re-request form (#115)

### New files
- 2 actions: `RequestPortalAccessLink`, `DeleteVolunteerProfile`
- 4 notifications: `PortalAccessLink`, `TicketResendNotification`, `ProfileDeletionConfirmation`, `VolunteerProfileDeletedNotification`
- 3 test files: `RequestPortalAccessLinkTest`, `DeleteVolunteerProfileTest`, `ProjectWebsiteAccessLinkTest`

42 new tests added. 1718 total tests passing (3729 assertions).

Resolves #117, resolves #125, resolves #115, resolves #126, resolves #127, resolves #105

## Test plan

- [ ] Run full test suite: `vendor/bin/sail artisan test --compact`
- [ ] Verify admin volunteer detail: arrival button + gear pickup section
- [ ] Verify portal: next shift banner, maintenance banner for Draft events
- [ ] Verify project website: access link re-request form with neutral messages
- [ ] Verify portal: inline QR code, resend button with rate limiting
- [ ] Verify portal: attendance status on past/upcoming shifts
- [ ] Verify portal: self-deletion flow with confirmation modal and redirect
- [ ] Verify expired portal link shows re-request link to project website