### PR TITLE
feat: let organizers delete volunteer profiles

### DIFF
--- a/app/Actions/DeleteVolunteerProfile.php
+++ b/app/Actions/DeleteVolunteerProfile.php
@@ -2,10 +2,12 @@
 
 namespace App\Actions;
 
+use App\Enums\ActivityCategory;
 use App\Enums\StaffRole;
 use App\Exceptions\DomainException;
 use App\Models\ActivityLog;
 use App\Models\Project;
+use App\Models\User;
 use App\Models\Volunteer;
 use App\Notifications\ProfileDeletionConfirmation;
 use App\Notifications\VolunteerProfileDeletedNotification;
@@ -14,19 +16,20 @@ use Illuminate\Support\Facades\Log;
 
 class DeleteVolunteerProfile
 {
-    public function execute(Volunteer $volunteer): void
+    public function execute(Volunteer $volunteer, bool $enforceCancellationGuard = true, ?User $initiatedBy = null): void
     {
         $volunteer->loadMissing('project.organization');
         $project = $volunteer->project;
 
-        $this->guardAgainstNonCancellableShifts($volunteer, $project);
+        if ($enforceCancellationGuard) {
+            $this->guardAgainstNonCancellableShifts($volunteer, $project);
+        }
 
         $volunteerName = $volunteer->full_name;
         $organization = $project->organization;
 
-        // 1. Send confirmation email synchronously (before deletion)
         try {
-            $volunteer->notifyNow(new ProfileDeletionConfirmation($project));
+            $volunteer->notifyNow(new ProfileDeletionConfirmation($project, $initiatedBy?->name));
         } catch (\Throwable $e) {
             Log::warning('Failed to send profile deletion confirmation email', [
                 'volunteer_id' => $volunteer->id,
@@ -34,12 +37,9 @@ class DeleteVolunteerProfile
             ]);
         }
 
-        // 2. Collect upcoming shift details for organizer notification (before deletion)
         $shiftSummary = $this->collectUpcomingShiftSummary($volunteer);
 
-        // 3. DB::transaction: clean up activity logs + delete volunteer
-        DB::transaction(function () use ($volunteer, $volunteerName) {
-            // Nullify causer references and preserve name in properties
+        DB::transaction(function () use ($initiatedBy, $organization, $project, $volunteer, $volunteerName) {
             ActivityLog::where('causer_type', Volunteer::class)
                 ->where('causer_id', $volunteer->id)
                 ->each(function (ActivityLog $log) use ($volunteerName) {
@@ -52,7 +52,6 @@ class DeleteVolunteerProfile
                     ]);
                 });
 
-            // Preserve name in subject references (subject columns are NOT nullable)
             ActivityLog::where('subject_type', Volunteer::class)
                 ->where('subject_id', $volunteer->id)
                 ->each(function (ActivityLog $log) use ($volunteerName) {
@@ -61,11 +60,28 @@ class DeleteVolunteerProfile
                     $log->update(['properties' => $properties]);
                 });
 
-            // Cascade handles child records (signups, tickets, gear, tokens, etc.)
+            if ($initiatedBy) {
+                ActivityLog::create([
+                    'organization_id' => $organization->id,
+                    'project_id' => $project->id,
+                    'causer_type' => User::class,
+                    'causer_id' => $initiatedBy->id,
+                    'subject_type' => Volunteer::class,
+                    'subject_id' => $volunteer->id,
+                    'action' => 'deleted',
+                    'category' => ActivityCategory::Volunteer,
+                    'description' => "{$initiatedBy->name} deleted volunteer profile {$volunteerName}",
+                    'properties' => [
+                        'volunteer_name' => $volunteerName,
+                        'deleted_volunteer_name' => $volunteerName,
+                        'initiated_by_name' => $initiatedBy->name,
+                    ],
+                ]);
+            }
+
             $volunteer->delete();
         });
 
-        // 4. Notify organizers (outside transaction, after successful delete)
         $organizers = $organization->users()
             ->wherePivot('role', StaffRole::Organizer)
             ->get();
@@ -76,6 +92,7 @@ class DeleteVolunteerProfile
                     $volunteerName,
                     $project,
                     $shiftSummary,
+                    $initiatedBy?->name,
                 ));
             } catch (\Throwable $e) {
                 Log::warning('Failed to notify organizer about volunteer deletion', [

--- a/app/Livewire/Events/VolunteerDetail.php
+++ b/app/Livewire/Events/VolunteerDetail.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Events;
 
+use App\Actions\DeleteVolunteerProfile;
 use App\Actions\PromoteVolunteer;
 use App\Actions\RecordArrival;
 use App\Actions\RecordGearPickup;
@@ -17,6 +18,7 @@ use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
@@ -33,6 +35,10 @@ class VolunteerDetail extends Component
     public Volunteer $volunteer;
 
     public bool $showPromoteModal = false;
+
+    public bool $showDeleteModal = false;
+
+    public bool $deleteConfirmed = false;
 
     public string $promoteRole = 'organizer';
 
@@ -141,7 +147,7 @@ class VolunteerDetail extends Component
                 volunteer: $this->volunteer,
                 organization: $this->event->organization,
                 role: $role,
-                promotedBy: auth()->user(),
+                promotedBy: Auth::user(),
                 scannerId: $this->selectedScannerId !== '' ? (int) $this->selectedScannerId : null,
             );
 
@@ -154,6 +160,29 @@ class VolunteerDetail extends Component
         } catch (DomainException $e) {
             $this->addError('promote', $e->getMessage());
         }
+    }
+
+    public function deleteVolunteer(): void
+    {
+        Gate::authorize('update', $this->event);
+
+        if (! $this->deleteConfirmed) {
+            return;
+        }
+
+        try {
+            app(DeleteVolunteerProfile::class)->execute(
+                $this->volunteer,
+                enforceCancellationGuard: false,
+                initiatedBy: Auth::user(),
+            );
+        } catch (DomainException $e) {
+            $this->addError('delete', $e->getMessage());
+
+            return;
+        }
+
+        $this->redirect(route('events.volunteers', $this->event));
     }
 
     public function markAsArrived(): void
