### PR TITLE
feat(scanner): auth code management and configurable attendance states

### DIFF
--- a/app/Actions/CreateProject.php
+++ b/app/Actions/CreateProject.php
@@ -20,6 +20,7 @@ class CreateProject
         $project = $organization->projects()->create([
             'name' => $name,
             'description' => $description,
+            'attendance_states' => Project::defaultAttendanceStates(),
         ]);
 
         if ($titleImage) {

--- a/app/Actions/RegenerateAuthCode.php
+++ b/app/Actions/RegenerateAuthCode.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\ProjectScanner;
+use Illuminate\Support\Facades\Hash;
+
+class RegenerateAuthCode
+{
+    public function execute(ProjectScanner $scanner): string
+    {
+        $rawCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+
+        $scanner->update(['auth_code' => Hash::make($rawCode)]);
+
+        return $rawCode;
+    }
+}

--- a/app/Actions/SendScannerLinks.php
+++ b/app/Actions/SendScannerLinks.php
@@ -7,12 +7,12 @@ use App\Models\ProjectScanner;
 
 class SendScannerLinks
 {
-    public function execute(ProjectScanner $scanner): void
+    public function execute(ProjectScanner $scanner, ?string $rawAuthCode = null): void
     {
         $scanner->load('assignees');
 
         foreach ($scanner->assignees as $assignee) {
-            SendScannerLinksJob::dispatch($assignee);
+            SendScannerLinksJob::dispatch($assignee, $rawAuthCode);
         }
     }
 }

--- a/app/Enums/AttendanceStatus.php
+++ b/app/Enums/AttendanceStatus.php
@@ -7,4 +7,6 @@ enum AttendanceStatus: string
     case OnTime = 'on_time';
     case Late = 'late';
     case NoShow = 'no_show';
+    case EnRoute = 'en_route';
+    case Excused = 'excused';
 }

--- a/app/Http/Controllers/ScannerDataController.php
+++ b/app/Http/Controllers/ScannerDataController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Actions\CheckInGuest;
 use App\Actions\RecordArrival;
+use App\Actions\RecordAttendance;
 use App\Actions\RecordGearPickup;
 use App\Actions\RecordGuestGearPickup;
 use App\Enums\ArrivalMethod;
+use App\Enums\AttendanceStatus;
 use App\Enums\ScannerType;
 use App\Exceptions\DomainException;
 use App\Models\AttendanceRecord;
@@ -16,6 +18,7 @@ use App\Models\GuestEntry;
 use App\Models\GuestEntryGear;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
+use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
@@ -152,6 +155,7 @@ class ScannerDataController extends Controller
             'guest_entries' => $guestEntries,
             'gear_items' => $gearItems,
             'volunteer_gear' => $volunteerGearMap,
+            'attendance_states' => $scanner->project->active_attendance_states,
         ]);
     }
 
@@ -362,6 +366,47 @@ class ScannerDataController extends Controller
 
         return response()->json([
             'guest_entries' => $guestEntries,
+        ]);
+    }
+
+    public function attendance(
+        int $scannerId,
+        Request $request,
+        RecordAttendance $recordAttendance,
+    ): JsonResponse {
+        /** @var ProjectScanner $scanner */
+        $scanner = $request->attributes->get('scanner');
+
+        if ($scanner->id !== $scannerId) {
+            return response()->json(['error' => 'Scanner ID mismatch.'], 403);
+        }
+
+        if ($scanner->type !== ScannerType::VolunteerAdmin) {
+            return response()->json(['error' => 'Only volunteer admin scanners can record attendance.'], 403);
+        }
+
+        $activeKeys = collect($scanner->project->active_attendance_states)->pluck('key')->all();
+
+        $request->validate([
+            'shift_signup_id' => ['required', 'integer'],
+            'status' => ['required', 'string', Rule::in($activeKeys)],
+        ]);
+
+        $signup = ShiftSignup::whereHas('shift.volunteerJob.event', fn ($q) => $q->where('project_id', $scanner->project_id))
+            ->findOrFail($request->integer('shift_signup_id'));
+
+        $record = $recordAttendance->execute(
+            $signup,
+            AttendanceStatus::from($request->input('status')),
+        );
+
+        return response()->json([
+            'success' => true,
+            'attendance_record' => [
+                'id' => $record->id,
+                'shift_signup_id' => $record->shift_signup_id,
+                'status' => $record->status->value,
+            ],
         ]);
     }
 

--- a/app/Jobs/SendScannerLinksJob.php
+++ b/app/Jobs/SendScannerLinksJob.php
@@ -19,7 +19,10 @@ class SendScannerLinksJob implements ShouldQueue
 
     public int $timeout = 30;
 
-    public function __construct(public ProjectScannerAssignee $assignee) {}
+    public function __construct(
+        public ProjectScannerAssignee $assignee,
+        public ?string $rawAuthCode = null,
+    ) {}
 
     public function handle(): void
     {
@@ -32,7 +35,7 @@ class SendScannerLinksJob implements ShouldQueue
         $url = route('scanner.auth', $scanner->scanner_token);
 
         Mail::to($this->assignee->email)
-            ->send(new ScannerLinkMail($scanner, $url));
+            ->send(new ScannerLinkMail($scanner, $url, $this->rawAuthCode));
 
         $this->assignee->update(['link_sent_at' => now()]);
     }

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -171,7 +171,7 @@ class Dashboard extends Component
     }
 
     /**
-     * @return array{on_time: int, late: int, no_show: int, unmarked: int}
+     * @return array{on_time: int, late: int, no_show: int, en_route: int, excused: int, unmarked: int}
      */
     #[Computed]
     public function attendanceSummary(): array
