### PR TITLE
feat: add multi-organization dashboard overview

### DIFF
--- a/app/Actions/SetCurrentOrganization.php
+++ b/app/Actions/SetCurrentOrganization.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Organization;
+use App\Models\User;
+
+class SetCurrentOrganization
+{
+    public function execute(User $user, Organization $organization): void
+    {
+        session(['current_organization_id' => $organization->id]);
+
+        if ($user->current_organization_id !== $organization->id) {
+            $user->updateQuietly(['current_organization_id' => $organization->id]);
+        }
+    }
+}

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Actions\SetCurrentOrganization;
 use App\Models\Organization;
 use Closure;
 use Illuminate\Http\Request;
@@ -58,11 +59,7 @@ class ResolveOrganization
             return $next($request);
         }
 
-        session(['current_organization_id' => $organization->id]);
-
-        if ($user->current_organization_id !== $organization->id) {
-            $user->updateQuietly(['current_organization_id' => $organization->id]);
-        }
+        app(SetCurrentOrganization::class)->execute($user, $organization);
 
         app()->instance(Organization::class, $organization);
 

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -2,15 +2,20 @@
 
 namespace App\Livewire;
 
+use App\Actions\SetCurrentOrganization;
 use App\Enums\AttendanceStatus;
 use App\Models\AttendanceRecord;
 use App\Models\Event;
 use App\Models\Organization;
+use App\Models\Project;
 use App\Models\Shift;
 use App\Models\ShiftSignup;
+use App\Models\User;
 use App\Models\Volunteer;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
@@ -33,7 +38,10 @@ class Dashboard extends Component
     #[Computed]
     public function userRole(): ?string
     {
-        return auth()->user()->orgRoleFor($this->organization)?->value;
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user->orgRoleFor($this->organization)?->value;
     }
 
     #[Computed]
@@ -43,31 +51,69 @@ class Dashboard extends Component
     }
 
     /**
+     * Accessible organizations with safe cross-org previews.
+     *
+     * @return Collection<int, array{
+     *     organization: Organization,
+     *     is_active: bool,
+     *     role: string|null,
+     *     project_count: int,
+     *     projects: EloquentCollection<int, Project>,
+     *     remaining_project_count: int,
+     *     upcoming_events: EloquentCollection<int, Event>
+     * }>
+     */
+    #[Computed]
+    public function discoverableOrganizations(): Collection
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return Organization::query()
+            ->whereIn('id', $user->accessibleOrganizationIds())
+            ->orderByRaw('id = ? desc', [$this->organization->id])
+            ->orderBy('name')
+            ->get()
+            ->map(function (Organization $organization) use ($user): array {
+                $visibleProjects = $this->visibleProjectsQuery($organization)
+                    ->orderBy('name')
+                    ->get(['id', 'organization_id', 'name']);
+
+                $upcomingEvents = $this->scopedEventsFor($organization)
+                    ->active()
+                    ->published()
+                    ->with('project:id,name')
+                    ->where('starts_at', '>=', now())
+                    ->orderBy('starts_at')
+                    ->limit(3)
+                    ->get(['id', 'organization_id', 'project_id', 'name', 'starts_at']);
+
+                return [
+                    'organization' => $organization,
+                    'is_active' => $organization->is($this->organization),
+                    'role' => $user->orgRoleFor($organization)?->value,
+                    'project_count' => $visibleProjects->count(),
+                    'projects' => $visibleProjects->take(3)->values(),
+                    'remaining_project_count' => max($visibleProjects->count() - 3, 0),
+                    'upcoming_events' => $upcomingEvents,
+                ];
+            });
+    }
+
+    /**
      * Projects accessible to the current user, with aggregate metrics.
      */
     #[Computed]
-    public function projects(): Collection
+    public function projects(): EloquentCollection
     {
-        $user = auth()->user();
-
-        $query = $this->organization->projects()
-            ->active()
+        return $this->visibleProjectsQuery($this->organization)
             ->withCount([
                 'events' => fn ($q) => $q->published()->where('starts_at', '>=', now()),
                 'volunteers',
                 'scanners',
             ])
-            ->latest();
-
-        if (! $user->isOrgOrganizerFor($this->organization)) {
-            $assignedProjectIds = $user->projects()
-                ->where('projects.organization_id', $this->organization->id)
-                ->pluck('projects.id');
-
-            $query->whereIn('id', $assignedProjectIds);
-        }
-
-        return $query->get();
+            ->latest()
+            ->get();
     }
 
     /**
@@ -151,10 +197,10 @@ class Dashboard extends Component
      * Global volunteer search across all projects.
      */
     #[Computed]
