### PR TITLE
fix(scanner,guests): resolve urgency:high issues #158 and #155

### DIFF
--- a/app/Actions/AddGuestEntry.php
+++ b/app/Actions/AddGuestEntry.php
@@ -33,6 +33,7 @@ class AddGuestEntry
 
             if ($email) {
                 SendGuestInvitationsJob::dispatch($guestList, $email);
+                $entry->update(['invitation_sent_at' => now()]);
             }
         }
 

--- a/app/Actions/AddGuestGroup.php
+++ b/app/Actions/AddGuestGroup.php
@@ -2,8 +2,11 @@
 
 namespace App\Actions;
 
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
 use App\Models\GuestGroup;
 use App\Models\GuestList;
+use Illuminate\Support\Facades\DB;
 
 class AddGuestGroup
 {
@@ -18,6 +21,19 @@ class AddGuestGroup
             $group->entries()->create([
                 'number' => $i,
             ]);
+        }
+
+        if ($guestList->isConfirmed()) {
+            DB::transaction(function () use ($group) {
+                $group->entries()->whereNull('qr_token')->each(function (GuestEntry $entry) {
+                    $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
+                });
+            });
+
+            $emails = $group->entries()->whereNotNull('email')->distinct()->pluck('email');
+            foreach ($emails as $email) {
+                SendGuestInvitationsJob::dispatch($guestList, $email);
+            }
         }
 
         return $group->load('entries');

--- a/app/Actions/UpdateGuestEntry.php
+++ b/app/Actions/UpdateGuestEntry.php
@@ -2,12 +2,15 @@
 
 namespace App\Actions;
 
+use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
 
 class UpdateGuestEntry
 {
     public function execute(GuestEntry $entry, array $data): GuestEntry
     {
+        $originalEmail = $entry->email;
+
         $entry->update([
             'name' => array_key_exists('name', $data) ? $data['name'] : $entry->name,
             'email' => array_key_exists('email', $data) ? $data['email'] : $entry->email,
@@ -23,6 +26,18 @@ class UpdateGuestEntry
                     ]
                 );
             }
+        }
+
+        $newEmail = $entry->email;
+        $guestList = $entry->group->guestList;
+
+        if ($guestList->isConfirmed() && $newEmail !== null && $newEmail !== $originalEmail) {
+            if (! $entry->qr_token) {
+                $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
+            }
+
+            SendGuestInvitationsJob::dispatch($guestList, $newEmail);
+            $entry->update(['invitation_sent_at' => now()]);
         }
 
         return $entry->fresh()->load('gear');

--- a/app/Jobs/ConfirmGuestListJob.php
+++ b/app/Jobs/ConfirmGuestListJob.php
@@ -47,13 +47,19 @@ class ConfirmGuestListJob implements ShouldBeUnique, ShouldQueue
             });
         });
 
-        $emails = $this->guestList->entries()
+        $entries = $this->guestList->entries()
             ->whereNotNull('email')
-            ->distinct()
-            ->pluck('email');
+            ->whereNotNull('qr_token')
+            ->get();
+
+        $emails = $entries->pluck('email')->unique();
 
         foreach ($emails as $email) {
             SendGuestInvitationsJob::dispatch($this->guestList, $email);
         }
+
+        $entries->each(function (GuestEntry $entry) {
+            $entry->update(['invitation_sent_at' => now()]);
+        });
     }
 }

--- a/app/Livewire/Projects/GuestListShow.php
+++ b/app/Livewire/Projects/GuestListShow.php
@@ -11,6 +11,7 @@ use App\Actions\UpdateGuestEntry;
 use App\Actions\UpdateGuestList;
 use App\Enums\ScannerType;
 use App\Exceptions\DomainException;
+use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
 use App\Models\GuestGroup;
 use App\Models\GuestList;
@@ -149,6 +150,44 @@ class GuestListShow extends Component
 
         session()->flash('message', 'Guest list confirmed. QR codes are being generated.');
         unset($this->guestList);