@@ -194,12 +194,16 @@ class Dashboard extends Component
         $onTime = $counts[AttendanceStatus::OnTime->value] ?? 0;
         $late = $counts[AttendanceStatus::Late->value] ?? 0;
         $noShow = $counts[AttendanceStatus::NoShow->value] ?? 0;
+        $enRoute = $counts[AttendanceStatus::EnRoute->value] ?? 0;
+        $excused = $counts[AttendanceStatus::Excused->value] ?? 0;
 
         return [
             'on_time' => $onTime,
             'late' => $late,
             'no_show' => $noShow,
-            'unmarked' => $totalSignups - $onTime - $late - $noShow,
+            'en_route' => $enRoute,
+            'excused' => $excused,
+            'unmarked' => $totalSignups - $onTime - $late - $noShow - $enRoute - $excused,
         ];
     }
 
@@ -207,7 +211,7 @@ class Dashboard extends Component
     public function noShowRate(): float
     {
         $summary = $this->attendanceSummary;
-        $total = $summary['on_time'] + $summary['late'] + $summary['no_show'];
+        $total = $summary['on_time'] + $summary['late'] + $summary['no_show'] + $summary['en_route'] + $summary['excused'];
 
         if ($total === 0) {
             return 0;

--- a/app/Livewire/Events/AttendanceTracker.php
+++ b/app/Livewire/Events/AttendanceTracker.php
@@ -26,6 +26,13 @@ class AttendanceTracker extends Component
         Gate::authorize('markAttendance', $this->event);
     }
 
+    /** @return array<int, array{key: string, label: string, active: bool, core: bool}> */
+    #[Computed]
+    public function attendanceStates(): array
+    {
+        return $this->event->project->active_attendance_states;
+    }
+
     #[Computed]
     public function shifts(): Collection
     {
@@ -61,6 +68,11 @@ class AttendanceTracker extends Component
     public function markStatus(int $signupId, string $status): void
     {
         Gate::authorize('markAttendance', $this->event);
+
+        $activeKeys = collect($this->attendanceStates)->pluck('key')->all();
+        if (! in_array($status, $activeKeys, true)) {
+            return;
+        }
 
         $signup = ShiftSignup::whereHas('shift.volunteerJob', fn ($q) => $q->where('event_id', $this->event->id))
             ->findOrFail($signupId);

--- a/app/Livewire/Projects/AttendanceStatesSettings.php
+++ b/app/Livewire/Projects/AttendanceStatesSettings.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Livewire\Projects;
+
+use App\Enums\AttendanceStatus;
+use App\Models\Project;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Attendance States')]
+class AttendanceStatesSettings extends Component
+{
+    #[Locked]
+    public Project $project;
+
+    /** @var array<int, array{key: string, label: string, active: bool, core: bool}> */
+    public array $states = [];
+
+    public function mount(int $projectId): void
+    {
+        $this->project = currentOrganization()->projects()->findOrFail($projectId);
+
+        Gate::authorize('update', $this->project);
+
+        $this->states = $this->project->all_attendance_states;
+    }
+
+    public function save(): void
+    {
+        $validKeys = array_column(AttendanceStatus::cases(), 'value');
+
+        $rules = [];
+        foreach ($this->states as $i => $state) {
+            $rules["states.{$i}.label"] = ['required', 'string', 'max:50'];
+            $rules["states.{$i}.key"] = ['required', 'string', 'in:'.implode(',', $validKeys)];
+            $rules["states.{$i}.active"] = ['required', 'boolean'];
+
+            if ($state['core'] ?? false) {
+                $rules["states.{$i}.active"] = ['required', 'boolean', 'accepted'];
+            }
+        }
+
+        $this->validate($rules);
+
+        $this->project->update(['attendance_states' => $this->states]);
+    }
+}

--- a/app/Livewire/Projects/ScannerManagement.php
+++ b/app/Livewire/Projects/ScannerManagement.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Projects;
 
 use App\Actions\CreateProjectScanner;
 use App\Actions\DeleteProjectScanner;
+use App\Actions\RegenerateAuthCode;
 use App\Actions\SendScannerLinks;
 use App\Actions\UpdateProjectScanner;
 use App\Concerns\ConvertsTimezone;
@@ -161,6 +162,25 @@ class ScannerManagement extends Component
 
         $this->showDeleteConfirm = false;
         $this->deletingScannerId = null;
+        unset($this->scanners);
+    }
+
+    public function regenerateAuthCode(int $scannerId): void
+    {
+        $scanner = ProjectScanner::where('project_id', $this->projectId)
+            ->findOrFail($scannerId);
+
+        $action = new RegenerateAuthCode;
+        $rawCode = $action->execute($scanner);
+
+        session()->flash('rawAuthCode', [
+            'id' => $scanner->id,
+            'code' => $rawCode,
+        ]);
+
+        $sendLinks = new SendScannerLinks;
+        $sendLinks->execute($scanner, $rawCode);
+
         unset($this->scanners);
     }
 

--- a/app/Mail/ScannerLinkMail.php
+++ b/app/Mail/ScannerLinkMail.php
@@ -16,6 +16,7 @@ class ScannerLinkMail extends Mailable
     public function __construct(
         public ProjectScanner $scanner,
         public string $url,
+        public ?string $authCode = null,
     ) {}
 
     public function envelope(): Envelope
@@ -34,6 +35,7 @@ class ScannerLinkMail extends Mailable
                 'url' => $this->url,
                 'startsAt' => $this->scanner->starts_at->setTimezone($this->scanner->project->timezone ?? 'UTC')->format('M d, Y H:i'),
                 'endsAt' => $this->scanner->ends_at->setTimezone($this->scanner->project->timezone ?? 'UTC')->format('M d, Y H:i'),
+                'authCode' => $this->authCode,
             ],
         );
     }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -32,6 +32,7 @@ class Project extends Model
         'website_description',
         'website_contact_info',
         'website_published',
+        'attendance_states',
         'deletion_requested_at',
     ];
 
