### PR TITLE
fix(signup,portal): overlap check + cancel 403

### DIFF
--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -215,29 +215,41 @@ class EventSignup extends Component
 
         $intIds = array_map('intval', $this->selectedShiftIds);
 
-        // Exclude existing shifts from overlap detection — they were already approved
         $newOnly = array_diff($intIds, $this->existingShiftIds);
         if (count($newOnly) < 1) {
             return [];
         }
 
-        $selected = $this->jobs
-            ->flatMap(fn ($job) => $job->shifts)
-            ->filter(fn ($shift) => in_array((int) $shift->id, $newOnly, true)
-                && $shift->starts_at !== null
-                && $shift->ends_at !== null)
+        $allShifts = $this->jobs->flatMap(fn ($job) => $job->shifts);
+
+        $newShifts = $allShifts
+            ->filter(fn ($s) => in_array((int) $s->id, $newOnly, true)
+                && $s->starts_at !== null && $s->ends_at !== null)
+            ->values();
+
+        $existingShifts = $allShifts
+            ->filter(fn ($s) => in_array((int) $s->id, $this->existingShiftIds, true)
+                && $s->starts_at !== null && $s->ends_at !== null)
             ->values();
 
         $conflicting = [];
 
-        for ($i = 0; $i < $selected->count(); $i++) {
-            for ($j = $i + 1; $j < $selected->count(); $j++) {
-                $a = $selected[$i];
-                $b = $selected[$j];
+        // New vs new
+        for ($i = 0; $i < $newShifts->count(); $i++) {
+            for ($j = $i + 1; $j < $newShifts->count(); $j++) {
+                if ($newShifts[$i]->starts_at < $newShifts[$j]->ends_at
+                    && $newShifts[$i]->ends_at > $newShifts[$j]->starts_at) {
+                    $conflicting[] = $newShifts[$i]->id;
+                    $conflicting[] = $newShifts[$j]->id;
+                }
+            }
+        }
 
-                if ($a->starts_at < $b->ends_at && $a->ends_at > $b->starts_at) {
-                    $conflicting[] = $a->id;
-                    $conflicting[] = $b->id;
+        // New vs existing — only flag the new shift (existing is locked in the UI)
+        foreach ($newShifts as $new) {
+            foreach ($existingShifts as $existing) {
+                if ($new->starts_at < $existing->ends_at && $new->ends_at > $existing->starts_at) {
+                    $conflicting[] = $new->id;
                 }
             }
         }

--- a/app/Livewire/Public/VolunteerPortal.php
+++ b/app/Livewire/Public/VolunteerPortal.php
@@ -45,6 +45,8 @@ class VolunteerPortal extends Component
 
     public ?int $cancellingSignupId = null;
 
+    public bool $showCancelModal = false;
+
     public string $successMessage = '';
 
     public ?string $projectPublicToken = null;
@@ -220,15 +222,28 @@ class VolunteerPortal extends Component
     public function confirmCancel(int $signupId): void
     {
         $this->cancellingSignupId = $signupId;
+        $this->showCancelModal = true;
     }
 
     public function dismissCancel(): void
     {
         $this->cancellingSignupId = null;
+        $this->showCancelModal = false;
+    }
+
+    public function updatedShowCancelModal(bool $value): void
+    {
+        if (! $value) {
+            $this->cancellingSignupId = null;
+        }
     }
 
     public function cancelSignup(): void
     {
+        if (! $this->cancellingSignupId) {
+            return;
+        }
+
         $signup = $this->volunteer->shiftSignups()
             ->with('shift.volunteerJob.event.project')
             ->find($this->cancellingSignupId);
@@ -246,6 +261,7 @@ class VolunteerPortal extends Component
         }
 
         $this->cancellingSignupId = null;
+        $this->showCancelModal = false;
         $this->successMessage = 'Signup cancelled successfully.';
 
         unset($this->upcomingSignups, $this->pastSignups);

--- a/resources/views/livewire/public/volunteer-portal.blade.php
+++ b/resources/views/livewire/public/volunteer-portal.blade.php
@@ -271,7 +271,7 @@
 
         {{-- Cancel confirmation modal --}}
         @if ($cancellingSignupId)
-            <flux:modal wire:model="cancellingSignupId" class="max-w-sm">
+            <flux:modal wire:model="showCancelModal" class="max-w-sm">
                 <div class="space-y-4">
                     <h3 class="font-bebas text-white text-xl" style="letter-spacing: 0.04em;">{{ __('Cancel Signup?') }}</h3>
                     <p style="color: #a1a1aa;">{{ __('Are you sure you want to cancel this shift signup? Your spot will be freed for other volunteers.') }}</p>

--- a/tests/Feature/Livewire/VolunteerPortalTest.php
+++ b/tests/Feature/Livewire/VolunteerPortalTest.php
@@ -868,3 +868,64 @@ it('cannot delete another volunteers profile', function () {
     // Other volunteer should still exist
     expect(Volunteer::find($otherVolunteer->id))->not->toBeNull();
 });
+
+// --- Cancel modal: wire:model boolean coercion protection ---
+
+it('rejects cancellation when cancellingSignupId is coerced to boolean true', function () {
+    // Create decoy signups (different volunteer) to consume low IDs
+    $otherVolunteer = Volunteer::factory()->for($this->project)->create();
+    $decoyShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(5),
+        'ends_at' => now()->addDays(5)->addHours(2),
+    ]);
+    ShiftSignup::factory()->create(['volunteer_id' => $otherVolunteer->id, 'shift_id' => $this->futureShift->id]);
+    ShiftSignup::factory()->create(['volunteer_id' => $otherVolunteer->id, 'shift_id' => $decoyShift->id]);
+
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    // Ensure the real signup ID is not 1 (what true coerces to)
+    expect($signup->id)->toBeGreaterThan(1);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    // Simulate the corruption: Flux modal wire:model coerces integer to boolean true -> ?int casts to 1
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('confirmCancel', $signup->id)
+        ->set('cancellingSignupId', true)
+        ->call('cancelSignup')
+        ->assertForbidden();
+});
+
+it('cancellingSignupId is cleared when showCancelModal becomes false', function () {
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('confirmCancel', $signup->id)
+        ->assertSet('cancellingSignupId', $signup->id)
+        ->assertSet('showCancelModal', true)
+        ->set('showCancelModal', false)
+        ->assertSet('cancellingSignupId', null);
+});
+
+it('does not abort when cancellingSignupId is null', function () {
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->call('cancelSignup')
+        ->assertOk()
+        ->assertDontSee('Signup cancelled successfully');
+});

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -1130,3 +1130,130 @@ it('resets existingGearSelections on restartSignup', function () {
         ->assertSet('existingGearSelections', [])
         ->assertSet('gearSelections', []);
 });
+
+// --- Returning volunteer: overlap detection includes existing shifts ---
+
+it('detects overlap between new shift and existing shift for returning volunteer', function () {
+    $existingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'capacity' => 10,
+    ]);
+    $newShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $existingShift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->assertSet('existingShiftIds', [$existingShift->id])
+        ->set('selectedShiftIds', [$existingShift->id, $newShift->id])
+        ->assertSee(__('Conflict'))
+        ->assertSee(__('Some selected shifts overlap in time'))
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::SelectingShifts);
+
+    expect(ShiftReservation::count())->toBe(0);
+});
+
+it('allows new shift that does not overlap with existing shift for returning volunteer', function () {
+    $existingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 09:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'capacity' => 10,
+    ]);
+    $newShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 15:00:00'),
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $existingShift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$existingShift->id, $newShift->id])
+        ->assertDontSee(__('Conflict'))
+        ->call('reserveAndAdvance')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Confirming);
+});
+
+it('does not flag false conflict when existing shift has no defined times', function () {
+    $existingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => null,
+        'ends_at' => null,
+        'capacity' => 10,
+    ]);
+    $newShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $existingShift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$existingShift->id, $newShift->id])
+        ->assertDontSee(__('Conflict'))
+        ->call('reserveAndAdvance')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Confirming);
+});
+
+it('returning volunteer with existing shifts can reach confirming step without error', function () {
+    $existingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 09:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'capacity' => 10,
+    ]);
+    $newShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 15:00:00'),
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'returning-confirm@example.com',
+        'first_name' => 'Returning',
+        'last_name' => 'Confirmer',
+    ]);
+    ShiftSignup::factory()->create(['shift_id' => $existingShift->id, 'volunteer_id' => $volunteer->id]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning-confirm@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning-confirm@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$existingShift->id, $newShift->id])
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::Confirming)
+        ->assertSee('Confirm Your Signup')
+        ->assertSee('Returning Confirmer')
+        ->assertSee('returning-confirm@example.com')
+        ->assertSee(__('already signed up'));
+});