@@ -171,7 +200,7 @@ class VolunteerDetail extends Component
         app(RecordArrival::class)->execute(
             ticket: $ticket,
             event: $this->event,
-            scannedBy: auth()->user(),
+            scannedBy: Auth::user(),
             method: ArrivalMethod::ManualLookup,
         );
 
@@ -186,7 +215,7 @@ class VolunteerDetail extends Component
             ->findOrFail($gearId);
 
         try {
-            app(RecordGearPickup::class)->execute($gear, auth()->user());
+            app(RecordGearPickup::class)->execute($gear, Auth::user());
         } catch (DomainException $e) {
             $this->addError('gear', $e->getMessage());
         }

--- a/app/Notifications/ProfileDeletionConfirmation.php
+++ b/app/Notifications/ProfileDeletionConfirmation.php
@@ -13,6 +13,7 @@ class ProfileDeletionConfirmation extends Notification
 
     public function __construct(
         public Project $project,
+        public ?string $deletedByName = null,
     ) {}
 
     /**
@@ -25,10 +26,14 @@ class ProfileDeletionConfirmation extends Notification
 
     public function toMail(object $notifiable): MailMessage
     {
+        $deletionLine = $this->deletedByName
+            ? "Dein Volunteer-Profil und alle zugehörigen Daten wurden durch {$this->deletedByName} gelöscht."
+            : 'Dein Volunteer-Profil und alle zugehörigen Daten wurden auf deine Anfrage hin gelöscht.';
+
         $mail = (new MailMessage)
             ->subject('Dein Profil wurde gelöscht')
             ->greeting("Hallo {$notifiable->first_name}!")
-            ->line('Dein Volunteer-Profil und alle zugehörigen Daten wurden auf deine Anfrage hin gelöscht.')
+            ->line($deletionLine)
             ->line('**Folgende Daten wurden unwiderruflich entfernt:**')
             ->line('- Alle Schicht-Anmeldungen')
             ->line('- Eventuelle Tickets und QR-Codes')

--- a/app/Notifications/VolunteerProfileDeletedNotification.php
+++ b/app/Notifications/VolunteerProfileDeletedNotification.php
@@ -20,6 +20,7 @@ class VolunteerProfileDeletedNotification extends Notification implements Should
         public string $volunteerName,
         public Project $project,
         public string $shiftSummary,
+        public ?string $deletedByName = null,
     ) {}
 
     /**
@@ -32,10 +33,14 @@ class VolunteerProfileDeletedNotification extends Notification implements Should
 
     public function toMail(object $notifiable): MailMessage
     {
+        $deletionLine = $this->deletedByName
+            ? "**{$this->volunteerName}** wurde im Projekt **{$this->project->name}** durch **{$this->deletedByName}** gelöscht."
+            : "**{$this->volunteerName}** hat sein Volunteer-Profil im Projekt **{$this->project->name}** gelöscht.";
+
         $mail = (new MailMessage)
             ->subject("Volunteer-Profil gelöscht: {$this->volunteerName}")
             ->greeting("Hallo {$notifiable->name}!")
-            ->line("**{$this->volunteerName}** hat sein Volunteer-Profil im Projekt **{$this->project->name}** gelöscht.")
+            ->line($deletionLine)
             ->line('Alle zugehörigen Daten (Anmeldungen, Tickets, Gear) wurden unwiderruflich entfernt.');
 
         if ($this->shiftSummary !== '') {

--- a/e2e/organizer-delete-volunteer.spec.ts
+++ b/e2e/organizer-delete-volunteer.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test('organizer can delete a volunteer profile from event detail', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByPlaceholder('email@example.com').fill('test@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+
+    await page.goto('/admin/events');
+    await page.getByRole('link', { name: 'Spring Community Fair' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/events\/\d+$/);
+
+    await page.goto(`${page.url()}/volunteers`);
+
+    await expect(page).toHaveURL(/\/admin\/events\/\d+\/volunteers$/);
+
+    await page.getByPlaceholder('Search volunteers...').fill('E2E Delete Volunteer');
+    await page.getByRole('link', { name: 'E2E Delete Volunteer' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/events\/\d+\/volunteers\/\d+$/);
+    await expect(page.getByText('E2E Delete Volunteer').first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Volunteer löschen' }).click();
+
+    await expect(page.getByText('Dieses Event öffnet nur den Einstiegspunkt.')).toBeVisible();
+
+    await page.getByRole('checkbox', { name: 'Ich bestätige die endgültige Löschung des gesamten Volunteer-Profils.' }).check();
+    await page.getByRole('button', { name: 'Volunteer endgültig löschen' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/events\/\d+\/volunteers$/);
+
+    await page.getByPlaceholder('Search volunteers...').fill('E2E Delete Volunteer');
+    await expect(page.getByText('No volunteers match your search.')).toBeVisible();
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -24,7 +24,25 @@ vendor/bin/sail artisan tinker --execute="
   echo 'EntranceStaff user created';
 "
 
-# 4. Clear Mailpit inbox
+# 4. Create deterministic volunteer for organizer deletion E2E
+echo "Creating organizer-delete E2E volunteer..."
+vendor/bin/sail artisan tinker --execute="
+  \$event = \App\Models\Event::where('name', 'Spring Community Fair')->firstOrFail();
+  \$shift = \App\Models\Shift::whereHas('volunteerJob', fn (\$q) => \$q->where('event_id', \$event->id))->firstOrFail();
+  \$volunteer = \App\Models\Volunteer::factory()->verified()->for(\$event->project)->create([
+    'first_name' => 'E2E',
+    'last_name' => 'Delete Volunteer',
+    'email' => 'e2e-delete-volunteer@example.com',
+    'phone' => '+15550001111',
+  ]);
+  \App\Models\ShiftSignup::factory()->create([
+    'volunteer_id' => \$volunteer->id,
+    'shift_id' => \$shift->id,
+  ]);
+  echo 'E2E volunteer created';
+ "
+
+# 5. Clear Mailpit inbox
 echo "Clearing Mailpit inbox..."
 curl -s -X DELETE http://localhost:8025/api/v1/messages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             },
             "devDependencies": {
                 "@playwright/mcp": "^0.0.68",
+                "@playwright/test": "^1.59.1",
                 "@vitest/coverage-v8": "^4.0.18",
                 "fake-indexeddb": "^6.2.5",
                 "jsdom": "^28.1.0",
@@ -787,6 +788,54 @@
             },
             "bin": {
                 "playwright-mcp": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.59.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@playwright/test/node_modules/playwright": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.59.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/@playwright/test/node_modules/playwright-core": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
             },
             "engines": {
                 "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "build": "vite build",
         "dev": "vite",
         "test": "vitest",
+        "test:e2e": "playwright test",
         "test:e2e:setup": "bash e2e/setup.sh"
     },
     "dependencies": {
@@ -26,6 +27,7 @@
         "lightningcss-linux-x64-gnu": "^1.29.1"
     },
     "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@playwright/mcp": "^0.0.68",
         "@vitest/coverage-v8": "^4.0.18",
         "fake-indexeddb": "^6.2.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    testMatch: ['**/*.spec.ts'],