@@ -39,9 +40,36 @@ class Project extends Model
     {
         return [
             'cancellation_enabled' => 'boolean',
+            'attendance_states' => 'array',
             'cancellation_cutoff_hours' => 'integer',
             'website_published' => 'boolean',
             'deletion_requested_at' => 'datetime',
+        ];
+    }
+
+    /** @return array<int, array{key: string, label: string, active: bool, core: bool}> */
+    public function getActiveAttendanceStatesAttribute(): array
+    {
+        $states = $this->attendance_states ?? self::defaultAttendanceStates();
+
+        return array_values(array_filter($states, fn ($s) => ($s['active'] ?? false)));
+    }
+
+    /** @return array<int, array{key: string, label: string, active: bool, core: bool}> */
+    public function getAllAttendanceStatesAttribute(): array
+    {
+        return $this->attendance_states ?? self::defaultAttendanceStates();
+    }
+
+    /** @return array<int, array{key: string, label: string, active: bool, core: bool}> */
+    public static function defaultAttendanceStates(): array
+    {
+        return [
+            ['key' => 'on_time', 'label' => 'Pünktlich', 'active' => true, 'core' => true],
+            ['key' => 'late', 'label' => 'Verspätet', 'active' => true, 'core' => false],
+            ['key' => 'en_route', 'label' => 'Unterwegs', 'active' => true, 'core' => false],
+            ['key' => 'excused', 'label' => 'Entschuldigt', 'active' => true, 'core' => false],
+            ['key' => 'no_show', 'label' => 'Nicht erschienen', 'active' => true, 'core' => true],
         ];
     }
 

--- a/database/migrations/2026_04_08_183256_add_attendance_states_to_projects_table.php
+++ b/database/migrations/2026_04_08_183256_add_attendance_states_to_projects_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->json('attendance_states')->nullable()->after('cancellation_cutoff_hours');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('attendance_states');
+        });
+    }
+};

--- a/resources/views/components/projects/tab-nav.blade.php
+++ b/resources/views/components/projects/tab-nav.blade.php
@@ -67,6 +67,14 @@
             {{ __('Website') }}
         </flux:navlist.item>
         <flux:navlist.item
+            :href="route('projects.attendance-states', $project)"
+            :current="request()->routeIs('projects.attendance-states')"
+            icon="clipboard-document-check"
+            wire:navigate
+        >
+            {{ __('Anwesenheit') }}
+        </flux:navlist.item>
+        <flux:navlist.item
             :href="route('projects.hint-texts', $project)"
             :current="request()->routeIs('projects.hint-texts')"
             icon="information-circle"

--- a/resources/views/livewire/events/attendance-tracker.blade.php
+++ b/resources/views/livewire/events/attendance-tracker.blade.php
@@ -64,6 +64,7 @@
                                                 \App\Enums\AttendanceStatus::OnTime => 'emerald',
                                                 \App\Enums\AttendanceStatus::Late => 'amber',
                                                 \App\Enums\AttendanceStatus::NoShow => 'red',
+                                                default => 'zinc',
                                             };
                                         @endphp
                                         <flux:badge size="sm" :color="$color">{{ $signup->attendanceRecord->status->name }}</flux:badge>
@@ -73,33 +74,33 @@
                                 </flux:table.cell>
                                 <flux:table.cell align="end">
                                     <div class="flex items-center justify-end gap-1">
-                                        <flux:button
-                                            size="xs"
-                                            :variant="$signup->attendanceRecord?->status === \App\Enums\AttendanceStatus::OnTime ? 'primary' : 'ghost'"
-                                            wire:click="markStatus({{ $signup->id }}, 'on_time')"
-                                            title="{{ __('On Time') }}"
-                                        >
-                                            <flux:icon name="check" class="size-4 sm:hidden" />
-                                            <span class="hidden sm:inline">{{ __('On Time') }}</span>
-                                        </flux:button>
-                                        <flux:button
-                                            size="xs"
-                                            :variant="$signup->attendanceRecord?->status === \App\Enums\AttendanceStatus::Late ? 'primary' : 'ghost'"
-                                            wire:click="markStatus({{ $signup->id }}, 'late')"
-                                            title="{{ __('Late') }}"
-                                        >
-                                            <flux:icon name="clock" class="size-4 sm:hidden" />
-                                            <span class="hidden sm:inline">{{ __('Late') }}</span>
-                                        </flux:button>
-                                        <flux:button
-                                            size="xs"
-                                            :variant="$signup->attendanceRecord?->status === \App\Enums\AttendanceStatus::NoShow ? 'danger' : 'ghost'"
-                                            wire:click="markStatus({{ $signup->id }}, 'no_show')"
-                                            title="{{ __('No Show') }}"
-                                        >
-                                            <flux:icon name="x-mark" class="size-4 sm:hidden" />
-                                            <span class="hidden sm:inline">{{ __('No Show') }}</span>
-                                        </flux:button>
+                                        @foreach ($this->attendanceStates as $state)
+                                            @php
+                                                $isActive = $signup->attendanceRecord?->status?->value === $state['key'];
+                                                $variant = match(true) {
+                                                    $isActive && $state['key'] === 'no_show' => 'danger',
+                                                    $isActive => 'primary',
+                                                    default => 'ghost',
+                                                };
+                                                $icon = match($state['key']) {
+                                                    'on_time' => 'check',
+                                                    'late' => 'clock',
+                                                    'no_show' => 'x-mark',
+                                                    'en_route' => 'arrow-right',
+                                                    'excused' => 'shield-check',
+                                                    default => 'tag',
+                                                };
+                                            @endphp
+                                            <flux:button
+                                                size="xs"
+                                                :variant="$variant"
+                                                wire:click="markStatus({{ $signup->id }}, '{{ $state['key'] }}')"
+                                                title="{{ $state['label'] }}"
+                                            >
+                                                <flux:icon :name="$icon" class="size-4 sm:hidden" />
+                                                <span class="hidden sm:inline">{{ $state['label'] }}</span>
+                                            </flux:button>
+                                        @endforeach
                                     </div>
                                 </flux:table.cell>
                             </flux:table.row>

