### PR TITLE
fix(signup): require email verification for all volunteers, read-only shifts & gear

### DIFF
--- a/app/Livewire/Public/EmailVerificationPage.php
+++ b/app/Livewire/Public/EmailVerificationPage.php
@@ -34,7 +34,7 @@ class EmailVerificationPage extends Component
             $event = $result->event;
             $this->eventName = $event->name;
             $this->eventPublicToken = $event->public_token;
-            $this->continueSignupUrl = route('events.public', $event->public_token).'?vt='.$result->id;
+            $this->continueSignupUrl = route('events.public', $event->public_token).'?vt='.$result->token_hash;
 
             if ($result->verified_at->lt(now()->subSeconds(5))) {
                 $this->alreadyVerified = true;

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -70,6 +70,10 @@ class EventSignup extends Component
     #[Locked]
     public array $existingShiftIds = [];
 
+    /** @var array<int, string|null> gear_item_id => size */
+    #[Locked]
+    public array $existingGearSelections = [];
+
     #[Locked]
     public bool $isReturningVolunteer = false;
 
@@ -83,10 +87,10 @@ class EventSignup extends Component
             ->where('status', EventStatus::PublishedOpen)
             ->firstOrFail();
 
-        // Cross-device verification: accept ?vt= query param with recently-verified token ID
+        // Cross-device verification: accept ?vt= query param with token hash (unguessable)
         $vt = request()->query('vt');
         if ($vt) {
-            $token = EmailVerificationToken::where('id', $vt)
+            $token = EmailVerificationToken::where('token_hash', $vt)
                 ->where('event_id', $this->event->id)
                 ->whereNotNull('verified_at')
                 ->where('verified_at', '>', now()->subMinutes(30))
@@ -211,9 +215,15 @@ class EventSignup extends Component
 
         $intIds = array_map('intval', $this->selectedShiftIds);
 
+        // Exclude existing shifts from overlap detection — they were already approved
+        $newOnly = array_diff($intIds, $this->existingShiftIds);
+        if (count($newOnly) < 1) {
+            return [];
+        }
+
         $selected = $this->jobs
             ->flatMap(fn ($job) => $job->shifts)
-            ->filter(fn ($shift) => in_array((int) $shift->id, $intIds, true)
+            ->filter(fn ($shift) => in_array((int) $shift->id, $newOnly, true)
                 && $shift->starts_at !== null
                 && $shift->ends_at !== null)
             ->values();
@@ -264,19 +274,7 @@ class EventSignup extends Component
             ->where('project_id', $this->event->project_id)
             ->first();
 
-        if ($volunteer && $volunteer->isEmailVerified()) {
-            // Branch A: existing + verified → skip verification
-            $this->prefillFromVolunteer($volunteer);
-            $this->state = WizardState::PersonalInfo;
-
-            return;
-        }
-
-        // Branch B (existing + unverified) or C (new email)
-        if ($volunteer) {
-            $this->prefillFromVolunteer($volunteer);
-        }
-
+        // ALL emails go through verification — no skip, no prefill before proof of ownership
         $token = app(SendEmailVerification::class)->execute(
             $this->volunteerEmail,
             $this->event,
@@ -352,7 +350,19 @@ class EventSignup extends Component
      */
     public function advanceToShifts(): void
     {
+        if ($this->state !== WizardState::PersonalInfo) {
+            return;
+        }
+
         $this->validatePersonalInfo();
+
+        // Pre-select existing shifts for returning volunteers
+        if (! empty($this->existingShiftIds)) {
+            $this->selectedShiftIds = array_map('intval', array_unique(
+                array_merge($this->selectedShiftIds, $this->existingShiftIds)
+            ));
+        }
+
         $this->state = WizardState::SelectingShifts;
     }
 
@@ -487,6 +497,7 @@ class EventSignup extends Component
                 ? collect($this->gearSelections)
                     ->filter()
                     ->only($this->gearItems->pluck('id')->all())
+                    ->except(array_keys($this->existingGearSelections))
                     ->all()
                 : null;
 
@@ -565,6 +576,9 @@ class EventSignup extends Component
         $this->verificationTokenId = null;
         $this->existingVolunteerId = null;
         $this->existingShiftIds = [];
+        $this->existingGearSelections = [];
+        $this->gearSelections = [];
+        $this->customFieldResponses = [];
         $this->isReturningVolunteer = false;
         $this->verificationStartedAt = null;
         unset($this->jobs, $this->overlappingShiftIds, $this->selectedJobIds, $this->gearItems, $this->hasGearOrFields);
@@ -574,6 +588,9 @@ class EventSignup extends Component
     {
         $gearRules = [];
         foreach ($this->gearItems as $item) {
+            if (array_key_exists($item->id, $this->existingGearSelections)) {
+                continue;
+            }
             if ($item->requires_size) {
                 $gearRules['gearSelections.'.$item->id] = ['required', 'string', Rule::in($item->available_sizes ?? [])];
             }
@@ -629,7 +646,15 @@ class EventSignup extends Component
             ->pluck('shift_id')
             ->all();
 
-        if (! empty($this->existingShiftIds)) {
+        // Load existing gear selections (SizeSelection type only, project-scoped)
+        $this->existingGearSelections = $volunteer->volunteerGear()
+            ->whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id)
+                ->where('type', GearItemType::SizeSelection))
+            ->get()
+            ->pluck('size', 'project_gear_item_id')
+            ->all();
+
+        if (! empty($this->existingShiftIds) || ! empty($this->existingGearSelections)) {
             $this->lookupMessage = __('Details pre-filled from your previous signup.');
         }
     }

--- a/resources/views/livewire/public/event-signup.blade.php
+++ b/resources/views/livewire/public/event-signup.blade.php
@@ -310,27 +310,34 @@
                                     $isFull = $spotsLeft === 0;
                                     $isSelected = in_array($shift->id, $selectedShiftIds);
                                     $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
+                                    $isExisting = in_array($shift->id, $existingShiftIds);
                                     $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
                                 @endphp
                                 <label
-                                    class="flex items-center justify-between p-3 rounded-lg cursor-pointer transition-all duration-200"
-                                    style="border: 2px solid {{ $isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)') }};
-                                           background: {{ $isSelected && $isConflicting ? 'rgba(244,208,63,0.08)' : ($isSelected ? 'rgba(5,150,105,0.08)' : 'transparent') }};
-                                           {{ $isFull ? 'opacity: 0.4; cursor: not-allowed;' : '' }}"
+                                    class="flex items-center justify-between p-3 rounded-lg transition-all duration-200"
+                                    style="border: 2px solid {{ $isExisting ? 'rgba(59,130,246,0.3)' : ($isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)')) }};
+                                           background: {{ $isExisting ? 'rgba(59,130,246,0.08)' : ($isSelected && $isConflicting ? 'rgba(244,208,63,0.08)' : ($isSelected ? 'rgba(5,150,105,0.08)' : 'transparent')) }};
+                                           {{ $isExisting ? 'opacity: 0.7; cursor: default;' : ($isFull ? 'opacity: 0.4; cursor: not-allowed;' : 'cursor: pointer;') }}"
                                     wire:key="shift-{{ $shift->id }}"
                                 >
                                     <div class="flex items-center gap-3">
                                         <input type="checkbox" value="{{ $shift->id }}"
                                             wire:model.live="selectedShiftIds"
-                                            @disabled($isFull)
+                                            @disabled($isFull || $isExisting)
+                                            @checked($isExisting)
                                             @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
+                                            @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
                                             class="accent-emerald-600"
                                         />
                                         <div>
                                             <span class="text-sm font-medium text-white">
                                                 {{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}
                                             </span>
-                                            @if ($spotsLeft <= 3 && $spotsLeft > 0)
+                                            @if ($isExisting)
+                                                <span class="block text-sm font-semibold" style="color: #93c5fd;">
+                                                    {{ __('Already signed up') }}
+                                                </span>
+                                            @elseif ($spotsLeft <= 3 && $spotsLeft > 0)
                                                 <span class="block text-sm font-semibold urgency-pulse" style="color: var(--yellow);">
                                                     {{ __('Nur noch :count Plätze!', ['count' => $spotsLeft]) }}
                                                 </span>
@@ -341,7 +348,9 @@
                                             @endif
                                         </div>
                                     </div>
-                                    @if ($isFull)
+                                    @if ($isExisting)
+                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
+                                    @elseif ($isFull)
                                         <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Full') }}</span>
                                     @elseif ($isConflicting && $isSelected)
                                         <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(244,208,63,0.15); color: #fbbf24;">{{ __('Conflict') }}</span>
@@ -381,9 +390,21 @@
                         <h2 class="font-bebas text-white text-2xl" style="letter-spacing: 0.04em;">{{ __('Event Gear') }}</h2>
 
                         @foreach ($this->gearItems as $item)
-                            <div wire:key="gear-{{ $item->id }}" class="rounded-lg p-4" style="background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08);">
-                                <div class="font-medium text-white mb-1">{{ $item->name }}</div>
-                                @if ($item->requires_size)
+                            @php $isExistingGear = array_key_exists($item->id, $existingGearSelections); @endphp
+                            <div wire:key="gear-{{ $item->id }}" class="rounded-lg p-4" style="background: rgba(255,255,255,0.05); border: 1px solid {{ $isExistingGear ? 'rgba(59,130,246,0.2)' : 'rgba(255,255,255,0.08)' }};">
+                                <div class="flex items-center justify-between mb-1">
+                                    <div class="font-medium text-white">{{ $item->name }}</div>
+                                    @if ($isExistingGear)
+                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Already selected') }}</span>
+                                    @endif
+                                </div>
+                                @if ($isExistingGear)
+                                    @if ($item->requires_size)
+                                        <p class="text-sm" style="color: #93c5fd;">{{ __('Size') }}: {{ $existingGearSelections[$item->id] ?? '—' }}</p>
+                                    @else
+                                        <p class="text-sm" style="color: #93c5fd;">{{ __('Included with your signup') }}</p>
+                                    @endif
+                                @elseif ($item->requires_size)
                                     <flux:field>
                                         <flux:label>{{ __('Size') }}</flux:label>
                                         <flux:select wire:model="gearSelections.{{ $item->id }}">
@@ -518,9 +539,12 @@
                             @foreach ($job->shifts as $shift)
                                 @if (in_array($shift->id, $selectedShiftIds))
                                     <div class="flex items-center gap-2 text-sm" wire:key="confirm-shift-{{ $shift->id }}">
-                                        <flux:icon name="check" variant="mini" class="size-4" style="color: var(--brand);" />
+                                        <flux:icon name="check" variant="mini" class="size-4" style="color: {{ in_array($shift->id, $existingShiftIds) ? '#93c5fd' : 'var(--brand)' }};" />
                                         <span class="font-medium text-white">{{ $job->name }}:</span>
                                         <span style="color: #a1a1aa;">{{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}</span>
+                                        @if (in_array($shift->id, $existingShiftIds))
+                                            <span class="text-xs" style="color: #93c5fd;">({{ __('already signed up') }})</span>
+                                        @endif
                                     </div>
                                 @endif
                             @endforeach
@@ -534,9 +558,13 @@
                         <h3 class="text-sm font-semibold text-white mb-3">{{ __('Gear') }}</h3>
                         <div class="space-y-1">
                             @foreach ($this->gearItems as $item)
+                                @php $isExistingGear = array_key_exists($item->id, $existingGearSelections); @endphp
                                 <div class="flex items-center gap-2 text-sm" wire:key="confirm-gear-{{ $item->id }}">
-                                    <flux:icon name="check" variant="mini" class="size-4" style="color: var(--brand);" />
+                                    <flux:icon name="check" variant="mini" class="size-4" style="color: {{ $isExistingGear ? '#93c5fd' : 'var(--brand)' }};" />
                                     <span style="color: #a1a1aa;">{{ $item->name }}{{ $item->requires_size && isset($gearSelections[$item->id]) ? ' (' . $gearSelections[$item->id] . ')' : '' }}</span>
+                                    @if ($isExistingGear)
+                                        <span class="text-xs" style="color: #93c5fd;">({{ __('previously selected') }})</span>
+                                    @endif
                                 </div>
                             @endforeach
                         </div>

--- a/tests/Feature/Flows/VolunteerSignupFlowTest.php
+++ b/tests/Feature/Flows/VolunteerSignupFlowTest.php
@@ -82,7 +82,7 @@ it('completes full flow: email → verify → info → shifts → confirm → co
     expect(Ticket::where('volunteer_id', $volunteer->id)->where('project_id', $this->project->id)->exists())->toBeTrue();
 });
 
-it('handles returning verified volunteer: email → info (prefilled) → shifts → confirm', function () {
+it('handles returning verified volunteer: email → verify → info (prefilled) → shifts → confirm', function () {
     $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
         'first_name' => 'Bob',
         'last_name' => 'Verified',
@@ -90,11 +90,16 @@ it('handles returning verified volunteer: email → info (prefilled) → shifts 
         'phone' => '+2222222222',
     ]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->assertSet('state', WizardState::EmailEntry)
         ->set('volunteerEmail', 'bob@verified.test')
         ->call('submitEmail')
-        // Skips PendingVerification for verified volunteers
+        ->assertSet('state', WizardState::PendingVerification);
+
+    // Simulate verification
+    $token = EmailVerificationToken::where('email', 'bob@verified.test')->first();
+    $token->update(['verified_at' => now()]);
+    $component->call('checkVerification')
         ->assertSet('state', WizardState::PersonalInfo)
         ->assertSet('volunteerFirstName', 'Bob')
         ->assertSet('volunteerLastName', 'Verified')
@@ -153,9 +158,13 @@ it('handles reservation expiry flow: reserve → expire → restart to EmailEntr
         'last_name' => 'Test',
     ]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'expire@test.com')
-        ->call('submitEmail')
+        ->call('submitEmail');
+
+    $token = EmailVerificationToken::where('email', 'expire@test.com')->first();
+    $token->update(['verified_at' => now()]);
+    $component->call('checkVerification')
         ->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
@@ -174,9 +183,13 @@ it('releases reservations after successful signup', function () {
         'last_name' => 'Test',
     ]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'release@test.com')
-        ->call('submitEmail')
+        ->call('submitEmail');
+
+    $token = EmailVerificationToken::where('email', 'release@test.com')->first();
+    $token->update(['verified_at' => now()]);
+    $component->call('checkVerification')
         ->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
@@ -220,8 +233,8 @@ it('handles cross-device verification via vt query param', function () {
         'expires_at' => now()->addHours(24),
     ]);
 
-    // Verify cross-device access via full HTTP request with ?vt= query param
-    $url = route('events.public', $this->event->public_token).'?vt='.$token->id;
+    // Verify cross-device access via full HTTP request with ?vt= query param (uses token_hash)
+    $url = route('events.public', $this->event->public_token).'?vt='.$token->token_hash;
     $this->get($url)
         ->assertOk()
         ->assertSeeLivewire(EventSignup::class);

--- a/tests/Feature/Livewire/EventSignupTest.php
+++ b/tests/Feature/Livewire/EventSignupTest.php
@@ -29,6 +29,7 @@ it('renders custom fields on step 2 of the wizard', function () {
     CustomRegistrationField::factory()->checkbox()->for($this->event)->create(['label' => 'Photo Release', 'sort_order' => 3]);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'test@example.com')
@@ -55,6 +56,7 @@ it('validates required custom fields on step 2', function () {
     $field = CustomRegistrationField::factory()->required()->for($this->event)->create(['label' => 'Required Field']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'test@example.com')
@@ -70,6 +72,7 @@ it('completes signup flow with custom field responses for new volunteer', functi
     $field = CustomRegistrationField::factory()->for($this->event)->create(['label' => 'Diet']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'newvolunteer@example.com')
@@ -91,6 +94,7 @@ it('completes signup with custom fields for verified volunteer', function () {
     $field = CustomRegistrationField::factory()->for($this->event)->create(['label' => 'Diet']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Verified')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'verified@example.com')
@@ -111,6 +115,7 @@ it('renders placeholder option in custom field select dropdown', function () {
     CustomRegistrationField::factory()->select(['Vegan', 'Vegetarian', 'None'])->for($this->event)->create(['label' => 'Diet Preference']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'test@example.com')
@@ -125,6 +130,7 @@ it('renders placeholder option in gear size select dropdown', function () {
     ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'test@example.com')
@@ -151,6 +157,7 @@ it('validates multi-choice custom field with array values', function () {
     $field = CustomRegistrationField::factory()->select(['Red', 'Blue', 'Green'])->allowMultiple()->for($this->event)->create(['label' => 'Favorite Colors']);
 
     Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', 'Test')
         ->set('volunteerLastName', 'Person')
         ->set('volunteerEmail', 'test@example.com')

--- a/tests/Feature/Public/EmailVerificationPageTest.php
+++ b/tests/Feature/Public/EmailVerificationPageTest.php
@@ -57,21 +57,23 @@ it('shows already-verified message for re-used token', function () {
         ->assertSee('Continue Signup');
 });
 
-it('includes continue-signup link with token ID', function () {
+it('includes continue-signup link with token hash', function () {
     $plainToken = Str::random(64);
+    $hashed = HashedToken::fromPlaintext($plainToken);
     $token = EmailVerificationToken::factory()->create([
         'volunteer_id' => $this->volunteer->id,
         'event_id' => $this->event->id,
         'email' => $this->volunteer->email,
-        'token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+        'token_hash' => $hashed->hash,
         'expires_at' => now()->addHours(24),
     ]);
 
     $component = Livewire::test(EmailVerificationPage::class, ['token' => $plainToken]);
 
     $continueUrl = $component->get('continueSignupUrl');
-    expect($continueUrl)->toContain('vt='.$token->id)
-        ->and($continueUrl)->toContain($this->event->public_token);
+    expect($continueUrl)->toContain('vt='.$hashed->hash)
+        ->and($continueUrl)->toContain($this->event->public_token)
+        ->and($continueUrl)->not->toContain('vt='.$token->id);
 });
 
 it('shows expired message for expired token', function () {

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -20,7 +20,21 @@ use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
+
+/**
+ * Simulate email verification by marking the latest token as verified and polling.
+ * Intentionally bypasses EmailVerificationPage — full path covered by VolunteerSignupFlowTest.
+ */
+function simulateVerification(Testable $component, string $email): Testable
+{
+    $token = EmailVerificationToken::where('email', $email)->latest()->first();
+    expect($token)->not->toBeNull('No verification token found for '.$email);
+    $token->update(['verified_at' => now()]);
+
+    return $component->call('checkVerification');
+}
 
 beforeEach(function () {
     Notification::fake();
@@ -121,7 +135,7 @@ it('transitions to PendingVerification for new email on submitEmail', function (
     Notification::assertSentOnDemand(EmailVerification::class);
 });
 
-it('skips verification for already-verified volunteer on submitEmail', function () {
+it('sends verification for already-verified volunteer on submitEmail', function () {
     Volunteer::factory()->for($this->project)->verified()->create([
         'email' => 'verified@example.com',
         'first_name' => 'Verified',
@@ -132,20 +146,28 @@ it('skips verification for already-verified volunteer on submitEmail', function 
         ->set('volunteerEmail', 'verified@example.com')
         ->call('submitEmail')
         ->assertHasNoErrors()
-        ->assertSet('state', WizardState::PersonalInfo);
+        ->assertSet('state', WizardState::PendingVerification)
+        ->assertSet('volunteerFirstName', '')
+        ->assertSet('volunteerLastName', '');
 });
 
-it('prefills data for returning verified volunteer on submitEmail', function () {
-    Volunteer::factory()->for($this->project)->verified()->create([
+it('prefills data for returning verified volunteer only after verification', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
         'email' => 'returning@example.com',
         'first_name' => 'Returning',
         'last_name' => 'Helper',
         'phone' => '+15559876543',
     ]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'returning@example.com')
         ->call('submitEmail')
+        ->assertSet('state', WizardState::PendingVerification)
+        ->assertSet('volunteerFirstName', '');
+
+    simulateVerification($component, 'returning@example.com');
+
+    $component
         ->assertSet('volunteerFirstName', 'Returning')
         ->assertSet('volunteerLastName', 'Helper')
         ->assertSet('volunteerPhone', '+15559876543')
@@ -153,17 +175,40 @@ it('prefills data for returning verified volunteer on submitEmail', function () 
         ->assertSet('state', WizardState::PersonalInfo);
 });
 
-it('does not show PendingVerification on submitSignup for verified volunteer', function () {
+it('shows identical response for known and unknown emails', function () {
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'known@example.com']);
+
+    $known = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'known@example.com')
+        ->call('submitEmail');
+
+    $unknown = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'unknown-new@example.com')
+        ->call('submitEmail');
+
+    expect($known->get('state'))->toBe(WizardState::PendingVerification)
+        ->and($unknown->get('state'))->toBe(WizardState::PendingVerification)
+        ->and($known->get('volunteerFirstName'))->toBe('')
+        ->and($unknown->get('volunteerFirstName'))->toBe('')
+        ->and($known->get('isReturningVolunteer'))->toBeFalse()
+        ->and($unknown->get('isReturningVolunteer'))->toBeFalse();
+});
+
+it('completes full wizard for verified volunteer with verification step', function () {
     Volunteer::factory()->for($this->project)->verified()->create([
         'email' => 'already-verified@example.com',
         'first_name' => 'Already',
         'last_name' => 'Verified',
     ]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'already-verified@example.com')
         ->call('submitEmail')
-        ->assertSet('state', WizardState::PersonalInfo)
+        ->assertSet('state', WizardState::PendingVerification);
+
+    simulateVerification($component, 'already-verified@example.com');
+
+    $component
         ->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
@@ -177,10 +222,11 @@ it('does not show PendingVerification on submitSignup for verified volunteer', f
 it('validates at least one shift selected before advancing', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->call('reserveAndAdvance')
         ->assertHasErrors('selectedShiftIds');
 });
@@ -188,10 +234,11 @@ it('validates at least one shift selected before advancing', function () {
 it('creates reservations and advances past shift selection', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertHasNoErrors()
@@ -204,10 +251,11 @@ it('creates reservations and advances past shift selection', function () {
 it('skips gear step when no gear or custom fields exist', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::Confirming);
@@ -218,10 +266,11 @@ it('advances to gear step when gear items exist', function () {
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields);
@@ -234,10 +283,11 @@ it('shows error when all selected shifts are full at reservation time', function
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$tinyShift->id])
         ->call('reserveAndAdvance')
         ->assertHasErrors('selectedShiftIds')
@@ -251,10 +301,11 @@ it('shows warning and advances with partial availability', function () {
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id, $fullShift->id])
         ->call('reserveAndAdvance')
         ->assertHasNoErrors()
@@ -279,10 +330,11 @@ it('blocks reserveAndAdvance when selected shifts overlap in time', function () 
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->assertSee(__('Some selected shifts overlap in time'))
@@ -308,10 +360,11 @@ it('allows reserveAndAdvance after deselecting one conflicting shift', function 
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->set('selectedShiftIds', [$shiftA->id])
@@ -337,10 +390,11 @@ it('allows selecting adjacent shifts that meet exactly at midnight', function ()
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertDontSee(__('Conflict'))
         ->assertDontSee(__('Some selected shifts overlap in time'))
@@ -364,10 +418,11 @@ it('blocks reserveAndAdvance when overnight shift overlaps next-day shift', func
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->assertSee(__('Some selected shifts overlap in time'))
@@ -391,10 +446,11 @@ it('allows reserveAndAdvance after deselecting one conflicting cross-midnight sh
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->set('selectedShiftIds', [$shiftA->id])
@@ -414,10 +470,11 @@ it('shows gear selectors on step 2', function () {
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -430,10 +487,11 @@ it('validates size is required for size-required gear items on step 2', function
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -446,10 +504,11 @@ it('validates size is required for size-required gear items on step 2', function
 it('validates required personal info fields', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->assertSet('state', WizardState::PersonalInfo)
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->assertSet('state', WizardState::PersonalInfo)
         ->set('volunteerFirstName', '')
         ->set('volunteerLastName', '')
         ->set('volunteerEmail', '')
@@ -464,10 +523,11 @@ it('rejects empty phone when phone_required is true', function () {
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $phoneRequiredEvent->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $phoneRequiredEvent->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->set('volunteerPhone', '')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->set('volunteerPhone', '')
         ->call('advanceToShifts')
         ->assertHasErrors(['volunteerPhone']);
 });
@@ -475,10 +535,11 @@ it('rejects empty phone when phone_required is true', function () {
 it('accepts empty phone when phone_required is false', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'nophone@example.com', 'first_name' => 'No', 'last_name' => 'Phone']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'nophone@example.com')
-        ->call('submitEmail')
-        ->set('volunteerPhone', '')
+        ->call('submitEmail');
+    simulateVerification($component, 'nophone@example.com');
+    $component->set('volunteerPhone', '')
         ->call('advanceToShifts')
         ->assertHasNoErrors()
         ->assertSet('state', WizardState::SelectingShifts);
@@ -489,10 +550,11 @@ it('accepts empty phone when phone_required is false', function () {
 it('shows summary of all selections on confirmation step', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'summary@example.com', 'first_name' => 'Summary', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'summary@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'summary@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::Confirming)
@@ -507,10 +569,11 @@ it('shows summary of all selections on confirmation step', function () {
 it('completes signup for verified volunteer through wizard', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'john@example.com', 'first_name' => 'John', 'last_name' => 'Smith']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'john@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'john@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->call('submitSignup')
@@ -530,10 +593,11 @@ it('completes signup for verified volunteer through wizard', function () {
 it('submits signup with phone number for verified volunteer', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'phone@example.com', 'first_name' => 'Phone', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'phone@example.com')
-        ->call('submitEmail')
-        ->set('volunteerPhone', '+15551234567')
+        ->call('submitEmail');
+    simulateVerification($component, 'phone@example.com');
+    $component->set('volunteerPhone', '+15551234567')
         ->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
@@ -547,10 +611,11 @@ it('submits signup with phone number for verified volunteer', function () {
 it('submits signup without phone number for verified volunteer', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'nophone@example.com', 'first_name' => 'No', 'last_name' => 'Phone', 'phone' => null]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'nophone@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'nophone@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->call('submitSignup')
@@ -565,8 +630,9 @@ it('shows error for already signed up volunteer on all selected shifts', functio
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'repeat@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'repeat@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance');
 
@@ -585,8 +651,9 @@ it('shows error when all selected shifts are full at submit time for verified vo
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'late@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'late@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$tinyShift->id])
         ->call('reserveAndAdvance');
 
@@ -613,10 +680,11 @@ it('submits multi-shift signup and creates all records for verified volunteer', 
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'multi@example.com', 'first_name' => 'Multi', 'last_name' => 'Shift']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'multi@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'multi@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id, $shift2->id])
         ->call('reserveAndAdvance')
         ->call('submitSignup')
@@ -646,8 +714,9 @@ it('shows warning when some shifts are skipped during submit for verified volunt
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'partial@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'partial@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id, $shift2->id])
         ->call('reserveAndAdvance');
 
@@ -669,8 +738,9 @@ it('shows all-duplicate error for mixed duplicate and full shifts', function () 
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'mixed@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'mixed@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance');
 
@@ -687,10 +757,11 @@ it('creates gear records on signup with gear selections through wizard', functio
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'gear-signup@example.com', 'first_name' => 'Gear', 'last_name' => 'Signup']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'gear-signup@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'gear-signup@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -709,10 +780,11 @@ it('creates gear records on signup with gear selections through wizard', functio
 it('goes back from PersonalInfo to EmailEntry', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->assertSet('state', WizardState::PersonalInfo)
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->assertSet('state', WizardState::PersonalInfo)
         ->call('goBack')
         ->assertSet('state', WizardState::EmailEntry);
 });
@@ -720,10 +792,11 @@ it('goes back from PersonalInfo to EmailEntry', function () {
 it('can go back to previous steps', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->assertSet('state', WizardState::SelectingShifts)
         ->call('goBack')
         ->assertSet('state', WizardState::PersonalInfo)
@@ -736,10 +809,11 @@ it('can navigate back through gear step', function () {
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -750,10 +824,11 @@ it('can navigate back through gear step', function () {
 it('goes back from Confirming to SelectingShifts when no gear', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::Confirming)
@@ -772,10 +847,11 @@ it('cannot go back before step 1', function () {
 it('resets wizard when reservation expires', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::Confirming)
@@ -786,10 +862,11 @@ it('resets wizard when reservation expires', function () {
 it('can restart signup after expiry', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->call('handleReservationExpired')
@@ -803,10 +880,11 @@ it('can restart signup after expiry', function () {
 it('sets reservationExpiresAt after reservation', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertNotSet('reservationExpiresAt', '');
@@ -817,8 +895,9 @@ it('checks DB reservation existence before submit (D13)', function () {
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'd13@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'd13@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance');
 
@@ -832,10 +911,11 @@ it('checks DB reservation existence before submit (D13)', function () {
 it('shows signed up message for verified volunteer', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'verified@example.com', 'first_name' => 'Verified', 'last_name' => 'Person']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'verified@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'verified@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->call('submitSignup')
@@ -864,11 +944,189 @@ it('filters gear to SizeSelection items only in wizard', function () {
 
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
-        ->call('submitEmail')
-        ->call('advanceToShifts')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
         ->assertSee('T-Shirt')
         ->assertDontSee('Water Bottle');
+});
+
+// --- Returning volunteer: existing shifts read-only ---
+
+it('pre-selects existing shifts when advancing to shift step for returning volunteer', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $this->shift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->assertSet('existingShiftIds', [$this->shift->id])
+        ->assertSet('selectedShiftIds', [$this->shift->id]);
+});
+
+it('renders existing shifts as disabled with Already signed up badge', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $this->shift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->assertSee(__('Already signed up'))
+        ->assertSee(__('Signed Up'));
+});
+
+it('allows selecting new shifts alongside existing shifts for returning volunteer', function () {
+    $shift2 = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'capacity' => 10,
+        'starts_at' => Carbon::parse('2026-07-02 09:00:00'),
+        'ends_at' => Carbon::parse('2026-07-02 12:00:00'),
+    ]);
+    $this->shift->update(['starts_at' => Carbon::parse('2026-07-01 09:00:00'), 'ends_at' => Carbon::parse('2026-07-01 12:00:00')]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $this->shift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id, $shift2->id])
+        ->call('reserveAndAdvance')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Confirming);
+
+    // Only the new shift gets reserved
+    expect(ShiftReservation::where('shift_id', $shift2->id)->count())->toBe(1)
+        ->and(ShiftReservation::where('shift_id', $this->shift->id)->count())->toBe(0);
+});
+
+it('shows error when returning volunteer selects only existing shifts', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $this->shift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->call('reserveAndAdvance')
+        ->assertHasErrors('selectedShiftIds');
+});
+
+// --- Returning volunteer: existing gear read-only ---
+
+it('loads existing gear selections for returning volunteer', function () {
+    $tshirt = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $tshirt->id,
+        'size' => 'L',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->assertSet('existingGearSelections', [$tshirt->id => 'L']);
+});
+
+it('renders existing gear as read-only with Already selected badge', function () {
+    $tshirt = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $tshirt->id,
+        'size' => 'L',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id])
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::GearAndFields)
+        ->assertSee(__('Already selected'))
+        ->assertSee('T-Shirt');
+});
+
+it('does not require size selection for existing gear items', function () {
+    $tshirt = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
+    $vest = ProjectGearItem::factory()->sized(['S', 'M'])->for($this->project)->create(['name' => 'Vest']);
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $tshirt->id,
+        'size' => 'L',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id])
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::GearAndFields)
+        ->set('gearSelections.'.$vest->id, 'M')
+        ->call('advanceToConfirmation')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Confirming);
+});
+
+it('allows selecting new gear alongside existing gear', function () {
+    $tshirt = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
+    $hat = ProjectGearItem::factory()->sized(['S', 'M'])->for($this->project)->create(['name' => 'Hat']);
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $tshirt->id,
+        'size' => 'L',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id])
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::GearAndFields)
+        ->set('gearSelections.'.$hat->id, 'M')
+        ->call('advanceToConfirmation')
+        ->call('submitSignup')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Complete);
+
+    // Only hat gear record is created (tshirt already existed)
+    expect(VolunteerGear::where('project_gear_item_id', $hat->id)->first()->size)->toBe('M');
+});
+
+it('resets existingGearSelections on restartSignup', function () {
+    $tshirt = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $tshirt->id,
+        'size' => 'L',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->assertSet('existingGearSelections', [$tshirt->id => 'L'])
+        ->call('restartSignup')
+        ->assertSet('existingGearSelections', [])
+        ->assertSet('gearSelections', []);
 });


### PR DESCRIPTION
## Summary

- **Security**: All volunteers (including previously verified ones) must re-verify email on every signup, closing an info-leak where anyone could discover registered emails and see personal data
- **Security**: Cross-device `?vt=` URL now uses opaque token hash instead of sequential integer ID to prevent enumeration
- **UX**: Returning volunteers see existing shifts as disabled with "Signed Up" badge (not deselectable)
- **UX**: Returning volunteers see existing gear as read-only with "Already selected" badge
- **Bugfix**: `gearSelections` and `customFieldResponses` now properly reset on `restartSignup()`

Resolves #149

## Changes

| Area | Detail |
|------|--------|
| `EventSignup.php` | Remove verified-volunteer skip in `submitEmail()`, add state guard to `advanceToShifts()`, add `existingGearSelections` property, pre-populate `selectedShiftIds`, exclude existing shifts from overlap detection, skip existing gear in validation/submission |
| `EmailVerificationPage.php` | Use `token_hash` instead of `id` for `?vt=` URL |
| `event-signup.blade.php` | Read-only shift rendering (disabled + blue badge), read-only gear rendering, confirmation summary labels |
| Tests | Updated ~49 existing tests, added ~13 new tests covering security + read-only behavior |

## Test plan

- [x] 1866 tests pass (4087 assertions)
- [x] Pint clean
- [ ] Manual: enter known email → see PendingVerification (not PersonalInfo skip)
- [ ] Manual: enter unknown email → see identical PendingVerification (no info-leak)
- [ ] Manual: returning volunteer → existing shifts shown as disabled with "Signed Up" badge
- [ ] Manual: returning volunteer → existing gear shown as read-only with "Already selected" badge
- [ ] Manual: cross-device verification link → URL uses hash, not integer ID