-    public function searchResults(): Collection
+    public function searchResults(): EloquentCollection
     {
         if (strlen($this->search) < 2) {
-            return new Collection;
+            return new EloquentCollection;
         }
 
         $projectIds = $this->projects->pluck('id');
@@ -221,7 +267,7 @@ class Dashboard extends Component
     }
 
     #[Computed]
-    public function recentPastEvents(): Collection
+    public function recentPastEvents(): EloquentCollection
     {
         $events = $this->scopedEvents()
             ->published()
@@ -233,24 +279,59 @@ class Dashboard extends Component
             ->limit(5)
             ->get();
 
-        $user = auth()->user();
+        /** @var User $user */
+        $user = Auth::user();
         $projectIds = $events->pluck('project_id')->unique()->values()->all();
         $user->preloadProjectRoles($projectIds);
 
         return $events;
     }
 
-    private function scopedEvents(): HasMany
+    public function switchOrganization(int $organizationId, SetCurrentOrganization $action): void
     {
-        $user = auth()->user();
-        $query = $this->organization->events();
+        $organization = Organization::findOrFail($organizationId);
+        /** @var User $user */
+        $user = Auth::user();
 
-        if (! $user->isOrgOrganizerFor($this->organization)) {
+        Gate::authorize('view', $organization);
+
+        $action->execute($user, $organization);
+
+        $this->redirect(route('dashboard'), navigate: true);
+    }
+
+    private function visibleProjectsQuery(Organization $organization): HasMany
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        $query = $organization->projects()->active();
+
+        if (! $user->isOrgOrganizerFor($organization)) {
             $projectIds = $user->projects()
-                ->where('projects.organization_id', $this->organization->id)
+                ->where('projects.organization_id', $organization->id)
                 ->pluck('projects.id');
 
-            $query->whereIn('project_id', $projectIds);
+            $query->whereIn('id', $projectIds);
+        }
+
+        return $query;
+    }
+
+    private function scopedEvents(): HasMany
+    {
+        return $this->scopedEventsFor($this->organization);
+    }
+
+    private function scopedEventsFor(Organization $organization): HasMany
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        $query = $organization->events();
+
+        if (! $user->isOrgOrganizerFor($organization)) {
+            $query->whereIn('project_id', $this->visibleProjectsQuery($organization)->select('projects.id'));
         }
 
         return $query;

--- a/app/Livewire/OrganizationSwitcher.php
+++ b/app/Livewire/OrganizationSwitcher.php
@@ -4,9 +4,12 @@ namespace App\Livewire;
 
 use App\Actions\CreateOrganization;
 use App\Actions\LeaveOrganization;
+use App\Actions\SetCurrentOrganization;
 use App\Exceptions\DomainException;
 use App\Models\Organization;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
@@ -27,7 +30,8 @@ class OrganizationSwitcher extends Component
     #[Computed]
     public function organizations(): Collection
     {
-        $user = auth()->user();
+        /** @var User $user */
+        $user = Auth::user();
         $orgIds = $user->accessibleOrganizationIds();
 
         return Organization::whereIn('id', $orgIds)->orderBy('name')->get();
@@ -49,14 +53,15 @@ class OrganizationSwitcher extends Component
         return $this->organizations->firstWhere('id', $this->leaveOrganizationId);
     }
 
-    public function switchOrganization(int $organizationId): void
+    public function switchOrganization(int $organizationId, SetCurrentOrganization $action): void
     {
         $organization = Organization::findOrFail($organizationId);
+        /** @var User $user */
+        $user = Auth::user();
 
         Gate::authorize('view', $organization);
 
-        session(['current_organization_id' => $organization->id]);
-        auth()->user()->updateQuietly(['current_organization_id' => $organization->id]);
+        $action->execute($user, $organization);
 
         $this->redirect(route('dashboard'), navigate: true);
     }
@@ -66,8 +71,11 @@ class OrganizationSwitcher extends Component
         $this->newOrgSlug = Str::slug($value);
     }
 