+    fullyParallel: false,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    reporter: 'list',
+    use: {
+        baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+});

--- a/resources/views/livewire/events/volunteer-detail.blade.php
+++ b/resources/views/livewire/events/volunteer-detail.blade.php
@@ -6,7 +6,7 @@
 
     <x-events.layout :event="$event">
         {{-- Info card --}}
-        <div class="rounded-xl border border-zinc-200 dark:border-zinc-700 p-6 mb-6">
+            <div class="rounded-xl border border-zinc-200 dark:border-zinc-700 p-6 mb-6">
             <div class="flex items-center justify-between mb-4">
                 <div class="flex items-center gap-3">
                     <flux:heading size="lg">{{ __('Volunteer Info') }}</flux:heading>
@@ -15,9 +15,14 @@
                     @endif
                 </div>
                 @if ($this->canPromote)
-                    <flux:button variant="primary" size="sm" icon="arrow-up-circle" wire:click="$set('showPromoteModal', true)">
-                        {{ __('Promote to Staff') }}
-                    </flux:button>
+                    <div class="flex items-center gap-2">
+                        <flux:button variant="danger" size="sm" icon="trash" wire:click="$set('showDeleteModal', true)">
+                            {{ __('Volunteer löschen') }}
+                        </flux:button>
+                        <flux:button variant="primary" size="sm" icon="arrow-up-circle" wire:click="$set('showPromoteModal', true)">
+                            {{ __('Promote to Staff') }}
+                        </flux:button>
+                    </div>
                 @endif
             </div>
             <div class="grid gap-4 sm:grid-cols-2">