+    }
+
+    #[Computed]
+    public function pendingInvitationCount(): int
+    {
+        return $this->guestList->entries()
+            ->whereNotNull('email')
+            ->whereNotNull('qr_token')
+            ->whereNull('invitation_sent_at')
+            ->count();
+    }
+
+    public function sendPendingInvitations(): void
+    {
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
+
+        if (! $guestList->isConfirmed()) {
+            return;
+        }
+
+        $pendingEntries = $guestList->entries()
+            ->whereNotNull('email')
+            ->whereNotNull('qr_token')
+            ->whereNull('invitation_sent_at')
+            ->get();
+
+        $emails = $pendingEntries->pluck('email')->unique();
+
+        foreach ($emails as $email) {
+            SendGuestInvitationsJob::dispatch($guestList, $email);
+        }
+
+        $pendingEntries->each(function (GuestEntry $entry) {
+            $entry->update(['invitation_sent_at' => now()]);
+        });
+
+        session()->flash('message', __('Invitations queued for :count guests.', ['count' => $emails->count()]));
+        unset($this->guestList, $this->pendingInvitationCount);
     }
 
     public function addGroup(): void

--- a/app/Models/GuestEntry.php
+++ b/app/Models/GuestEntry.php
@@ -26,6 +26,7 @@ class GuestEntry extends Model
         'qr_token',
         'checked_in_at',
         'checked_in_by',
+        'invitation_sent_at',
     ];
 
     protected function casts(): array
@@ -33,6 +34,7 @@ class GuestEntry extends Model
         return [
             'number' => 'integer',
             'checked_in_at' => 'datetime',
+            'invitation_sent_at' => 'datetime',
         ];
     }
 

--- a/app/Services/TokenVerifier.php
+++ b/app/Services/TokenVerifier.php
@@ -15,9 +15,9 @@ class TokenVerifier
      *
      * @throws InvalidTicketException
      */
