### PR TITLE
feat(deploy): add pre-deploy backup workflow

### DIFF
--- a/bin/backup-prod-db
+++ b/bin/backup-prod-db
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly COMPOSE_FILE="${REPO_ROOT}/docker-compose.prod.yml"
+readonly BACKUP_DIR="/opt/backups/voluntify/db"
+
+mkdir -p "${BACKUP_DIR}"
+
+if [[ ! -w "${BACKUP_DIR}" ]]; then
+    printf 'Backup directory is not writable: %s\n' "${BACKUP_DIR}" >&2
+    exit 1
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+readonly final_path="${BACKUP_DIR}/pre-deploy-${timestamp}.sql.gz"
+readonly temp_path="${final_path}.tmp"
+
+cleanup() {
+    rm -f "${temp_path}"
+}
+
+trap cleanup EXIT
+
+printf 'Creating database backup at %s\n' "${final_path}" >&2
+
+docker compose -f "${COMPOSE_FILE}" exec -T mariadb sh -lc '
+    exec mariadb-dump \
+        -u root \
+        -p"$MARIADB_ROOT_PASSWORD" \
+        "$MARIADB_DATABASE" \
+        --single-transaction --quick --routines --triggers
+' | gzip > "${temp_path}"
+
+if [[ ! -s "${temp_path}" ]]; then
+    printf 'Backup file is empty: %s\n' "${temp_path}" >&2
+    exit 1
+fi
+
+gzip -t "${temp_path}"
+mv "${temp_path}" "${final_path}"
+
+find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'pre-deploy-*.sql.gz' -mtime +14 -delete
+
+printf '%s\n' "${final_path}"

--- a/bin/deploy-prod
+++ b/bin/deploy-prod
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly COMPOSE_FILE="${REPO_ROOT}/docker-compose.prod.yml"
+readonly BACKUP_SCRIPT="${SCRIPT_DIR}/backup-prod-db"
+readonly APP_CONTAINER="voluntify-app"
+readonly HEALTH_TIMEOUT_SECONDS=120
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: %s <image-tag>\n' "$0" >&2
+    exit 1
+fi
+
+readonly image_tag="$1"
+readonly previous_image="$(docker inspect --format='{{.Config.Image}}' "${APP_CONTAINER}" 2>/dev/null || true)"
+readonly previous_image_id="$(docker inspect --format='{{.Image}}' "${APP_CONTAINER}" 2>/dev/null || true)"
+
+backup_path="$(${BACKUP_SCRIPT})"
+
+printf 'Backup created: %s\n' "${backup_path}"
+
+IMAGE_TAG="${image_tag}" docker compose -f "${COMPOSE_FILE}" pull app scheduler queue
+IMAGE_TAG="${image_tag}" docker compose -f "${COMPOSE_FILE}" up -d app scheduler queue
+
+for ((elapsed_seconds = 0; elapsed_seconds < HEALTH_TIMEOUT_SECONDS; elapsed_seconds += 5)); do
+    health_status="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${APP_CONTAINER}" 2>/dev/null || true)"
+
+    if [[ "${health_status}" == "healthy" ]]; then
+        break
+    fi
+
+    sleep 5
+done
+
+health_status="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${APP_CONTAINER}" 2>/dev/null || true)"
+
+if [[ "${health_status}" != "healthy" ]]; then
+    printf 'App container did not become healthy within %s seconds. Current status: %s\n' "${HEALTH_TIMEOUT_SECONDS}" "${health_status:-unknown}" >&2
+    exit 1
+fi
+
+printf '\nDeployment complete for image tag: %s\n' "${image_tag}"
+
+if [[ -n "${previous_image}" ]]; then
+    printf 'Previous image: %s\n' "${previous_image}"
+
+    if [[ "${previous_image}" == *':latest' ]]; then
+        printf 'Warning: previous deployment used a mutable latest tag, so rollback should prefer the recorded image ID or a known CI tag.\n'
+    fi
+fi
+
+if [[ -n "${previous_image_id}" ]]; then
+    printf 'Previous image ID: %s\n' "${previous_image_id}"
+fi
+
+printf 'Verify:\n'
+printf '  docker compose -f %q ps\n' "${COMPOSE_FILE}"
+printf '  docker compose -f %q logs --tail=50 app\n' "${COMPOSE_FILE}"
+printf '  curl -f https://your-domain.example/up\n'
+
+printf 'Rollback:\n'
+printf '  docker compose -f %q stop app queue scheduler\n' "${COMPOSE_FILE}"
+printf '  gunzip -c %q | docker compose -f %q exec -T mariadb sh -lc %q\n' "${backup_path}" "${COMPOSE_FILE}" 'exec mariadb -u root -p"$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE"'
+
+if [[ -n "${previous_image}" ]]; then
+    previous_tag="${previous_image##*:}"
+    printf '  IMAGE_TAG=%q docker compose -f %q up -d app scheduler queue\n' "${previous_tag}" "${COMPOSE_FILE}"
+fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -161,23 +161,24 @@ No manual image builds are needed — merging a PR to `main` is sufficient.
 Voluntify uses a single Docker image for all services. After CI pushes a new image to GHCR, update the VPS:
 
 ```bash
-# 1. Record the current image SHA (for rollback)
-docker inspect --format='{{.Config.Image}}' voluntify-app
+# 1. Deploy a specific CI-built image tag (recommended: Git commit SHA)
+./bin/deploy-prod 0123abcd4567ef89...
 
-# 2. Pull the new image
-docker compose -f docker-compose.prod.yml pull
-
-# 3. Take a DB snapshot before applying changes
-docker compose -f docker-compose.prod.yml exec mariadb \
-  mariadb-dump -u root -p"$MARIADB_ROOT_PASSWORD" voluntify > backup_pre_update.sql
-
-# 4. Recreate containers (entrypoint.sh runs migrations automatically)
-docker compose -f docker-compose.prod.yml up -d
-
-# 5. Verify
+# 2. Verify
 docker compose -f docker-compose.prod.yml ps
 docker compose -f docker-compose.prod.yml logs --tail=50 app
+curl -f https://voluntify.example.com/up
 ```