@@ -226,6 +231,29 @@
                     <flux:button variant="ghost" wire:click="$set('showPromoteModal', false)">{{ __('Abbrechen') }}</flux:button>
                     <flux:button variant="primary" wire:click="promoteVolunteer" :disabled="$promoteRole === 'volunteer_admin' && $this->vaScanners->isEmpty()">
                         {{ __('Befördern') }}
+                    </flux:button>
+                </div>
+            </div>
+        </flux:modal>
+
+        <flux:modal wire:model="showDeleteModal" focusable class="max-w-lg">
+            <div class="space-y-4">
+                <flux:heading size="lg">{{ __('Volunteer löschen') }}</flux:heading>
+                <flux:text>{{ __('Dieses Event öffnet nur den Einstiegspunkt. Gelöscht wird das gesamte Volunteer-Profil im Projekt :project.', ['project' => $event->project->name]) }}</flux:text>
+                <flux:callout variant="warning">
+                    {{ __('Alle zugehörigen Projekt-Daten werden unwiderruflich entfernt: Schicht-Anmeldungen, Tickets/QR-Codes, Gear-Zuweisungen und persönliche Daten.') }}
+                </flux:callout>
+                <flux:checkbox
+                    wire:model.live="deleteConfirmed"
+                    :label="__('Ich bestätige die endgültige Löschung des gesamten Volunteer-Profils.')"
+                />
+
+                <flux:error name="delete" />
+
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" wire:click="$set('showDeleteModal', false)">{{ __('Abbrechen') }}</flux:button>
+                    <flux:button variant="danger" wire:click="deleteVolunteer" :disabled="! $deleteConfirmed">
+                        {{ __('Volunteer endgültig löschen') }}
                     </flux:button>
                 </div>
             </div>

--- a/tests/Feature/Actions/DeleteVolunteerProfileGuardTest.php
+++ b/tests/Feature/Actions/DeleteVolunteerProfileGuardTest.php
@@ -1,14 +1,17 @@
 <?php
 
 use App\Actions\DeleteVolunteerProfile;
+use App\Enums\StaffRole;
 use App\Exceptions\DomainException;
 use App\Models\Event;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\Shift;
 use App\Models\ShiftSignup;
+use App\Models\User;
 use App\Models\Volunteer;
 use App\Models\VolunteerJob;