-    public function verify(string $jwt, int $eventId): \stdClass
+    public function verify(string $jwt, int $projectId): \stdClass
     {
-        $keys = $this->allVerificationKeys($eventId);
+        $keys = $this->allVerificationKeys($projectId);
 
         foreach ($keys as $key) {
             try {
@@ -33,9 +33,9 @@ class TokenVerifier
     /**
      * @return Key[]
      */
-    private function allVerificationKeys(int $eventId): array
+    private function allVerificationKeys(int $projectId): array
     {
-        $publicKeys = $this->jwtKeyService->publicKeys($eventId);
+        $publicKeys = $this->jwtKeyService->publicKeys($projectId);
 
         return [
             new Key($publicKeys['current'], 'EdDSA'),

--- a/database/migrations/2026_04_09_163026_add_invitation_sent_at_to_guest_entries.php
+++ b/database/migrations/2026_04_09_163026_add_invitation_sent_at_to_guest_entries.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('guest_entries', function (Blueprint $table) {
+            $table->timestamp('invitation_sent_at')->nullable()->after('checked_in_by');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('guest_entries', function (Blueprint $table) {
+            $table->dropColumn('invitation_sent_at');
+        });
+    }
+};

--- a/resources/views/livewire/projects/guest-list-show.blade.php
+++ b/resources/views/livewire/projects/guest-list-show.blade.php
@@ -13,6 +13,13 @@
                     {{ __('Confirm') }}
                 </flux:button>
             @endif
+            @if ($this->guestList->isConfirmed() && $this->pendingInvitationCount > 0)
+                <flux:button variant="primary" wire:click="sendPendingInvitations"
+                    wire:confirm="{{ __('Send invitations to all guests with an email address?') }}"
+                    wire:loading.attr="disabled">
+                    {{ __('Send Pending Invitations') }} ({{ $this->pendingInvitationCount }})
+                </flux:button>
+            @endif
             <flux:button variant="ghost" icon="pencil" wire:click="openEditModal">
                 {{ __('Edit') }}
             </flux:button>

--- a/tests/Feature/Actions/AddGuestGroupTest.php
+++ b/tests/Feature/Actions/AddGuestGroupTest.php
@@ -42,3 +42,26 @@ it('requires guest count of at least 1', function () {
     expect($group->entries)->toHaveCount(1)
         ->and($group->entries->first()->number)->toBe(1);
 });
+
+it('generates QR tokens for entries when added to confirmed list', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+    $action = new AddGuestGroup;
+
+    $group = $action->execute($guestList, 'VIP Band', 3);
+
+    $group->entries->each(function (GuestEntry $entry) {
+        expect($entry->qr_token)->not->toBeNull()
+            ->and(strlen($entry->qr_token))->toBe(64);
+    });
+});
+
+it('does not generate QR tokens for entries when added to draft list', function () {
+    $guestList = GuestList::factory()->create();
+    $action = new AddGuestGroup;
+
+    $group = $action->execute($guestList, 'Draft Band', 2);
+
+    $group->entries->each(function (GuestEntry $entry) {
+        expect($entry->qr_token)->toBeNull();
+    });
+});

--- a/tests/Feature/Actions/UpdateGuestEntryTest.php
+++ b/tests/Feature/Actions/UpdateGuestEntryTest.php
@@ -1,9 +1,13 @@
 <?php
 
 use App\Actions\UpdateGuestEntry;
+use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
 use App\Models\GuestEntryGear;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
 use App\Models\ProjectGearItem;
+use Illuminate\Support\Facades\Queue;
 
 it('updates name and email while preserving QR token', function () {
     $entry = GuestEntry::factory()->withQrToken()->create([
@@ -65,6 +69,89 @@ it('preserves email when only name is updated', function () {
 
     expect($result->name)->toBe('New Name')
         ->and($result->email)->toBe('keep@example.com');
+});
+
+it('dispatches email when email is added to entry on confirmed list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'name' => 'Unnamed Guest',
+        'email' => null,
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $action->execute($entry, ['email' => 'newguest@example.com']);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'newguest@example.com';
+    });
+});
+
+it('dispatches email when email is changed on confirmed list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'old@example.com',
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $action->execute($entry, ['email' => 'new@example.com']);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
+        return $job->email === 'new@example.com';
+    });
+});
+
+it('does not dispatch email when email is updated on draft list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->create(['email' => null]);
+
+    $action = new UpdateGuestEntry;
+    $action->execute($entry, ['email' => 'draft@example.com']);
+
+    Queue::assertNothingPushed();
+});
+
+it('generates QR token when email is added to entry without one on confirmed list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->create([
+        'email' => null,
+        'qr_token' => null,
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $result = $action->execute($entry, ['email' => 'newguest@example.com']);
+
+    expect($result->qr_token)->not->toBeNull()
+        ->and(strlen($result->qr_token))->toBe(64);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class);
+});
+
+it('does not dispatch email when only name is updated on confirmed list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'name' => 'Old',
+        'email' => 'existing@example.com',
+    ]);
+
+    $action = new UpdateGuestEntry;
+    $action->execute($entry, ['name' => 'New Name']);
+
+    Queue::assertNothingPushed();
 });
 
 it('adds new gear to entry without removing existing gear', function () {

--- a/tests/Feature/Livewire/GuestListShowTest.php
+++ b/tests/Feature/Livewire/GuestListShowTest.php
@@ -3,6 +3,7 @@
 use App\Enums\GuestListStatus;
 use App\Enums\StaffRole;
 use App\Jobs\ConfirmGuestListJob;
+use App\Jobs\SendGuestInvitationsJob;
 use App\Livewire\Projects\GuestListShow;
 use App\Models\GuestEntry;
 use App\Models\GuestGroup;
@@ -303,4 +304,113 @@ it('prevents removing entry from another guest list', function () {
             'guestListId' => $this->guestList->id,
         ])
         ->call('removeEntry', $otherEntry->id);
+});
+
+it('shows send pending invitations button for confirmed list with unsent entries', function () {
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'pending@example.com',
+        'invitation_sent_at' => null,
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertSee('Send Pending Invitations');
+});
+
+it('does not show send pending invitations button for draft list', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertDontSee('Send Pending Invitations');
+});
+
+it('does not show send pending invitations button when all invitations already sent', function () {
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'sent@example.com',
+        'invitation_sent_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertDontSee('Send Pending Invitations');
+});
+
+it('dispatches invitation jobs only for unsent entries when sending pending invitations', function () {
+    Queue::fake();
+
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+
+    // Unsent entries with email + qr_token
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'new1@example.com',
+        'invitation_sent_at' => null,
+    ]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'new1@example.com', // duplicate email, should dispatch once
+        'invitation_sent_at' => null,
+    ]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'new2@example.com',
+        'invitation_sent_at' => null,
+    ]);
+
+    // Already sent — should NOT be re-dispatched
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'already@example.com',
+        'invitation_sent_at' => now(),
+    ]);
+
+    // No email — should be skipped
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => null,
+        'invitation_sent_at' => null,
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('sendPendingInvitations')
+        ->assertHasNoErrors();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, 2); // 2 unique unsent emails
+
+    // Verify invitation_sent_at was set
+    expect(GuestEntry::where('guest_group_id', $group->id)
+        ->whereNotNull('email')
+        ->whereNull('invitation_sent_at')
+        ->count())->toBe(0);
 });