--- a/resources/views/livewire/events/volunteer-detail.blade.php
+++ b/resources/views/livewire/events/volunteer-detail.blade.php
@@ -108,6 +108,7 @@
                                             \App\Enums\AttendanceStatus::OnTime => 'emerald',
                                             \App\Enums\AttendanceStatus::Late => 'amber',
                                             \App\Enums\AttendanceStatus::NoShow => 'red',
+                                            default => 'zinc',
                                         };
                                     @endphp
                                     <flux:badge size="sm" :color="$color">{{ $signup->attendanceRecord->status->name }}</flux:badge>

--- a/resources/views/livewire/projects/attendance-states-settings.blade.php
+++ b/resources/views/livewire/projects/attendance-states-settings.blade.php
@@ -1,0 +1,46 @@
+<div class="mx-auto max-w-7xl p-6">
+    <div class="flex items-center gap-3 mb-4">
+        <flux:button variant="ghost" icon="arrow-left" :href="route('projects.show', $project)" wire:navigate aria-label="{{ __('Back to project') }}" />
+        <flux:heading size="xl">{{ $project->name }}</flux:heading>
+    </div>
+
+    <x-projects.layout :project="$project">
+        <div class="flex items-center justify-between mb-6">
+            <flux:heading size="lg">{{ __('Attendance States') }}</flux:heading>
+        </div>
+
+        <flux:text class="mb-6">{{ __('Customize the labels and availability of attendance states for this project. Core states cannot be deactivated.') }}</flux:text>
+
+        <div class="space-y-3">
+            @foreach ($states as $i => $state)
+                <flux:card wire:key="state-{{ $state['key'] }}">
+                    <div class="flex items-center gap-4">
+                        <div class="flex-1">
+                            <flux:field>
+                                <flux:label>{{ $state['key'] }}</flux:label>
+                                <flux:input wire:model="states.{{ $i }}.label" placeholder="{{ $state['key'] }}" />
+                                <flux:error name="states.{{ $i }}.label" />
+                            </flux:field>
+                        </div>
+
+                        <div class="flex items-center gap-2">
+                            @if ($state['core'])
+                                <flux:badge size="sm" color="blue">{{ __('Core') }}</flux:badge>
+                            @else
+                                <flux:checkbox
+                                    wire:model="states.{{ $i }}.active"
+                                    label="{{ __('Active') }}"
+                                />
+                            @endif
+                            <flux:error name="states.{{ $i }}.active" />
+                        </div>
+                    </div>
+                </flux:card>
+            @endforeach
+        </div>
+
+        <div class="mt-6 flex justify-end">
+            <flux:button variant="primary" wire:click="save">{{ __('Save') }}</flux:button>
+        </div>
+    </x-projects.layout>
+</div>

--- a/resources/views/livewire/projects/scanner-management.blade.php
+++ b/resources/views/livewire/projects/scanner-management.blade.php
@@ -112,6 +112,14 @@
                             <flux:button size="sm" icon="paper-airplane" wire:click="sendLinks({{ $scanner->id }})" title="{{ __('Send links') }}">
                                 {{ __('Send Links') }}
                             </flux:button>
+                            <flux:button
+                                size="sm"
+                                variant="ghost"
+                                icon="arrow-path"
+                                wire:click="regenerateAuthCode({{ $scanner->id }})"
+                                wire:confirm="{{ __('This will generate a new auth code and email it to all assignees. The old code will stop working. Continue?') }}"
+                                title="{{ __('Regenerate Auth Code') }}"
+                            />
                             <flux:button size="sm" variant="ghost" icon="pencil" wire:click="editScanner({{ $scanner->id }})" title="{{ __('Edit') }}" />
                             <flux:button size="sm" variant="ghost" icon="trash" wire:click="confirmDelete({{ $scanner->id }})" title="{{ __('Delete') }}" />
                         </div>

--- a/resources/views/livewire/public/volunteer-portal.blade.php
+++ b/resources/views/livewire/public/volunteer-portal.blade.php
@@ -251,6 +251,12 @@
                                             @case(\App\Enums\AttendanceStatus::NoShow)
                                                 <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Nicht erschienen') }}</span>
                                                 @break
+                                            @case(\App\Enums\AttendanceStatus::EnRoute)
+                                                <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Unterwegs') }}</span>
+                                                @break
+                                            @case(\App\Enums\AttendanceStatus::Excused)
+                                                <span class="text-xs font-semibold px-2.5 py-1 rounded" style="background: rgba(107,114,128,0.15); color: #d1d5db;">{{ __('Entschuldigt') }}</span>
+                                                @break
                                         @endswitch
                                     @else
                                         <span class="text-xs" style="color: #9a9a9a;">—</span>

--- a/resources/views/mail/scanner-link.blade.php
+++ b/resources/views/mail/scanner-link.blade.php
@@ -9,7 +9,13 @@ You have been assigned as a scanner operator. Click the link below to access the
 Open Scanner
 </x-mail::button>
 
+@if ($authCode)
+**Your Auth Code:** `{{ $authCode }}`
+
+Keep this code secure and do not share it publicly.
+@else
 You will need the auth code provided by your organizer to log in.