+use Illuminate\Support\Facades\Notification;
 
 beforeEach(function () {
     $this->org = Organization::factory()->create();
@@ -19,10 +22,14 @@ beforeEach(function () {
     $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create();
     $this->job = VolunteerJob::factory()->for($this->event)->create();
     $this->volunteer = Volunteer::factory()->for($this->project)->verified()->create();
+    $this->organizer = User::factory()->create();
+    $this->project->users()->attach($this->organizer, ['role' => StaffRole::Organizer]);
     $this->action = new DeleteVolunteerProfile;
 });
 
 it('blocks deletion when volunteer has non-cancellable future shifts [#143]', function () {
+    Notification::fake();
+
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'starts_at' => now()->addHours(12),
         'ends_at' => now()->addHours(14),
@@ -37,6 +44,8 @@ it('blocks deletion when volunteer has non-cancellable future shifts [#143]', fu
 });
 
 it('allows deletion when all shifts are completed [#143]', function () {
+    Notification::fake();
+
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'starts_at' => now()->subHours(4),
         'ends_at' => now()->subHours(2),
@@ -52,6 +61,8 @@ it('allows deletion when all shifts are completed [#143]', function () {
 });
 
 it('allows deletion when all shifts are cancellable [#143]', function () {
+    Notification::fake();
+
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'starts_at' => now()->addDays(5),
         'ends_at' => now()->addDays(5)->addHours(2),
@@ -67,12 +78,16 @@ it('allows deletion when all shifts are cancellable [#143]', function () {
 });
 
 it('allows deletion when volunteer has no active signups [#143]', function () {
+    Notification::fake();
+
     $this->action->execute($this->volunteer);
 
     expect(Volunteer::find($this->volunteer->id))->toBeNull();
 });
 
 it('allows deletion when only cancelled signups exist [#143]', function () {
+    Notification::fake();
+
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'starts_at' => now()->addHours(12),
         'ends_at' => now()->addHours(14),
@@ -89,6 +104,8 @@ it('allows deletion when only cancelled signups exist [#143]', function () {
 });
 
 it('allows deletion when cancellation is disabled on project [#143]', function () {
+    Notification::fake();
+
     $this->project->update(['cancellation_enabled' => false, 'cancellation_cutoff_hours' => null]);
 
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
@@ -106,6 +123,8 @@ it('allows deletion when cancellation is disabled on project [#143]', function (
 });
 
 it('blocks deletion for shifts without defined times past cutoff [#143]', function () {
+    Notification::fake();
+
     $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'shift_date' => now()->toDateString(),
         'starts_at' => null,
@@ -119,4 +138,21 @@ it('blocks deletion for shifts without defined times past cutoff [#143]', functi
 
     expect(fn () => $this->action->execute($this->volunteer))
         ->toThrow(DomainException::class, 'Dein Profil kann gerade nicht gelöscht werden');
+});
+
+it('allows organizer-initiated deletion even when volunteer has non-cancellable future shifts [#148]', function () {
+    Notification::fake();
+
+    $shift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addHours(12),
+        'ends_at' => now()->addHours(14),
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    $this->action->execute($this->volunteer, false, $this->organizer);
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
 });

--- a/tests/Feature/Actions/DeleteVolunteerProfileTest.php
+++ b/tests/Feature/Actions/DeleteVolunteerProfileTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\DeleteVolunteerProfile;
+use App\Enums\ActivityCategory;
 use App\Enums\StaffRole;
 use App\Models\ActivityLog;
 use App\Models\Event;
@@ -80,6 +81,16 @@ it('sends confirmation email before deletion', function () {
     Notification::assertSentTo($this->volunteer, ProfileDeletionConfirmation::class);
 });
 
+it('uses self-service wording for volunteer deletion confirmation', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer);
+
+    Notification::assertSentTo($this->volunteer, ProfileDeletionConfirmation::class, function ($notification) {
+        return $notification->deletedByName === null;
+    });
+});
+
 it('notifies organizer after deletion', function () {
     Notification::fake();
 
@@ -145,4 +156,32 @@ it('includes upcoming shifts in organizer notification', function () {
     Notification::assertSentTo($this->organizer, VolunteerProfileDeletedNotification::class, function ($notification) {
         return str_contains($notification->shiftSummary, 'Setup Crew');
     });
+});
+
+it('records organizer-initiated deletion context in notifications and activity logs', function () {
+    Notification::fake();
+
+    app(DeleteVolunteerProfile::class)->execute($this->volunteer, false, $this->organizer);
+
+    Notification::assertSentTo($this->volunteer, ProfileDeletionConfirmation::class, function ($notification) {
+        return $notification->deletedByName === $this->organizer->name;
+    });
+
+    Notification::assertSentTo($this->organizer, VolunteerProfileDeletedNotification::class, function ($notification) {
+        return $notification->deletedByName === $this->organizer->name;
+    });
+
+    $log = ActivityLog::query()
+        ->where('causer_type', User::class)
+        ->where('causer_id', $this->organizer->id)
+        ->where('subject_type', Volunteer::class)
+        ->where('subject_id', $this->volunteer->id)
+        ->where('action', 'deleted')
+        ->first();
+
+    expect($log)->not->toBeNull()
+        ->and($log->category)->toBe(ActivityCategory::Volunteer)
+        ->and($log->project_id)->toBe($this->project->id)
+        ->and($log->properties)->toHaveKey('initiated_by_name', $this->organizer->name)
+        ->and($log->properties)->toHaveKey('deleted_volunteer_name', 'Test Volunteer');
 });

--- a/tests/Feature/Events/VolunteerDetailTest.php
+++ b/tests/Feature/Events/VolunteerDetailTest.php
@@ -109,6 +109,7 @@ it('shows not arrived status when no arrival', function () {
 it('shows promote button for organizer when not promoted', function () {
     Livewire::actingAs($this->user)
         ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertSee('Volunteer löschen')
         ->assertSee('Promote to Staff');
 });
 
@@ -117,6 +118,20 @@ it('denies promotion for non-organizer', function () {
 
     $this->actingAs($outsider)
         ->get(route('events.volunteers.show', [$this->event, $this->volunteer]))
+        ->assertForbidden();
+});
+
+it('allows project members to view volunteer detail but forbids deletion', function () {
+    $member = User::factory()->create();
+    $this->project->users()->attach($member, ['role' => StaffRole::VolunteerAdmin]);
+
+    $this->actingAs($member)
+        ->get(route('events.volunteers.show', [$this->event, $this->volunteer]))
+        ->assertOk();
+
+    Livewire::actingAs($member)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('deleteVolunteer')
         ->assertForbidden();
 });
 
@@ -190,6 +205,60 @@ it('promotes volunteer and creates user', function () {
 
     expect($this->volunteer->fresh()->user_id)->not->toBeNull();
     expect(User::where('email', $this->volunteer->email)->exists())->toBeTrue();
+});
+
+it('requires confirmation before deleting a volunteer profile', function () {
+    Notification::fake();
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->set('showDeleteModal', true)
+        ->call('deleteVolunteer');
+
+    expect(Volunteer::find($this->volunteer->id))->not->toBeNull();
+});
+
+it('deletes volunteer profile from detail page and redirects to event volunteer list', function () {
+    Notification::fake();
+
+    $expectedUrl = route('events.volunteers', $this->event);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->set('showDeleteModal', true)
+        ->set('deleteConfirmed', true)
+        ->call('deleteVolunteer')
+        ->assertRedirect($expectedUrl);
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
+});
+
+it('lets organizer delete volunteer even when self-service deletion would be blocked', function () {
+    Notification::fake();
+
+    $this->project->update([
+        'cancellation_enabled' => true,
+        'cancellation_cutoff_hours' => 24,
+    ]);
+
+    $blockingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addHours(12),
+        'ends_at' => now()->addHours(14),
+    ]);
+
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $blockingShift->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->set('showDeleteModal', true)
+        ->set('deleteConfirmed', true)
+        ->call('deleteVolunteer')
+        ->assertRedirect(route('events.volunteers', $this->event));
+
+    expect(Volunteer::find($this->volunteer->id))->toBeNull();
 });
 
 // --- Arrival management tests ---


### PR DESCRIPTION
## Summary
- add an organizer-only delete flow on event volunteer detail that removes the full volunteer profile without applying self-service cancellation cutoff rules
- make deletion notifications and activity logging context-aware so organizer-triggered deletions are communicated and audited correctly
- add focused Pest coverage and a Playwright E2E test with deterministic setup for the organizer deletion journey

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Actions/DeleteVolunteerProfileGuardTest.php
- vendor/bin/sail artisan test --compact tests/Feature/Actions/DeleteVolunteerProfileTest.php
- vendor/bin/sail artisan test --compact tests/Feature/Events/VolunteerDetailTest.php
- vendor/bin/sail npx playwright test e2e/organizer-delete-volunteer.spec.ts
- vendor/bin/sail bin pint --dirty --format agent

Closes #148