### PR TITLE
fix event volunteer list cancelled signup counts

### DIFF
--- a/resources/views/livewire/events/volunteer-list.blade.php
+++ b/resources/views/livewire/events/volunteer-list.blade.php
@@ -42,6 +42,12 @@
                 </flux:table.columns>
                 <flux:table.rows>
                     @foreach ($this->volunteers as $volunteer)
+                        @php
+                            $activeSignups = $volunteer->shiftSignups->reject(fn ($signup) => $signup->isCancelled());
+                            $cancelledCount = $volunteer->shiftSignups->count() - $activeSignups->count();
+                            $total = $activeSignups->count();
+                            $marked = $activeSignups->filter(fn ($signup) => $signup->attendanceRecord)->count();
+                        @endphp
                         <flux:table.row :key="'volunteer-'.$volunteer->id">
                             <flux:table.cell>
                                 <a href="{{ route('events.volunteers.show', [$event, $volunteer]) }}" wire:navigate class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">
@@ -49,7 +55,16 @@
                                 </a>
                             </flux:table.cell>
                             <flux:table.cell>{{ $volunteer->email }}</flux:table.cell>
-                            <flux:table.cell>{{ $volunteer->shiftSignups->count() }}</flux:table.cell>
+                            <flux:table.cell>
+                                <div class="flex flex-col gap-1">
+                                    <span data-test="volunteer-active-shifts-{{ $volunteer->id }}">{{ $total }}</span>
+                                    @if ($cancelledCount > 0)
+                                        <flux:text size="sm" class="text-zinc-500 dark:text-zinc-400" data-test="volunteer-cancelled-shifts-{{ $volunteer->id }}">
+                                            {{ __(':count storniert', ['count' => $cancelledCount]) }}
+                                        </flux:text>
+                                    @endif
+                                </div>
+                            </flux:table.cell>
                             <flux:table.cell>
                                 @if ($volunteer->eventArrivals->isNotEmpty())
                                     <flux:badge size="sm" color="emerald">{{ __('Yes') }}</flux:badge>
@@ -58,10 +73,7 @@
                                 @endif
                             </flux:table.cell>
                             <flux:table.cell>
-                                @php
-                                    $total = $volunteer->shiftSignups->count();
-                                    $marked = $volunteer->shiftSignups->filter(fn ($s) => $s->attendanceRecord)->count();
-                                @endphp
+                                <div data-test="volunteer-attendance-{{ $volunteer->id }}">
                                 @if ($total === 0)
                                     <flux:badge size="sm" color="zinc">{{ __('None') }}</flux:badge>
                                 @elseif ($marked === $total)
@@ -71,6 +83,7 @@
                                 @else
                                     <flux:badge size="sm" color="zinc">{{ __('0/:total', ['total' => $total]) }}</flux:badge>
                                 @endif
+                                </div>
                             </flux:table.cell>
                         </flux:table.row>
                     @endforeach

--- a/tests/Feature/Events/VolunteerListTest.php
+++ b/tests/Feature/Events/VolunteerListTest.php
@@ -165,3 +165,67 @@ it('shows attendance badge', function () {
         ->assertSee('Attended Bob')
         ->assertSee('1/1');
 });
+
+it('shows cancelled signup count separately from active shifts', function () {
+    $secondShift = Shift::factory()->for($this->job, 'volunteerJob')->create();
+    $thirdShift = Shift::factory()->for($this->job, 'volunteerJob')->create();
+    $volunteer = Volunteer::factory()->for($this->project)->create(['first_name' => 'Cancelled', 'last_name' => 'Count']);
+
+    ShiftSignup::factory()->create(['volunteer_id' => $volunteer->id, 'shift_id' => $this->shift->id]);
+    ShiftSignup::factory()->create(['volunteer_id' => $volunteer->id, 'shift_id' => $secondShift->id]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $thirdShift->id,
+        'cancelled_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerList::class, ['eventId' => $this->event->id])
+        ->assertSee('Cancelled Count')
+        ->assertSeeHtml('data-test="volunteer-active-shifts-'.$volunteer->id.'">2</span>')
+        ->assertSee('1 storniert');
+});
+
+it('excludes cancelled signups from attendance totals', function () {
+    $secondShift = Shift::factory()->for($this->job, 'volunteerJob')->create();
+    $volunteer = Volunteer::factory()->for($this->project)->create(['first_name' => 'Attendance', 'last_name' => 'Filtered']);
+
+    $activeSignup = ShiftSignup::factory()->create(['volunteer_id' => $volunteer->id, 'shift_id' => $this->shift->id]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $secondShift->id,
+        'cancelled_at' => now(),
+    ]);
+
+    AttendanceRecord::create([
+        'shift_signup_id' => $activeSignup->id,
+        'status' => AttendanceStatus::OnTime,
+        'recorded_by' => $this->user->id,
+        'recorded_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerList::class, ['eventId' => $this->event->id])
+        ->assertSee('Attendance Filtered')
+        ->assertSeeHtml('data-test="volunteer-attendance-'.$volunteer->id.'">')
+        ->assertSee('1/1')
+        ->assertDontSee('1/2')
+        ->assertSee('1 storniert');
+});
+
+it('keeps volunteers with only cancelled signups visible', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create(['first_name' => 'Only', 'last_name' => 'Cancelled']);
+
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $this->shift->id,
+        'cancelled_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerList::class, ['eventId' => $this->event->id])
+        ->assertSee('Only Cancelled')
+        ->assertSeeHtml('data-test="volunteer-active-shifts-'.$volunteer->id.'">0</span>')
+        ->assertSee('1 storniert')
+        ->assertSee('None');
+});


### PR DESCRIPTION
## Summary
- show active shift counts separately from cancelled signups in the organizer event volunteer list
- exclude cancelled signups from attendance totals while keeping cancellation history visible in the table
- add regression coverage for mixed active/cancelled signups and the all-cancelled volunteer edge case

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Events/VolunteerListTest.php
- vendor/bin/sail bin pint --dirty --format agent

Closes #170