+@endif
 
 Thanks,<br>
 {{ config('app.name') }}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,4 +15,5 @@ Route::prefix('scanner')->middleware(['scanner-api', 'throttle:60,1'])->group(fu
     Route::post('/{scannerId}/guest-checkin', [ScannerDataController::class, 'guestCheckin'])->name('scanner-api.guest-checkin');
     Route::post('/{scannerId}/guest-gear-pickup', [ScannerDataController::class, 'guestGearPickup'])->name('scanner-api.guest-gear-pickup');
     Route::post('/{scannerId}/guest-sync', [ScannerDataController::class, 'guestSync'])->name('scanner-api.guest-sync');
+    Route::post('/{scannerId}/attendance', [ScannerDataController::class, 'attendance'])->name('scanner-api.attendance');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Livewire\Events\ProjectShow;
 use App\Livewire\Events\VolunteerDetail;
 use App\Livewire\Events\VolunteerList;
 use App\Livewire\Projects\AnnouncementComposer;
+use App\Livewire\Projects\AttendanceStatesSettings;
 use App\Livewire\Projects\GearSummary;
 use App\Livewire\Projects\GuestListIndex;
 use App\Livewire\Projects\GuestListShow;
@@ -82,6 +83,7 @@ Route::prefix('admin')->middleware(['auth', 'verified', 'resolve-org'])->group(f
     Route::livewire('projects/{projectId}/members', ProjectMembers::class)->name('projects.members');
     Route::livewire('projects/{projectId}/scanners', ScannerManagement::class)->name('projects.scanners');
     Route::livewire('projects/{projectId}/hint-texts', HintTextSettings::class)->name('projects.hint-texts');
+    Route::livewire('projects/{projectId}/attendance-states', AttendanceStatesSettings::class)->name('projects.attendance-states');
     Route::livewire('projects/{projectId}/website', ProjectWebsiteEditor::class)->name('projects.website-editor');
     Route::livewire('projects/{projectId}/gear-summary', GearSummary::class)->name('projects.gear-summary');
     Route::livewire('projects/{projectId}/guest-lists', GuestListIndex::class)->name('guest-lists.index');

--- a/tests/Feature/Actions/CreateProjectTest.php
+++ b/tests/Feature/Actions/CreateProjectTest.php
@@ -83,6 +83,25 @@ it('creates project without image', function () {
     expect($project->title_image_path)->toBeNull();
 });
 
+it('sets default attendance states on new project', function () {
+    $action = new CreateProject;
+
+    $project = $action->execute(
+        organization: $this->org,
+        name: 'Attendance Project',
+        causer: $this->user,
+    );
+
+    expect($project->attendance_states)->toBeArray()
+        ->toHaveCount(5);
+
+    $keys = array_column($project->attendance_states, 'key');
+    expect($keys)->toBe(['on_time', 'late', 'en_route', 'excused', 'no_show']);
+
+    $coreStates = array_filter($project->attendance_states, fn ($s) => $s['core']);
+    expect($coreStates)->toHaveCount(2);
+});
+
 it('dispatches ProjectCreatedActivity event with causer', function () {
     Event::fake([ProjectCreatedActivity::class]);
 

--- a/tests/Feature/Actions/MarkNoShowsTest.php
+++ b/tests/Feature/Actions/MarkNoShowsTest.php
@@ -88,6 +88,46 @@ it('skips cancelled signups', function () {
     expect($count)->toBe(0);
 });
 
+it('skips signups marked as en_route', function () {
+    $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->subHours(5),
+        'ends_at' => now()->subHours(3),
+    ]);
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::EnRoute,
+    ]);
+
+    $count = app(MarkNoShows::class)->execute();
+
+    expect($count)->toBe(0);
+});
+
+it('skips signups marked as excused', function () {
+    $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->subHours(5),
+        'ends_at' => now()->subHours(3),
+    ]);
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+        'status' => AttendanceStatus::Excused,
+    ]);
+
+    $count = app(MarkNoShows::class)->execute();
+
+    expect($count)->toBe(0);
+});
+
 it('respects two-hour buffer', function () {
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'starts_at' => now()->subHours(2),

--- a/tests/Feature/Actions/RecordAttendanceTest.php
+++ b/tests/Feature/Actions/RecordAttendanceTest.php
@@ -95,3 +95,17 @@ it('does not detect conflict for arrival at a different event', function () {
 
     expect($record->conflictDetected)->toBeFalse();
 });
+
+it('records attendance with en_route status', function () {
+    $record = $this->action->execute($this->signup, AttendanceStatus::EnRoute, $this->recorder);
+
+    expect($record->status)->toBe(AttendanceStatus::EnRoute)
+        ->and($record->conflictDetected)->toBeFalse();
+});
+
+it('records attendance with excused status', function () {
+    $record = $this->action->execute($this->signup, AttendanceStatus::Excused, $this->recorder);
+
+    expect($record->status)->toBe(AttendanceStatus::Excused)
+        ->and($record->conflictDetected)->toBeFalse();
+});

--- a/tests/Feature/Actions/RegenerateAuthCodeTest.php
+++ b/tests/Feature/Actions/RegenerateAuthCodeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Actions\RegenerateAuthCode;
+use App\Models\ProjectScanner;
+use Illuminate\Support\Facades\Hash;
+
+it('generates a new 6-digit code', function () {
+    $scanner = ProjectScanner::factory()->active()->create();
+
+    $action = new RegenerateAuthCode;
+    $rawCode = $action->execute($scanner);
+
+    expect($rawCode)->toMatch('/^\d{6}$/');
+});
+
+it('stores bcrypt hash of new code', function () {
+    $scanner = ProjectScanner::factory()->active()->create();
+
+    $action = new RegenerateAuthCode;
+    $rawCode = $action->execute($scanner);
+
+    $scanner->refresh();
+    expect(Hash::check($rawCode, $scanner->auth_code))->toBeTrue();
+});
+
+it('changes the auth code from previous value', function () {
+    $scanner = ProjectScanner::factory()->active()->create();
+    $oldHash = $scanner->auth_code;
+
+    $action = new RegenerateAuthCode;
+    $action->execute($scanner);
+
+    $scanner->refresh();
+    expect($scanner->auth_code)->not->toBe($oldHash);
+});

--- a/tests/Feature/Events/AttendanceTrackerTest.php
+++ b/tests/Feature/Events/AttendanceTrackerTest.php
@@ -142,6 +142,63 @@ it('excludes cancelled signups from attendance view', function () {
         ->assertDontSee('Cancelled Volunteer');
 });
 
+it('renders all active attendance states from project configuration', function () {
+    $this->project->update(['attendance_states' => Project::defaultAttendanceStates()]);
+
+    $volunteer = Volunteer::factory()->create();
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $this->shift->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(AttendanceTracker::class, ['eventId' => $this->event->id])
+        ->set('selectedShiftId', $this->shift->id)
+        ->assertSee('Pünktlich')
+        ->assertSee('Verspätet')
+        ->assertSee('Nicht erschienen')
+        ->assertSee('Unterwegs')
+        ->assertSee('Entschuldigt');
+});
+
+it('hides deactivated attendance states', function () {
+    $states = Project::defaultAttendanceStates();
+    $states[2]['active'] = false; // en_route
+    $states[3]['active'] = false; // excused
+    $this->project->update(['attendance_states' => $states]);
+
+    $volunteer = Volunteer::factory()->create();
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $this->shift->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(AttendanceTracker::class, ['eventId' => $this->event->id])
+        ->set('selectedShiftId', $this->shift->id)
+        ->assertSee('Pünktlich')
+        ->assertDontSee('Unterwegs')
+        ->assertDontSee('Entschuldigt');
+});
+
+it('uses custom labels from project configuration', function () {
+    $states = Project::defaultAttendanceStates();
+    $states[0]['label'] = 'Rechtzeitig';
+    $this->project->update(['attendance_states' => $states]);
+
+    $volunteer = Volunteer::factory()->create();
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $this->shift->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(AttendanceTracker::class, ['eventId' => $this->event->id])
+        ->set('selectedShiftId', $this->shift->id)
+        ->assertSee('Rechtzeitig')
+        ->assertDontSee('Pünktlich');
+});
+
 it('shows empty state when no shift selected', function () {
     Livewire::actingAs($this->user)
         ->test(AttendanceTracker::class, ['eventId' => $this->event->id])

--- a/tests/Feature/Http/ScannerAttendanceApiTest.php
+++ b/tests/Feature/Http/ScannerAttendanceApiTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Enums\AttendanceStatus;
+use App\Enums\ScannerType;
+use App\Models\AttendanceRecord;
+use App\Models\Event;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
+use App\Models\Volunteer;
+use App\Models\VolunteerJob;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-01 12:00:00');
+    $this->project = Project::factory()->create([
+        'attendance_states' => Project::defaultAttendanceStates(),
+    ]);
+    $this->event = Event::factory()->for($this->project)->create();
+    $this->job = VolunteerJob::factory()->for($this->event)->create();
+    $this->shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => '09:00',
+        'ends_at' => '17:00',
+    ]);
+    $this->volunteer = Volunteer::factory()->for($this->project)->create();
+    $this->signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->shift->id,
+    ]);
+    $this->scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+        'type' => ScannerType::VolunteerAdmin,
+    ]);
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+it('records attendance for valid shift signup', function () {
+    $response = $this->postJson(
+        route('scanner-api.attendance', $this->scanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'on_time',
+        ],
+        ['X-Scanner-Token' => $this->scanner->scanner_token],
+    );
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('attendance_record.status', 'on_time');
+
+    expect(AttendanceRecord::where('shift_signup_id', $this->signup->id)->exists())->toBeTrue();
+});
+
+it('returns 403 for entry staff scanner', function () {
+    $entryScanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $this->postJson(
+        route('scanner-api.attendance', $entryScanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'on_time',
+        ],
+        ['X-Scanner-Token' => $entryScanner->scanner_token],
+    )->assertForbidden();
+});
+
+it('returns 422 for invalid status', function () {
+    $this->postJson(
+        route('scanner-api.attendance', $this->scanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'totally_invalid',
+        ],
+        ['X-Scanner-Token' => $this->scanner->scanner_token],
+    )->assertUnprocessable();
+});
+
+it('returns 422 for inactive status', function () {
+    $states = $this->project->attendance_states;
+    $states[2]['active'] = false; // en_route
+    $this->project->update(['attendance_states' => $states]);
+
+    $this->postJson(
+        route('scanner-api.attendance', $this->scanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'en_route',
+        ],
+        ['X-Scanner-Token' => $this->scanner->scanner_token],
+    )->assertUnprocessable();
+});
+
+it('updates existing attendance record on re-post', function () {
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $this->signup->id,
+        'status' => AttendanceStatus::Late,
+    ]);
+
+    $this->postJson(
+        route('scanner-api.attendance', $this->scanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'on_time',
+        ],
+        ['X-Scanner-Token' => $this->scanner->scanner_token],
+    )->assertOk();
+
+    expect(AttendanceRecord::where('shift_signup_id', $this->signup->id)->count())->toBe(1);
+    expect(AttendanceRecord::where('shift_signup_id', $this->signup->id)->first()->status)
+        ->toBe(AttendanceStatus::OnTime);
+});
+
+it('scopes shift signup to scanner project', function () {
+    $otherProject = Project::factory()->create();
+    $otherEvent = Event::factory()->for($otherProject)->create();
+    $otherJob = VolunteerJob::factory()->for($otherEvent)->create();
+    $otherShift = Shift::factory()->for($otherJob, 'volunteerJob')->create();
+    $otherVolunteer = Volunteer::factory()->for($otherProject)->create();
+    $otherSignup = ShiftSignup::factory()->create([
+        'volunteer_id' => $otherVolunteer->id,
+        'shift_id' => $otherShift->id,
+    ]);
+
+    $this->postJson(
+        route('scanner-api.attendance', $this->scanner->id),
+        [
+            'shift_signup_id' => $otherSignup->id,
+            'status' => 'on_time',
+        ],
+        ['X-Scanner-Token' => $this->scanner->scanner_token],
+    )->assertNotFound();
+});

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -52,6 +52,39 @@ it('returns scanner data with valid token', function () {
         ->assertJsonPath('scanner.type', ScannerType::EntryStaff->value);
 });
 
