### PR TITLE
fix signup verification persistence and archive event announcements

### DIFF
--- a/app/Actions/ProcessVolunteerSignup.php
+++ b/app/Actions/ProcessVolunteerSignup.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Events\Activity\VolunteerSignedUp;
+use App\Models\EmailVerificationToken;
 use App\Models\Event;
 use App\Models\Shift;
 use App\Models\Volunteer;
@@ -36,6 +37,19 @@ class ProcessVolunteerSignup
             ['email' => $email, 'project_id' => $event->project_id],
             ['first_name' => $firstName, 'last_name' => $lastName, 'phone' => $phone],
         );
+
+        if (! $volunteer->isEmailVerified()) {
+            $verifiedAt = EmailVerificationToken::query()
+                ->where('project_id', $event->project_id)
+                ->where('email', $email)
+                ->whereNotNull('verified_at')
+                ->latest('verified_at')
+                ->value('verified_at');
+
+            if ($verifiedAt !== null) {
+                $volunteer->update(['email_verified_at' => $verifiedAt]);
+            }
+        }
 
         if ($phone !== null && $volunteer->phone !== $phone) {
             $volunteer->update(['phone' => $phone]);

--- a/app/Actions/SendAnnouncement.php
+++ b/app/Actions/SendAnnouncement.php
@@ -5,6 +5,7 @@ namespace App\Actions;
 use App\Models\Announcement;
 use App\Models\Volunteer;
 use App\Notifications\AnnouncementNotification;
+use Illuminate\Support\Facades\Notification;
 
 class SendAnnouncement
 {
@@ -37,6 +38,13 @@ class SendAnnouncement
 
         foreach ($volunteers as $volunteer) {
             $volunteer->notify(new AnnouncementNotification($announcement));
+        }
+
+        $notificationEmail = $announcement->event?->notification_email;
+
+        if ($notificationEmail && $volunteers->isNotEmpty()) {
+            Notification::route('mail', $notificationEmail)
+                ->notify(new AnnouncementNotification($announcement, true, $volunteers->count()));
         }
 
         $announcement->update([

--- a/app/Console/Commands/BackfillVolunteerEmailVerificationCommand.php
+++ b/app/Console/Commands/BackfillVolunteerEmailVerificationCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EmailVerificationToken;
+use App\Models\Volunteer;
+use Illuminate\Console\Command;
+
+class BackfillVolunteerEmailVerificationCommand extends Command
+{
+    protected $signature = 'app:backfill-volunteer-email-verification';
+
+    protected $description = 'Backfill volunteer email verification timestamps from verified email tokens';
+
+    public function handle(): int
+    {
+        $volunteers = Volunteer::query()
+            ->whereNull('email_verified_at')
+            ->whereExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('email_verification_tokens')
+                    ->whereColumn('email_verification_tokens.project_id', 'volunteers.project_id')
+                    ->whereColumn('email_verification_tokens.email', 'volunteers.email')
+                    ->whereNotNull('email_verification_tokens.verified_at');
+            })
+            ->get();
+
+        if ($volunteers->isEmpty()) {
+            $this->info('No volunteers needed backfilling.');
+
+            return self::SUCCESS;
+        }
+
+        $backfilled = 0;
+
+        $volunteers->each(function (Volunteer $volunteer) use (&$backfilled) {
+            $verifiedAt = EmailVerificationToken::query()
+                ->where('project_id', $volunteer->project_id)
+                ->where('email', $volunteer->email)
+                ->whereNotNull('verified_at')
+                ->latest('verified_at')
+                ->value('verified_at');
+
+            if ($verifiedAt === null) {
+                return;
+            }
+
+            $volunteer->update(['email_verified_at' => $verifiedAt]);
+            $backfilled++;
+        });
+
+        $this->info("Backfilled {$backfilled} volunteer(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Notifications/AnnouncementNotification.php
+++ b/app/Notifications/AnnouncementNotification.php
@@ -18,6 +18,8 @@ class AnnouncementNotification extends Notification implements ShouldQueue
 
     public function __construct(
         public Announcement $announcement,
+        public bool $isArchiveCopy = false,
+        public int $archiveRecipientCount = 0,
     ) {}
 
     /**
@@ -30,9 +32,17 @@ class AnnouncementNotification extends Notification implements ShouldQueue
 
     public function toMail(object $notifiable): MailMessage
     {
+        $subject = $this->isArchiveCopy
+            ? '[Archiv-Kopie] '.$this->announcement->subject
+            : $this->announcement->subject;
+
         $mail = (new MailMessage)
-            ->subject($this->announcement->subject)
-            ->greeting("Hallo {$notifiable->first_name}!");
+            ->subject($subject)
+            ->greeting($this->isArchiveCopy ? 'Hallo!' : "Hallo {$notifiable->first_name}!");
+
+        if ($this->isArchiveCopy) {
+            $mail->line("Kopie einer Nachricht, die an {$this->archiveRecipientCount} Volunteers versendet wurde.");
+        }
 
         foreach (explode("\n", $this->announcement->body) as $line) {
             $trimmed = trim($line);

--- a/app/Notifications/SignupConfirmation.php
+++ b/app/Notifications/SignupConfirmation.php
@@ -67,7 +67,7 @@ class SignupConfirmation extends Notification implements ShouldQueue
                 'shift_date' => $firstShift->shift_date->setTimezone($tz)->format('d.m.Y'),
                 'shift_time' => $firstShift->displayTimeRange($tz),
                 'event_location' => $this->event->location ? "**Ort:** {$this->event->location}" : '',
-                'portal_link' => route('volunteer.ticket', $this->magicLinkToken),
+                'portal_link' => route('volunteer.portal', $this->magicLinkToken),
                 'project_name' => $this->event->project?->name ?? '',
                 'kontakt_email' => $this->event->project?->contact_email ?? $this->event->organization->smtp_from_address ?? '',
             ],
@@ -84,8 +84,8 @@ class SignupConfirmation extends Notification implements ShouldQueue
             }
         }
 
-        $ticketUrl = route('volunteer.ticket', $this->magicLinkToken);
-        $mail->action('Ticket anzeigen', $ticketUrl);
+        $portalUrl = route('volunteer.portal', $this->magicLinkToken);
+        $mail->action('Portal öffnen', $portalUrl);
 
         return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
     }

--- a/tests/Feature/Actions/ProcessVolunteerSignupTest.php
+++ b/tests/Feature/Actions/ProcessVolunteerSignupTest.php
@@ -17,8 +17,10 @@ use App\Models\VolunteerGear;
 use App\Models\VolunteerJob;
 use App\Notifications\EmailVerification;
 use App\Notifications\SignupConfirmation;
+use App\ValueObjects\HashedToken;
 use App\ValueObjects\ShiftSignupResult;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 
 beforeEach(function () {
     Notification::fake();
@@ -86,6 +88,58 @@ it('creates volunteer and signups for new volunteer', function () {
         Volunteer::where('email', 'new@example.com')->first(),
         SignupConfirmation::class,
     );
+});
+
+it('marks a newly created volunteer as verified when a matching email token was already verified', function () {
+    EmailVerificationToken::factory()->create([
+        'event_id' => $this->event->id,
+        'project_id' => $this->project->id,
+        'email' => 'verified-new@example.com',
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $action = app(ProcessVolunteerSignup::class);
+
+    $action->execute(
+        firstName: 'Verified',
+        lastName: 'New',
+        email: 'verified-new@example.com',
+        event: $this->event,
+        shiftIds: [$this->shift->id],
+    );
+
+    expect(Volunteer::where('email', 'verified-new@example.com')->first())
+        ->not->toBeNull()
+        ->email_verified_at->not->toBeNull();
+});
+
+it('reuses verification from another event in the same project', function () {
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+
+    EmailVerificationToken::factory()->create([
+        'event_id' => $otherEvent->id,
+        'project_id' => $this->project->id,
+        'email' => 'cross-event@example.com',
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $action = app(ProcessVolunteerSignup::class);
+
+    $action->execute(
+        firstName: 'Cross',
+        lastName: 'Event',
+        email: 'cross-event@example.com',
+        event: $this->event,
+        shiftIds: [$this->shift->id],
+    );
+
+    expect(Volunteer::where('email', 'cross-event@example.com')->first())
+        ->not->toBeNull()
+        ->email_verified_at->not->toBeNull();
 });
 
 it('completes signup for verified returning volunteer', function () {

--- a/tests/Feature/Actions/SendAnnouncementTest.php
+++ b/tests/Feature/Actions/SendAnnouncementTest.php
@@ -145,3 +145,85 @@ it('does not re-send already sent announcement', function () {
 
     Notification::assertNothingSent();
 });
+
+it('sends one archive copy to the event notification email when present', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'notification_email' => 'archive@example.com',
+    ]);
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create();
+    ShiftSignup::factory()->for($volunteer)->for($shift)->create();
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'created_by' => $this->creator->id,
+    ]);
+
+    $this->action->execute($announcement);
+
+    Notification::assertSentTo($volunteer, AnnouncementNotification::class);
+    Notification::assertSentOnDemand(
+        AnnouncementNotification::class,
+        function (AnnouncementNotification $notification, array $channels, object $notifiable) {
+            return $notifiable->routes['mail'] === 'archive@example.com'
+                && $notification->archiveRecipientCount === 1
+                && $notification->isArchiveCopy;
+        }
+    );
+    expect($announcement->fresh()->recipient_count)->toBe(1);
+});
+
+it('does not send an archive copy when the event has no notification email', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'notification_email' => null,
+    ]);
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create();
+    ShiftSignup::factory()->for($volunteer)->for($shift)->create();
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'created_by' => $this->creator->id,
+    ]);
+
+    $this->action->execute($announcement);
+
+    Notification::assertSentTo($volunteer, AnnouncementNotification::class);
+    Notification::assertSentOnDemandTimes(AnnouncementNotification::class, 0);
+});
+
+it('does not send an archive copy when no volunteer recipients match', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'notification_email' => 'archive@example.com',
+    ]);
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'created_by' => $this->creator->id,
+    ]);
+
+    $this->action->execute($announcement);
+
+    Notification::assertNothingSent();
+    expect($announcement->fresh()->recipient_count)->toBe(0);
+});
+
+it('renders archive copies with a labeled subject and recipient summary', function () {
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'subject' => 'Shift Update',
+        'body' => "Line one\nLine two",
+        'created_by' => $this->creator->id,
+    ]);
+
+    $mail = (new AnnouncementNotification($announcement, true, 3))
+        ->toMail((object) ['first_name' => 'Organizer']);
+
+    expect($mail->subject)->toBe('[Archiv-Kopie] Shift Update')
+        ->and(implode(' ', $mail->introLines))->toContain('Kopie einer Nachricht, die an 3 Volunteers versendet wurde.')
+        ->and(implode(' ', $mail->introLines))->toContain('Line one')
+        ->and(implode(' ', $mail->introLines))->toContain('Line two');
+});

--- a/tests/Feature/BackfillVolunteerEmailVerificationCommandTest.php
+++ b/tests/Feature/BackfillVolunteerEmailVerificationCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\EmailVerificationToken;
+use App\Models\Event;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Volunteer;
+use App\ValueObjects\HashedToken;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+});
+
+it('backfills volunteer email_verified_at from matching verified tokens', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'backfill@example.com',
+        'email_verified_at' => null,
+    ]);
+
+    EmailVerificationToken::factory()->create([
+        'event_id' => $this->event->id,
+        'project_id' => $this->project->id,
+        'email' => $volunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subHour(),
+    ]);
+
+    $this->artisan('app:backfill-volunteer-email-verification')
+        ->expectsOutput('Backfilled 1 volunteer(s).')
+        ->assertSuccessful();
+
+    expect($volunteer->fresh()->email_verified_at)->not->toBeNull();
+});
+
+it('skips volunteers without a matching verified token', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'unverified@example.com',
+        'email_verified_at' => null,
+    ]);
+
+    EmailVerificationToken::factory()->create([
+        'event_id' => $this->event->id,
+        'project_id' => $this->project->id,
+        'email' => $volunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => null,
+    ]);
+
+    $this->artisan('app:backfill-volunteer-email-verification')
+        ->expectsOutput('No volunteers needed backfilling.')
+        ->assertSuccessful();
+
+    expect($volunteer->fresh()->email_verified_at)->toBeNull();
+});
+
+it('backfills from a verified token on another event in the same project', function () {
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'cross-event-backfill@example.com',
+        'email_verified_at' => null,
+    ]);
+
+    EmailVerificationToken::factory()->create([
+        'event_id' => $otherEvent->id,
+        'project_id' => $this->project->id,
+        'email' => $volunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subHour(),
+    ]);
+
+    $this->artisan('app:backfill-volunteer-email-verification')
+        ->expectsOutput('Backfilled 1 volunteer(s).')
+        ->assertSuccessful();
+
+    expect($volunteer->fresh()->email_verified_at)->not->toBeNull();
+});

--- a/tests/Feature/Flows/VolunteerSignupFlowTest.php
+++ b/tests/Feature/Flows/VolunteerSignupFlowTest.php
@@ -76,7 +76,8 @@ it('completes full flow: email → verify → info → shifts → confirm → co
     $volunteer = Volunteer::where('email', 'alice@flow.test')->first();
     expect($volunteer)->not->toBeNull()
         ->and($volunteer->first_name)->toBe('Alice')
-        ->and($volunteer->last_name)->toBe('Flow');
+        ->and($volunteer->last_name)->toBe('Flow')
+        ->and($volunteer->email_verified_at)->not->toBeNull();
 
     expect(ShiftSignup::where('volunteer_id', $volunteer->id)->where('shift_id', $this->shift->id)->exists())->toBeTrue();
     expect(Ticket::where('volunteer_id', $volunteer->id)->where('project_id', $this->project->id)->exists())->toBeTrue();

--- a/tests/Feature/Notifications/SignupConfirmationTest.php
+++ b/tests/Feature/Notifications/SignupConfirmationTest.php
@@ -75,7 +75,6 @@ it('includes ticket action URL in German', function () {
     $notification = new SignupConfirmation($this->event, [$this->shift->id], 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
-    // #81 - Updated to German button text
-    expect($mail->actionText)->toBe('Ticket anzeigen')
-        ->and($mail->actionUrl)->toBe(route('volunteer.ticket', 'test-token'));
+    expect($mail->actionText)->toBe('Portal öffnen')
+        ->and($mail->actionUrl)->toBe(route('volunteer.portal', 'test-token'));
 });


### PR DESCRIPTION
## Summary
- persist volunteer email verification across project events during signup, switch signup confirmations to the portal, and add a backfill command for already affected records
- send a labeled archive copy of event-scoped announcements to the event notification inbox only when volunteer recipients actually matched
- add focused test coverage for cross-event verification reuse, the backfill command, portal CTA behavior, and archive-copy delivery rules

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Actions/ProcessVolunteerSignupTest.php tests/Feature/Actions/SendAnnouncementTest.php tests/Feature/BackfillVolunteerEmailVerificationCommandTest.php tests/Feature/Flows/VolunteerSignupFlowTest.php tests/Feature/Notifications/SignupConfirmationTest.php
- vendor/bin/sail bin pint --dirty --format agent

Closes #175
Closes #176