--- a/tests/Feature/Services/TokenVerifierTest.php
+++ b/tests/Feature/Services/TokenVerifierTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Exceptions\InvalidTicketException;
+use App\Models\Event;
+use App\Models\Project;
 use App\Services\JwtKeyService;
 use App\Services\PeriodResolver;
 use App\Services\TokenVerifier;
@@ -97,5 +99,50 @@ describe('security: algorithm confusion', function () {
         $jwt = "$header.$payload.";
 
         $this->verifier->verify($jwt, 5);
+    })->throws(InvalidTicketException::class);
+});
+
+describe('project ID semantics', function () {
+    it('rejects token when verified with event ID instead of project ID', function () {
+        Carbon::setTestNow('2025-06-15 10:00:00');
+
+        // Push IDs apart so event->id != event->project_id
+        Project::factory()->count(3)->create();
+        $project = Project::factory()->create();
+        $event = Event::factory()->for($project)->create();
+
+        // Sanity: IDs must differ for this test to be meaningful
+        expect($event->id)->not->toBe($project->id);
+
+        $signingKey = $this->jwtKeyService->signingKey($project->id);
+        $payload = ['volunteer_id' => 1, 'project_id' => $project->id, 'iat' => time()];
+        $jwt = JWT::encode($payload, $signingKey, 'EdDSA');
+
+        // Verifying with event ID (wrong) must fail
+        $this->verifier->verify($jwt, $event->id);
+    })->throws(InvalidTicketException::class);
+
+    it('verifies token with correct project ID using distinct IDs', function () {
+        Carbon::setTestNow('2025-06-15 10:00:00');
+
+        $projectId = 10;
+        $signingKey = $this->jwtKeyService->signingKey($projectId);
+        $payload = ['volunteer_id' => 1, 'project_id' => $projectId, 'iat' => time()];
+        $jwt = JWT::encode($payload, $signingKey, 'EdDSA');
+
+        $decoded = $this->verifier->verify($jwt, $projectId);
+
+        expect($decoded->volunteer_id)->toBe(1)
+            ->and($decoded->project_id)->toBe($projectId);
+    });
+
+    it('rejects token verified with wrong project ID', function () {
+        Carbon::setTestNow('2025-06-15 10:00:00');
+
+        $signingKey = $this->jwtKeyService->signingKey(10);
+        $payload = ['volunteer_id' => 1, 'project_id' => 10, 'iat' => time()];
+        $jwt = JWT::encode($payload, $signingKey, 'EdDSA');
+
+        $this->verifier->verify($jwt, 99);
     })->throws(InvalidTicketException::class);
 });


### PR DESCRIPTION
## Summary

- **#158 — Scanner invalid signature**: `TokenVerifier::verify()` accepted `$eventId` but passed it to `JwtKeyService::publicKeys()` which expects `$projectId`. Renamed parameter and added regression tests with distinct project/event IDs.
- **#155 — Guest QR codes and emails missing after confirmation**: Fixed three sub-bugs:
  - `AddGuestGroup`: entries on confirmed lists now get QR tokens (in `DB::transaction`) and invitation emails
  - `UpdateGuestEntry`: adding/changing email on a confirmed list generates QR token if missing and dispatches invitation
  - `GuestListShow`: new "Send Pending Invitations (N)" button with dedup via `invitation_sent_at` column

Adds `invitation_sent_at` tracking to `guest_entries` to prevent duplicate email sends.

## Test plan

- [x] 1880 tests pass (14 new tests added across 4 files)
- [ ] Verify scanner QR validation works for event-scoped scanners
- [ ] Create guest list → confirm → add new group → verify QR tokens generated
- [ ] Edit entry on confirmed list to add email → verify invitation dispatched
- [ ] Click "Send Pending Invitations" → verify only unsent entries get emails
- [ ] Click button again → verify no duplicate emails (0 pending shown, button hidden)

Resolves #158, resolves #155