+it('includes attendance_states in data response', function () {
+    $this->project->update(['attendance_states' => Project::defaultAttendanceStates()]);
+
+    $scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['attendance_states'])
+        ->assertJsonCount(5, 'attendance_states');
+});
+
+it('returns default states for projects with null attendance_states', function () {
+    $this->project->update(['attendance_states' => null]);
+
+    $scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(5, 'attendance_states');
+});
+
 it('returns 401 for expired scanner token', function () {
     $scanner = ProjectScanner::factory()->expired()->create([
         'project_id' => $this->project->id,

--- a/tests/Feature/Jobs/SendScannerLinksJobTest.php
+++ b/tests/Feature/Jobs/SendScannerLinksJobTest.php
@@ -64,6 +64,43 @@ it('includes correct scanner auth URL in mail', function () {
     Carbon::setTestNow();
 });
 
+it('passes auth code to ScannerLinkMail when provided', function () {
+    Mail::fake();
+    Carbon::setTestNow('2026-07-01 12:00:00');
+
+    $scanner = ProjectScanner::factory()->active()->create();
+    $assignee = ProjectScannerAssignee::factory()->for($scanner, 'projectScanner')->create([
+        'email' => 'staff@example.com',
+    ]);
+
+    $job = new SendScannerLinksJob($assignee, '654321');
+    $job->handle();
+
+    Mail::assertSent(ScannerLinkMail::class, function ($mail) {
+        return $mail->hasTo('staff@example.com')
+            && $mail->authCode === '654321';
+    });
+
+    Carbon::setTestNow();
+});
+
+it('sends mail without auth code when none provided', function () {
+    Mail::fake();
+    Carbon::setTestNow('2026-07-01 12:00:00');
+
+    $scanner = ProjectScanner::factory()->active()->create();
+    $assignee = ProjectScannerAssignee::factory()->for($scanner, 'projectScanner')->create();
+
+    $job = new SendScannerLinksJob($assignee);
+    $job->handle();
+
+    Mail::assertSent(ScannerLinkMail::class, function ($mail) {
+        return $mail->authCode === null;
+    });
+
+    Carbon::setTestNow();
+});
+
 it('is configured as retryable with backoff', function () {
     $assignee = ProjectScannerAssignee::factory()->create();
     $job = new SendScannerLinksJob($assignee);

--- a/tests/Feature/Livewire/Projects/AttendanceStatesSettingsTest.php
+++ b/tests/Feature/Livewire/Projects/AttendanceStatesSettingsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Enums\StaffRole;
+use App\Livewire\Projects\AttendanceStatesSettings;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    ['user' => $this->organizer, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
+    $this->project = Project::factory()->for($this->org)->create([
+        'attendance_states' => Project::defaultAttendanceStates(),
+    ]);
+    app()->instance(Organization::class, $this->org);
+});
+
+it('renders current attendance states', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(AttendanceStatesSettings::class, ['projectId' => $this->project->id])
+        ->assertSee('on_time')
+        ->assertSee('late')
+        ->assertSee('en_route')
+        ->assertSee('excused')
+        ->assertSee('no_show')
+        ->assertSee('Attendance States');
+});
+
+it('allows renaming a state label', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(AttendanceStatesSettings::class, ['projectId' => $this->project->id])
+        ->set('states.0.label', 'Rechtzeitig')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $this->project->refresh();
+    expect($this->project->attendance_states[0]['label'])->toBe('Rechtzeitig');
+});
+
+it('prevents deactivating core states', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(AttendanceStatesSettings::class, ['projectId' => $this->project->id])
+        ->set('states.0.active', false) // on_time is core
+        ->call('save')
+        ->assertHasErrors('states.0.active');
+});
+
+it('allows deactivating non-core states', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(AttendanceStatesSettings::class, ['projectId' => $this->project->id])
+        ->set('states.1.active', false) // late is non-core
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $this->project->refresh();
+    expect($this->project->attendance_states[1]['active'])->toBeFalse();
+});
+
+it('validates state data before saving', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(AttendanceStatesSettings::class, ['projectId' => $this->project->id])
+        ->set('states.0.label', '') // empty label
+        ->call('save')
+        ->assertHasErrors('states.0.label');
+});
+
+it('requires organizer authorization', function () {
+    $volunteerAdmin = User::factory()->create();
+    $this->org->users()->attach($volunteerAdmin, ['role' => StaffRole::VolunteerAdmin]);
+
+    $this->actingAs($volunteerAdmin)
+        ->get(route('projects.attendance-states', $this->project))
+        ->assertForbidden();
+});

