### PR TITLE
fix flaky email verification link test

### DIFF
--- a/issue-170-plan.md
+++ b/issue-170-plan.md
@@ -1,0 +1,47 @@
+# Issue 170 Plan
+
+## Goal
+Fix `#170` so the organizer event volunteer list no longer treats cancelled signups as active shifts, while still surfacing cancellation information.
+
+## Current State
+- `app/Livewire/Events/VolunteerList.php` loads all signups for the event.
+- `resources/views/livewire/events/volunteer-list.blade.php` uses `shiftSignups->count()` directly.
+- Attendance also uses all signups as the denominator.
+- Result: cancelled signups inflate shift counts and attendance counts.
+
+## Product Direction
+Per `docs/decisions/2026-04-09-po-session.md`:
+- Organizer/Admin view should still retain visibility into cancellations.
+- Cancelled signups should be marked, not treated as active.
+
+## Smallest Safe Fix
+Keep loading all event signups, but split them in the Blade view:
+- `activeSignups`: `shiftSignups` where `cancelled_at` is null
+- `cancelledCount`: count of cancelled signups
+
+Render:
+- `Shifts` column: active count as primary value
+- if cancellations exist, show secondary muted marker like `1 storniert`
+- `Attendance` column: compute denominator and marked count from `activeSignups` only
+
+## Files to Change
+- `resources/views/livewire/events/volunteer-list.blade.php`
+- `tests/Feature/Events/VolunteerListTest.php`
+
+## Tests to Add
+1. Volunteer with 2 active + 1 cancelled signup:
+   - list shows active count `2`
+   - list also shows cancelled marker `1 storniert`
+2. Attendance denominator excludes cancelled signups:
+   - if 1 active signup has attendance and 1 cancelled signup exists, badge shows `1/1`, not `1/2`
+3. Optional:
+   - volunteer with only cancelled signups still appears with `0` active and cancellation marker
+
+## Verification
+- `vendor/bin/sail artisan test --compact tests/Feature/Events/VolunteerListTest.php`
+- `vendor/bin/sail bin pint --dirty --format agent`
+
+## Notes
+- Do not filter cancelled signups out at query level for this issue.
+- Do not redesign the table into a per-shift detail view in this fix.
+- A richer cancelled-shift display can be a follow-up enhancement.

--- a/tests/Feature/Public/EmailVerificationPageTest.php
+++ b/tests/Feature/Public/EmailVerificationPageTest.php
@@ -7,6 +7,7 @@ use App\Models\Organization;
 use App\Models\Project;
 use App\Models\Volunteer;
 use App\ValueObjects\HashedToken;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
@@ -60,7 +61,7 @@ it('shows already-verified message for re-used token', function () {
 it('includes continue-signup link with token hash', function () {
     $plainToken = Str::random(64);
     $hashed = HashedToken::fromPlaintext($plainToken);
-    $token = EmailVerificationToken::factory()->create([
+    EmailVerificationToken::factory()->create([
         'volunteer_id' => $this->volunteer->id,
         'event_id' => $this->event->id,
         'email' => $this->volunteer->email,
@@ -71,9 +72,10 @@ it('includes continue-signup link with token hash', function () {
     $component = Livewire::test(EmailVerificationPage::class, ['token' => $plainToken]);
 
     $continueUrl = $component->get('continueSignupUrl');
-    expect($continueUrl)->toContain('vt='.$hashed->hash)
-        ->and($continueUrl)->toContain($this->event->public_token)
-        ->and($continueUrl)->not->toContain('vt='.$token->id);
+    parse_str(parse_url($continueUrl, PHP_URL_QUERY) ?? '', $query);
+
+    expect($continueUrl)->toContain($this->event->public_token)
+        ->and(Arr::get($query, 'vt'))->toBe($hashed->hash);
 });
 
 it('shows expired message for expired token', function () {


### PR DESCRIPTION
## Summary
- fix the flaky `EmailVerificationPageTest` assertion by checking the parsed `vt` query param instead of relying on a brittle substring exclusion
- add `issue-170-plan.md` to capture the agreed implementation plan for the organizer volunteer list cancellation fix

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Public/EmailVerificationPageTest.php tests/Feature/Actions/ProcessVolunteerSignupTest.php tests/Feature/Flows/VolunteerSignupFlowTest.php
- vendor/bin/sail bin pint --dirty --format agent