+
+The deploy wrapper:
+
+- creates a pre-deploy database backup at `/opt/backups/voluntify/db/`
+- validates the gzip archive before marking it successful
+- prunes pre-deploy DB backups older than 14 days
+- pulls and recreates only `app`, `scheduler`, and `queue`
+- waits for `voluntify-app` to become healthy before returning success
+
+Run these scripts on the VPS from the Voluntify checkout. The user running them must have write access to `/opt/backups/voluntify/db`.
 
 **Note:** There is a brief downtime window while the app container restarts (FrankenPHP re-caches config and runs migrations on start). This is typically under 30 seconds.
 
@@ -186,16 +187,20 @@ docker compose -f docker-compose.prod.yml logs --tail=50 app
 If a migration fails or the new version has issues:
 
 ```bash
-# Roll back the last migration batch
-docker compose -f docker-compose.prod.yml exec app \
-  php artisan migrate:rollback --step=1
+# 1. Stop application services before restoring the database
+docker compose -f docker-compose.prod.yml stop app queue scheduler
 
-# Revert to the previous image
-IMAGE_TAG=previous-tag docker compose -f docker-compose.prod.yml up -d
+# 2. Restore the pre-deploy snapshot
+gunzip -c /opt/backups/voluntify/db/pre-deploy-20260427-153000.sql.gz | \
+  docker compose -f docker-compose.prod.yml exec -T mariadb sh -lc \
+  'exec mariadb -u root -p"$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE"'
 
-# Or restore from DB snapshot
-docker compose -f docker-compose.prod.yml exec -T mariadb \
-  mariadb -u root -p"$MARIADB_ROOT_PASSWORD" voluntify < backup_pre_update.sql
+# 3. Start the previous application image again
+IMAGE_TAG=previous-image-tag docker compose -f docker-compose.prod.yml up -d app scheduler queue
+
+# 4. Verify recovery
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --tail=50 app
 ```
 
 ## Backups
@@ -203,9 +208,10 @@ docker compose -f docker-compose.prod.yml exec -T mariadb \
 ### Database
 
 ```bash
-docker compose -f docker-compose.prod.yml exec mariadb \
-  mariadb-dump -u root -p"$MARIADB_ROOT_PASSWORD" voluntify > backup_$(date +%Y%m%d).sql
+./bin/backup-prod-db
 ```
+
+Database backups are stored on the VPS at `/opt/backups/voluntify/db/` as gzip-compressed SQL dumps named `pre-deploy-YYYYmmdd-HHMMSS.sql.gz`.
 
 ### File Storage
 
@@ -218,8 +224,8 @@ docker compose -f docker-compose.prod.yml cp app:/app/storage/app ./backup-stora
 Add to your VPS crontab (`crontab -e`):
 
 ```cron
-# Daily DB backup at 2am, keep 7 days
-0 2 * * * cd /path/to/voluntify && docker compose -f docker-compose.prod.yml exec -T mariadb mariadb-dump -u root -p"$MARIADB_ROOT_PASSWORD" voluntify | gzip > /backups/voluntify/db_$(date +\%Y\%m\%d).sql.gz && find /backups/voluntify -name "db_*.sql.gz" -mtime +7 -delete
+# Daily DB backup at 2am, keep 14 days
+0 2 * * * cd /path/to/voluntify && ./bin/backup-prod-db >/dev/null
 
 # Weekly storage backup on Sunday at 3am, keep 4 weeks
 0 3 * * 0 cd /path/to/voluntify && docker compose -f docker-compose.prod.yml cp app:/app/storage/app /backups/voluntify/storage_$(date +\%Y\%m\%d)/ && find /backups/voluntify -maxdepth 1 -name "storage_*" -mtime +28 -exec rm -rf {} +
@@ -229,12 +235,15 @@ Add to your VPS crontab (`crontab -e`):
 
 ```bash
 # Database
-docker compose -f docker-compose.prod.yml exec -T mariadb \
-  mariadb -u root -p"$MARIADB_ROOT_PASSWORD" voluntify < backup_20260325.sql
+gunzip -c /opt/backups/voluntify/db/pre-deploy-20260325-020000.sql.gz | \
+  docker compose -f docker-compose.prod.yml exec -T mariadb sh -lc \
+  'exec mariadb -u root -p"$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE"'
 
 # Storage
 docker compose -f docker-compose.prod.yml cp ./backup-storage-20260325/. app:/app/storage/app/
 ```
+
+This database backup flow creates a local VPS rollback point before deploys. It does not replace storage backups or full-host disaster recovery.
 
 ## Logs and Debugging
 


### PR DESCRIPTION
## Summary
- add `bin/backup-prod-db` to create validated VPS-local MariaDB backups in `/opt/backups/voluntify/db` and prune snapshots older than 14 days
- add `bin/deploy-prod <image-tag>` to back up the database before deploys, update only the app services, and wait for `voluntify-app` to become healthy
- update the Docker deployment docs with the new deploy, rollback, restore, and cron backup flow

## Testing
- `bash -n bin/backup-prod-db`
- `bash -n bin/deploy-prod`
- `./bin/deploy-prod`