--- a/tests/Feature/Livewire/ScannerManagementTest.php
+++ b/tests/Feature/Livewire/ScannerManagementTest.php
@@ -11,6 +11,7 @@ use App\Models\Project;
 use App\Models\ProjectScanner;
 use App\Models\ProjectScannerAssignee;
 use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 
@@ -135,6 +136,64 @@ it('removes an assignee from a scanner', function () {
 
     expect(ProjectScannerAssignee::find($assignee->id))->toBeNull();
 });
+
+it('regenerates auth code and flashes new code', function () {
+    $scanner = ProjectScanner::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $oldHash = $scanner->auth_code;
+
+    $component = Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->call('regenerateAuthCode', $scanner->id)
+        ->assertHasNoErrors();
+
+    $scanner->refresh();
+    expect($scanner->auth_code)->not->toBe($oldHash);
+});
+
+it('dispatches SendScannerLinksJob with new code to all assignees after regeneration', function () {
+    Queue::fake();
+
+    $scanner = ProjectScanner::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+    ProjectScannerAssignee::factory()->count(2)->for($scanner, 'projectScanner')->create();
+
+    Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->call('regenerateAuthCode', $scanner->id);
+
+    Queue::assertPushed(SendScannerLinksJob::class, 2);
+    Queue::assertPushed(SendScannerLinksJob::class, function ($job) {
+        return $job->rawAuthCode !== null && preg_match('/^\d{6}$/', $job->rawAuthCode);
+    });
+});
+
+it('does not dispatch jobs when scanner has no assignees on regeneration', function () {
+    Queue::fake();
+
+    $scanner = ProjectScanner::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->call('regenerateAuthCode', $scanner->id);
+
+    Queue::assertNothingPushed();
+});
+
+it('scopes regeneration to project scanners only', function () {
+    $otherProject = Project::factory()->for($this->org)->create();
+    $otherScanner = ProjectScanner::factory()->create([
+        'project_id' => $otherProject->id,
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->call('regenerateAuthCode', $otherScanner->id);
+})->throws(ModelNotFoundException::class);
 
 it('shows error when deleting scanner with guest lists', function () {
     $scanner = ProjectScanner::factory()->create([

--- a/tests/Feature/Mail/ScannerLinkMailTest.php
+++ b/tests/Feature/Mail/ScannerLinkMailTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Mail\ScannerLinkMail;
+use App\Models\ProjectScanner;
+
+it('renders email with auth code when provided', function () {
+    $scanner = ProjectScanner::factory()->active()->create();
+    $url = route('scanner.auth', $scanner->scanner_token);
+
+    $mail = new ScannerLinkMail($scanner, $url, '123456');
+
+    $rendered = $mail->render();
+
+    expect($rendered)->toContain('123456')
+        ->and($rendered)->not->toContain('provided by your organizer');
+});
+
+it('renders email without auth code section when null', function () {
+    $scanner = ProjectScanner::factory()->active()->create();
+    $url = route('scanner.auth', $scanner->scanner_token);
+
+    $mail = new ScannerLinkMail($scanner, $url);
+
+    $rendered = $mail->render();
+
+    expect($rendered)->toContain('provided by your organizer')
+        ->and($rendered)->not->toContain('Your Auth Code');
+});

--- a/tests/Unit/Enums/AttendanceStatusTest.php
+++ b/tests/Unit/Enums/AttendanceStatusTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Enums\AttendanceStatus;
+
+it('has all five expected cases', function () {
+    expect(AttendanceStatus::cases())->toHaveCount(5);
+});
+
+it('backs each case with correct string value', function () {
+    expect(AttendanceStatus::OnTime->value)->toBe('on_time')
+        ->and(AttendanceStatus::Late->value)->toBe('late')
+        ->and(AttendanceStatus::NoShow->value)->toBe('no_show')
+        ->and(AttendanceStatus::EnRoute->value)->toBe('en_route')
+        ->and(AttendanceStatus::Excused->value)->toBe('excused');
+});


### PR DESCRIPTION
## Summary

- **Auth code in scanner emails (#106)**: Include the 6-digit auth code directly in scanner link emails, add a "Regenerate Auth Code" button that generates a new code and automatically re-sends it to all assignees
- **Configurable attendance states (#130)**: Add `EnRoute` and `Excused` to the `AttendanceStatus` enum, per-project attendance state configuration (label customization, toggle active/inactive), `POST /scanner/{id}/attendance` API endpoint, and dynamic attendance buttons in the admin tracker
- **Dashboard & blade fixes**: Update `attendanceSummary` to count all 5 statuses, add default match arms in all blade files with exhaustive match on `AttendanceStatus`

Resolves #106, resolves #130

## Key changes

### Auth Code Management (#106)
- `ScannerLinkMail` accepts optional `$authCode` param, displayed conditionally in email
- `RegenerateAuthCode` action generates new 6-digit code with bcrypt hash
- `ScannerManagement::regenerateAuthCode()` with project-scoping (IDOR guard) and `wire:confirm`
- Auth code threaded through `SendScannerLinks` → `SendScannerLinksJob` → `ScannerLinkMail`

### Configurable Attendance States (#130)
- `AttendanceStatus` enum: added `EnRoute = 'en_route'` and `Excused = 'excused'`
- `projects.attendance_states` JSON column with null-safe accessors (`active_attendance_states`, `all_attendance_states`) and `defaultAttendanceStates()` static method
- `POST /scanner/{id}/attendance` endpoint validates against both enum AND project's active states
- `AttendanceTracker` renders dynamic buttons from project config with active-state validation in `markStatus()`
- `AttendanceStatesSettings` Livewire component: rename labels, toggle non-core states, validation (core states can't be deactivated)
- Dashboard counts all 5 statuses to prevent inflated `unmarked` metric

### Design Decision
Custom states are **label customization only** — the underlying status values are restricted to the 5 fixed enum cases. This avoids enum/database mismatch where `AttendanceStatus::from('custom_key')` would throw.

## Test plan

- [x] 1756 tests pass (0 failures), ~30 new tests added
- [ ] Verify scanner link email displays auth code when provided
- [ ] Verify "Regenerate Auth Code" button generates new code and re-sends emails
- [ ] Verify attendance tracker shows all 5 states with configured labels
- [ ] Verify deactivating a non-core state hides it from tracker buttons
- [ ] Verify `POST /scanner/{id}/attendance` endpoint accepts valid statuses
- [ ] Verify dashboard attendance summary counts all 5 statuses correctly
- [ ] Verify attendance states settings page allows label editing and state toggling