### PR DESCRIPTION
## Summary

- **#161 Bug 1:** Overlap detection in EventSignup now checks new shifts against existing (greyed-out) shifts of returning volunteers — previously only checked new-vs-new
- **#142:** Volunteer portal cancel returned 403 because `flux:modal wire:model="cancellingSignupId"` coerced the integer ID to boolean `true` (→ `1`). Decoupled modal visibility into separate `showCancelModal` bool with sync hook
- **#161 Bug 2:** Server-side test confirms the 500 on summary is browser-only — Playwright e2e confirms no 500 in browser after fix

### Changes

| File | Change |
|------|--------|
| `EventSignup.php` | Rewrote `overlappingShiftIds()` to compare new shifts against existing shifts |
| `VolunteerPortal.php` | Added `showCancelModal` property, `updatedShowCancelModal` hook, null guard in `cancelSignup()` |
| `volunteer-portal.blade.php` | Changed `wire:model` from `cancellingSignupId` to `showCancelModal` |
| `EventSignupTest.php` | +4 tests (overlap with existing, no-overlap, open-ended shift, confirming step) |
| `VolunteerPortalTest.php` | +3 tests (coercion simulation, sync hook, null guard) |

### Follow-up issues created

- #163 — UX: overlap warning should identify which specific shifts conflict
- #164 — Test cancelled-then-re-signup edge case

## Test plan

- [x] 1887 tests passing (full suite), 7 new tests added
- [x] Pint clean
- [x] E2E: returning volunteer signup with overlapping shift → "Conflict" badge + warning shown
- [x] E2E: volunteer portal cancel → succeeds without 403, DB updated
- [x] E2E: returning volunteer reaches confirming step → no 500, page renders correctly

Resolves #161, resolves #142