-    public function createOrganization(CreateOrganization $action): void
+    public function createOrganization(CreateOrganization $action, SetCurrentOrganization $setCurrentOrganization): void
     {
+        /** @var User $user */
+        $user = Auth::user();
+
         Gate::authorize('create', Organization::class);
 
         $this->validate([
@@ -76,13 +84,12 @@ class OrganizationSwitcher extends Component
         ]);
 
         $organization = $action->execute(
-            user: auth()->user(),
+            user: $user,
             name: $this->newOrgName,
             slug: $this->newOrgSlug,
         );
 
-        session(['current_organization_id' => $organization->id]);
-        auth()->user()->updateQuietly(['current_organization_id' => $organization->id]);
+        $setCurrentOrganization->execute($user, $organization);
 
         $this->reset('showCreateModal', 'newOrgName', 'newOrgSlug');
 
@@ -99,13 +106,15 @@ class OrganizationSwitcher extends Component
     public function leaveOrganization(LeaveOrganization $action): void
     {
         $organization = $this->organizationToLeave;
+        /** @var User $user */
+        $user = Auth::user();
 
         if (! $organization) {
             return;
         }
 
         try {
-            $action->execute(auth()->user(), $organization);
+            $action->execute($user, $organization);
         } catch (DomainException $e) {
             $this->addError('leave', $e->getMessage());
 

--- a/e2e/dashboard-multi-org-overview.spec.ts
+++ b/e2e/dashboard-multi-org-overview.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+test('dashboard shows accessible organizations and lets user switch active org', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByPlaceholder('email@example.com').fill('dashboard@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+    await expect(page.getByText('Dashboard Explorer Personal Org').first()).toBeVisible();
+    await expect(page.getByText('Organisationen')).toBeVisible();
+    await expect(page.locator('div').filter({ hasText: /^Shared Community Org$/ })).toBeVisible();
+    await expect(page.getByText('Neighborhood Welcome Project', { exact: true })).toBeVisible();
+    await expect(page.getByText('Community Onboarding Day', { exact: true })).toBeVisible();
+
+    const sharedOrgCard = page.locator('div')
+        .filter({ hasText: 'Shared Community Org' })
+        .filter({ has: page.getByRole('button', { name: 'Wechseln' }) })
+        .first();
+    await sharedOrgCard.getByRole('button', { name: 'Wechseln' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+    await expect(page.locator('div').filter({ hasText: 'Willkommen, Dashboard Explorer!' }).first()).toContainText('Shared Community Org');
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -42,7 +42,47 @@ vendor/bin/sail artisan tinker --execute="
   echo 'E2E volunteer created';
  "
 
-# 5. Clear Mailpit inbox
+# 5. Create deterministic multi-org dashboard user
+echo "Creating dashboard discoverability E2E user..."
+vendor/bin/sail artisan tinker --execute="
+  \$user = \App\Models\User::factory()->create([
+    'name' => 'Dashboard Explorer',
+    'email' => 'dashboard@example.com',
+    'password' => bcrypt('password'),
+  ]);
+
+  \$personalOrg = \App\Models\Organization::factory()->create([
+    'name' => 'Dashboard Explorer Personal Org',
+    'slug' => 'dashboard-explorer-personal',
+  ]);
+  \$personalOrg->users()->attach(\$user, ['role' => \App\Enums\StaffRole::Organizer]);
+
+  \$sharedOrg = \App\Models\Organization::factory()->create([
+    'name' => 'Shared Community Org',
+    'slug' => 'shared-community-org',
+  ]);
+  \$sharedOrg->users()->attach(\$user, ['role' => \App\Enums\StaffRole::Organizer]);
+
+  \$sharedProject = \App\Models\Project::factory()->for(\$sharedOrg)->create([
+    'name' => 'Neighborhood Welcome Project',
+  ]);
+
+  \App\Models\Event::factory()->for(\$sharedOrg)->for(\$sharedProject)->published()->create([
+    'name' => 'Community Onboarding Day',
+    'slug' => 'community-onboarding-day',
+    'starts_at' => now()->addDays(10),
+    'ends_at' => now()->addDays(10)->addHours(4),
+  ]);
+
+  \$user->update([
+    'personal_organization_id' => \$personalOrg->id,
+    'current_organization_id' => \$personalOrg->id,
+  ]);
+
+  echo 'Dashboard discoverability user created';
+"
+
+# 6. Clear Mailpit inbox
 echo "Clearing Mailpit inbox..."
 curl -s -X DELETE http://localhost:8025/api/v1/messages
 
@@ -51,3 +91,4 @@ echo "=== Setup complete ==="
 echo "Users available:"
 echo "  Organizer:      test@example.com / password"
 echo "  EntranceStaff:  entrance@example.com / password"
+echo "  Dashboard user: dashboard@example.com / password"

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -42,6 +42,91 @@
         </div>
     @endif
 
+    @if ($this->discoverableOrganizations->isNotEmpty())
+        <div class="mb-8">
+            <div class="mb-4 flex items-center justify-between gap-3">
+                <div>
+                    <flux:heading size="lg">{{ __('Organisationen') }}</flux:heading>
+                    <flux:text class="text-zinc-500">{{ __('Wechsle schnell zwischen deinen zugaenglichen Bereichen und sieh sichere Vorschauen auf Projekte und kommende Events.') }}</flux:text>
+                </div>
+            </div>
+
+            <div class="grid gap-4 lg:grid-cols-2">
+                @foreach ($this->discoverableOrganizations as $organizationOverview)
+                    @php
+                        $organization = $organizationOverview['organization'];
+                        $role = $organizationOverview['role'];
+                    @endphp
+
+                    <div wire:key="discoverable-org-{{ $organization->id }}" class="rounded-xl border border-zinc-200 dark:border-zinc-700 p-5">
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <flux:heading size="sm">{{ $organization->name }}</flux:heading>
+                                    @if ($organizationOverview['is_active'])
+                                        <flux:badge size="sm" color="emerald">{{ __('Aktiv') }}</flux:badge>
+                                    @endif
+                                    <flux:badge size="sm">{{ $role ? __(ucfirst(str_replace('_', ' ', $role))) : __('Projektzugang') }}</flux:badge>
+                                </div>
+                                <flux:text size="sm" class="mt-2 text-zinc-500">
+                                    {{ trans_choice(':count sichtbares Projekt|:count sichtbare Projekte', $organizationOverview['project_count'], ['count' => $organizationOverview['project_count']]) }}
+                                </flux:text>
+                            </div>
+
+                            @if ($organizationOverview['is_active'])
+                                <flux:button variant="subtle" size="sm" :href="route('projects.index')" wire:navigate>
+                                    {{ __('Oeffnen') }}
+                                </flux:button>
+                            @else
+                                <flux:button variant="outline" size="sm" wire:click="switchOrganization({{ $organization->id }})">
+                                    {{ __('Wechseln') }}
+                                </flux:button>
+                            @endif
+                        </div>
+
+                        <div class="mt-4 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <flux:text size="sm" class="font-medium">{{ __('Projekte') }}</flux:text>
+                                @if ($organizationOverview['projects']->isEmpty())
+                                    <flux:text size="sm" class="mt-2 text-zinc-500">{{ __('Keine sichtbaren Projekte') }}</flux:text>
+                                @else
+                                    <div class="mt-2 space-y-2">
+                                        @foreach ($organizationOverview['projects'] as $project)
+                                            <div class="rounded-lg bg-zinc-50 dark:bg-zinc-800/60 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-200">
+                                                {{ $project->name }}
+                                            </div>
+                                        @endforeach
+                                        @if ($organizationOverview['remaining_project_count'] > 0)
+                                            <flux:text size="sm" class="text-zinc-500">
+                                                {{ trans_choice('+ :count weiteres Projekt|+ :count weitere Projekte', $organizationOverview['remaining_project_count'], ['count' => $organizationOverview['remaining_project_count']]) }}
+                                            </flux:text>
+                                        @endif
+                                    </div>
+                                @endif
+                            </div>
+
+                            <div>
+                                <flux:text size="sm" class="font-medium">{{ __('Kommende Events') }}</flux:text>
+                                @if ($organizationOverview['upcoming_events']->isEmpty())
+                                    <flux:text size="sm" class="mt-2 text-zinc-500">{{ __('Keine bevorstehenden Events') }}</flux:text>
+                                @else
+                                    <div class="mt-2 space-y-2">
+                                        @foreach ($organizationOverview['upcoming_events'] as $event)
+                                            <div class="rounded-lg bg-zinc-50 dark:bg-zinc-800/60 px-3 py-2">
+                                                <div class="text-sm font-medium text-zinc-700 dark:text-zinc-200">{{ $event->name }}</div>
+                                                <div class="text-xs text-zinc-500">{{ $event->starts_at->format('d.m.Y H:i') }} @if ($event->project) &middot; {{ $event->project->name }} @endif</div>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
     {{-- Smart reminders --}}
     @if (count($this->reminders) > 0)
         <div class="mb-6 space-y-2">

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -342,3 +342,55 @@ test('project organizer only sees events from assigned project', function () {
         ->assertSee('My Project Event')
         ->assertDontSee('Other Project Event');
 });
+
+test('shows cross-organization overview with safe scoped previews', function () {
+    ['user' => $user, 'organization' => $currentOrg] = createUserWithOrganization();
+    $directAccessOrg = Organization::factory()->create(['name' => 'Direct Access Org']);
+    $directAccessOrg->users()->attach($user, ['role' => StaffRole::VolunteerAdmin]);
+
+    $projectAccessOrg = Organization::factory()->create(['name' => 'Project Access Org']);
+    $visibleProject = Project::factory()->for($projectAccessOrg)->create(['name' => 'Visible Project']);
+    $hiddenProject = Project::factory()->for($projectAccessOrg)->create(['name' => 'Hidden Project']);
+    $visibleProject->users()->attach($user, ['role' => StaffRole::Organizer]);
+
+    Event::factory()->for($projectAccessOrg)->for($visibleProject)->published()->create([
+        'name' => 'Visible Cross-Org Event',
+        'starts_at' => now()->addDays(2),
+        'ends_at' => now()->addDays(2)->addHours(4),
+    ]);
+    Event::factory()->for($projectAccessOrg)->for($hiddenProject)->published()->create([
+        'name' => 'Hidden Cross-Org Event',
+        'starts_at' => now()->addDays(3),
+        'ends_at' => now()->addDays(3)->addHours(4),
+    ]);
+
+    app()->instance(Organization::class, $currentOrg);
+
+    Livewire::actingAs($user)
+        ->test(Dashboard::class)
+        ->assertSee('Organisationen')
+        ->assertSee($currentOrg->name)
+        ->assertSee('Direct Access Org')
+        ->assertSee('Project Access Org')
+        ->assertSee('Projektzugang')
+        ->assertSee('Visible Project')
+        ->assertSee('Visible Cross-Org Event')
+        ->assertDontSee('Hidden Project')
+        ->assertDontSee('Hidden Cross-Org Event');
+});
+
+test('can switch organization from the dashboard overview', function () {
+    ['user' => $user, 'organization' => $currentOrg] = createUserWithOrganization();
+    $secondOrg = Organization::factory()->create();
+    $secondOrg->users()->attach($user, ['role' => StaffRole::Organizer]);
+
+    app()->instance(Organization::class, $currentOrg);
+
+    Livewire::actingAs($user)
+        ->test(Dashboard::class)
+        ->call('switchOrganization', $secondOrg->id)
+        ->assertSessionHas('current_organization_id', $secondOrg->id)
+        ->assertRedirect(route('dashboard'));
+
+    expect($user->fresh()->current_organization_id)->toBe($secondOrg->id);
+});

--- a/tests/Feature/OrganizationSwitcherTest.php
+++ b/tests/Feature/OrganizationSwitcherTest.php
@@ -3,6 +3,7 @@
 use App\Enums\StaffRole;
 use App\Livewire\OrganizationSwitcher;
 use App\Models\Organization;
+use App\Models\Project;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -46,6 +47,21 @@ it('prevents switching to non-member organization', function () {
         ->test(OrganizationSwitcher::class)
         ->call('switchOrganization', $otherOrg->id)
         ->assertForbidden();
+});
+
+it('lists and switches to organizations accessible through project membership', function () {
+    $projectAccessOrg = Organization::factory()->create(['name' => 'Project Access Org']);
+    $project = Project::factory()->for($projectAccessOrg)->create();
+    $project->users()->attach($this->user, ['role' => StaffRole::Organizer]);
+
+    Livewire::actingAs($this->user)
+        ->test(OrganizationSwitcher::class)
+        ->assertSee('Project Access Org')
+        ->call('switchOrganization', $projectAccessOrg->id)
+        ->assertSessionHas('current_organization_id', $projectAccessOrg->id)
+        ->assertRedirect(route('dashboard'));
+
+    expect($this->user->fresh()->current_organization_id)->toBe($projectAccessOrg->id);
 });
 
 it('creates organization and auto-switches', function () {


### PR DESCRIPTION
## Summary
- add a dashboard organizations overview that surfaces all accessible orgs with safe project and upcoming event previews for invited and multi-org users
- extract shared active-organization persistence into a reusable action and reuse it from the dashboard, switcher, and resolver middleware
- add focused feature coverage and a Playwright E2E that verifies discoverability and switching from the dashboard

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/DashboardTest.php
- vendor/bin/sail artisan test --compact tests/Feature/OrganizationSwitcherTest.php
- vendor/bin/sail pint --dirty --format=agent
- bash e2e/setup.sh
- vendor/bin/sail npx playwright test e2e/dashboard-multi-org-overview.spec.ts

Closes #174