### PR TITLE
feat(portal): make volunteer magic links non-expiring

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,9 +1,9 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "M18 complete — all stages done, security audit passed"
-current_milestone: m18-signup-custom-fields
-entry_point: plan
+current_focus: "M19 complete — issue #185 implemented and fully tested"
+current_milestone: m19-non-expiring-magic-links
+entry_point: implement
 stages_to_run:
   - plan
   - implement
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-09T12:00:00"
+last_updated: "2026-04-28T15:50:40+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -35,6 +35,7 @@ last_updated: "2026-04-09T12:00:00"
 | m16-bugfixes | Bug Fixes | #132 scanner modes, #133 gear-only shifts, #138 VA arrival button, #141 dropdown placeholder, #142 portal cancel errors | m15 | complete |
 | m17-reliability-quick-wins | Reliability & Quick Wins | #112 immed. cancel notify, #113 retry strategy, #114 idempotency, #122 tz picker, #135 gear counter, #136 camera pause, #140 signup nav, #143 deletion guard | m16 | complete |
 | m18-signup-custom-fields | Signup & Custom Fields Rework | #139 checkbox options + single/multi choice, #134 signup step rework | m17 | complete |
+| m19-non-expiring-magic-links | Non-Expiring Volunteer Magic Links | #185 make volunteer portal/ticket magic links non-expiring | m15, m17 | complete |
 
 ## Artifacts
 
@@ -52,6 +53,7 @@ last_updated: "2026-04-09T12:00:00"
 
 | `.tall-pipeline/m17-reliability-quick-wins.md` | plan+impl | m17 | M17 plan + implementation tracking | complete |
 | `.tall-pipeline/m18-signup-custom-fields.md` | all | m18 | M18 plan+implement+test+security: custom field enhancements + signup step rework | complete |
+| `.tall-pipeline/m19-non-expiring-magic-links.md` | plan+implement+test | m19 | Issue #185 plan + implementation tracking for volunteer magic link expiry removal | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/m19-non-expiring-magic-links.md
+++ b/.tall-pipeline/m19-non-expiring-magic-links.md
@@ -1,0 +1,49 @@
+# Milestone: m19-non-expiring-magic-links — Non-Expiring Volunteer Magic Links
+
+**GitHub Issue:** [#185](https://github.com/reneweiser/voluntify/issues/185)
+**Features:** #185
+**Dependencies:** m15-volunteer-portal-enhancements, m17-reliability-quick-wins
+
+## Plan
+- **Status:** complete
+- **Gate summary:** remove fixed expiry from volunteer magic links, preserve expired-state handling for explicit past timestamps, backfill existing rows
+
+### Scope
+- Make new volunteer magic links non-expiring by storing `expires_at = null`
+- Treat nullable expiry as valid during verification
+- Backfill existing `magic_link_tokens` rows to non-expiring
+- Remove the 72-hour sentence from volunteer-facing access-link emails
+- Keep explicit expired-state behavior for any non-null past timestamps
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] AC-1: Write failing tests for non-expiring token generation and verification
+  - [x] AC-2: Write failing tests for volunteer portal/ticket access with nullable expiry tokens
+  - [x] AC-3: Write failing notification assertions for removed expiry sentence
+  - [x] AC-4: Implement nullable expiry behavior in generation, verification, factory, and notifications
+  - [x] AC-5: Add migration to backfill existing magic links to non-expiring
+  - [x] Refactor: keep tests readable for explicit expired-token scenarios
+  - [x] Verify: run targeted Sail tests and Pint
+
+## Test
+- **Status:** complete
+- **Gate summary:** targeted RED/GREEN loop complete, related caller tests green, full suite green (`1920` tests)
+
+## Decisions
+
+| # | Stage | Decision | Rationale | Affects |
+|---|---|---|---|---|
+| 1 | plan | Treat `magic_link_tokens` as volunteer-only and backfill all rows | All current model and action call sites are volunteer portal/ticket related | implement |
+| 2 | plan | Prove backfill through behavior tests, not migration-runner tests | Repo uses `RefreshDatabase`; acceptance is retained access, not migration engine behavior | implement |
+| 3 | plan | `down()` restores null expiries to `created_at + 72 hours` before making column non-nullable again | Practical reversible path matching previous production semantics | implement |
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Actions | GenerateMagicLink, VerifyMagicLink, RequestPortalAccessLink |
+| Livewire | Public\VolunteerPortal, Public\VolunteerTicket |
+| Notifications | PortalAccessLink, TicketResendNotification, SignupConfirmation, CancellationConfirmation |
+| Traits | HasRetryStrategy |

--- a/app/Actions/GenerateMagicLink.php
+++ b/app/Actions/GenerateMagicLink.php
@@ -22,7 +22,7 @@ class GenerateMagicLink
         $token = MagicLinkToken::create([
             'volunteer_id' => $volunteer->id,
             'token_hash' => $hashed->hash,
-            'expires_at' => now()->addHours(72),
+            'expires_at' => null,
         ]);
 
         return [

--- a/app/Actions/VerifyMagicLink.php
+++ b/app/Actions/VerifyMagicLink.php
@@ -19,7 +19,7 @@ class VerifyMagicLink
             throw new InvalidMagicLinkException('Invalid magic link token.');
         }
 
-        if ($magicLink->expires_at->isPast()) {
+        if ($magicLink->expires_at !== null && $magicLink->expires_at->isPast()) {
             throw new InvalidMagicLinkException('This magic link has expired.');
         }
 

--- a/app/Notifications/PortalAccessLink.php
+++ b/app/Notifications/PortalAccessLink.php
@@ -40,7 +40,6 @@ class PortalAccessLink extends Notification implements ShouldQueue
             ->line("Du hast einen neuen Zugangslink für **{$projectName}** angefordert.")
             ->line('Klicke auf den Button, um dein Volunteer-Portal zu öffnen.')
             ->action('Portal öffnen', $portalUrl)
-            ->line('Dieser Link ist 72 Stunden gültig.')
             ->line('Falls du keinen Zugangslink angefordert hast, kannst du diese E-Mail ignorieren.');
 
         return $this->applyOrgMailer($mail, $this->project->organization, $this->project);

--- a/app/Notifications/TicketResendNotification.php
+++ b/app/Notifications/TicketResendNotification.php
@@ -42,8 +42,7 @@ class TicketResendNotification extends Notification implements ShouldQueue
             ->line('Klicke auf den Button, um dein Ticket mit QR-Code anzuzeigen.')
             ->action('Ticket anzeigen', $ticketUrl)
             ->line('Du kannst auch dein Volunteer-Portal über folgenden Link erreichen:')
-            ->line("[Portal öffnen]({$portalUrl})")
-            ->line('Dieser Link ist 72 Stunden gültig.');
+            ->line("[Portal öffnen]({$portalUrl})");
 
         return $this->applyOrgMailer($mail, $this->project->organization, $this->project);
     }

--- a/database/factories/MagicLinkTokenFactory.php
+++ b/database/factories/MagicLinkTokenFactory.php
@@ -8,7 +8,7 @@ use App\ValueObjects\HashedToken;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\MagicLinkToken>
+ * @extends Factory<MagicLinkToken>
  */
 class MagicLinkTokenFactory extends Factory
 {
@@ -19,7 +19,21 @@ class MagicLinkTokenFactory extends Factory
         return [
             'volunteer_id' => Volunteer::factory(),
             'token_hash' => HashedToken::fromPlaintext(fake()->sha256())->hash,
-            'expires_at' => now()->addHours(24),
+            'expires_at' => null,
         ];
+    }
+
+    public function expiring(): static
+    {
+        return $this->state(fn () => [
+            'expires_at' => now()->addHours(24),
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn () => [
+            'expires_at' => now()->subHour(),
+        ]);
     }
 }

--- a/database/migrations/2026_04_28_134607_make_magic_link_token_expiry_nullable.php
+++ b/database/migrations/2026_04_28_134607_make_magic_link_token_expiry_nullable.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('magic_link_tokens', function (Blueprint $table) {
+            $table->dateTime('expires_at')->nullable()->change();
+        });
+
+        DB::table('magic_link_tokens')->update([
+            'expires_at' => null,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('magic_link_tokens')
+            ->whereNull('expires_at')
+            ->orderBy('id')
+            ->eachById(function (object $token): void {
+                DB::table('magic_link_tokens')
+                    ->where('id', $token->id)
+                    ->update([
+                        'expires_at' => Carbon::parse($token->created_at)->addHours(72),
+                    ]);
+            });
+
+        Schema::table('magic_link_tokens', function (Blueprint $table) {
+            $table->dateTime('expires_at')->nullable(false)->change();
+        });
+    }
+};

--- a/tests/Feature/Actions/GenerateMagicLinkTest.php
+++ b/tests/Feature/Actions/GenerateMagicLinkTest.php
@@ -28,13 +28,10 @@ it('hashes the token with SHA-256', function () {
     expect($result['token']->token_hash)->toBe($hashedToken->hash);
 });
 
-it('sets expiry to 72 hours', function () {
-    $this->freezeSecond();
-
+it('creates a non-expiring magic link token', function () {
     $result = $this->action->execute($this->volunteer);
 
-    expect($result['token']->fresh()->expires_at->toDateTimeString())
-        ->toBe(now()->addHours(72)->toDateTimeString());
+    expect($result['token']->fresh()->expires_at)->toBeNull();
 });
 
 it('returns the plain token for email URL', function () {

--- a/tests/Feature/Actions/RequestPortalAccessLinkTest.php
+++ b/tests/Feature/Actions/RequestPortalAccessLinkTest.php
@@ -22,9 +22,19 @@ it('generates magic link and sends notification for existing volunteer', functio
     $action = app(RequestPortalAccessLink::class);
     $action->execute('volunteer@example.com', $this->project);
 
-    expect(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->count())->toBe(1);
+    $token = MagicLinkToken::where('volunteer_id', $this->volunteer->id)->first();
 
-    Notification::assertSentTo($this->volunteer, PortalAccessLink::class);
+    expect($token)->not->toBeNull()
+        ->and($token->expires_at)->toBeNull();
+
+    Notification::assertSentTo($this->volunteer, PortalAccessLink::class, function ($notification) {
+        $mail = $notification->toMail($this->volunteer);
+        $body = collect([...$mail->introLines, ...$mail->outroLines])->implode(' ');
+
+        expect($body)->not->toContain('72 Stunden gültig');
+
+        return true;
+    });
 });
 
 it('does nothing for non-existent email', function () {
@@ -43,12 +53,13 @@ it('does not invalidate existing tokens', function () {
 
     $existingToken = MagicLinkToken::factory()->create([
         'volunteer_id' => $this->volunteer->id,
-        'expires_at' => now()->addHours(72),
+        'expires_at' => null,
     ]);
 
     $action = app(RequestPortalAccessLink::class);
     $action->execute('volunteer@example.com', $this->project);
 
-    expect($existingToken->fresh()->expires_at->isFuture())->toBeTrue();
-    expect(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->count())->toBe(2);
+    expect($existingToken->fresh()->expires_at)->toBeNull()
+        ->and(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->count())->toBe(2)
+        ->and(MagicLinkToken::where('volunteer_id', $this->volunteer->id)->latest('id')->first()->expires_at)->toBeNull();
 });

--- a/tests/Feature/Actions/VerifyMagicLinkTest.php
+++ b/tests/Feature/Actions/VerifyMagicLinkTest.php
@@ -13,11 +13,23 @@ beforeEach(function () {
     $this->magicLink = MagicLinkToken::factory()->create([
         'volunteer_id' => $this->volunteer->id,
         'token_hash' => HashedToken::fromPlaintext($this->plainToken)->hash,
-        'expires_at' => now()->addHours(24),
+        'expires_at' => null,
     ]);
 });
 
 it('returns volunteer for valid token', function () {
+    $volunteer = $this->action->execute($this->plainToken);
+
+    expect($volunteer->id)->toBe($this->volunteer->id);
+});
+
+it('returns volunteer for a backfilled non-expiring token', function () {
+    $this->magicLink->forceFill([
+        'created_at' => now()->subMonths(6),
+        'updated_at' => now()->subMonths(6),
+        'expires_at' => null,
+    ])->save();
+
     $volunteer = $this->action->execute($this->plainToken);
 
     expect($volunteer->id)->toBe($this->volunteer->id);

--- a/tests/Feature/Livewire/VolunteerPortalTest.php
+++ b/tests/Feature/Livewire/VolunteerPortalTest.php
@@ -57,6 +57,22 @@ it('renders successfully with valid magic link', function () {
         ->assertSeeLivewire(VolunteerPortal::class);
 });
 
+it('renders successfully for a backfilled non-expiring magic link', function () {
+    $plainToken = 'legacy-non-expiring-token';
+
+    MagicLinkToken::create([
+        'volunteer_id' => $this->volunteer->id,
+        'token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+        'expires_at' => null,
+        'created_at' => now()->subYear(),
+        'updated_at' => now()->subYear(),
+    ]);
+
+    $this->get(route('volunteer.portal', $plainToken))
+        ->assertOk()
+        ->assertSeeLivewire(VolunteerPortal::class);
+});
+
 it('shows expired state for expired magic link', function () {
     $this->mock(VerifyMagicLink::class)
         ->shouldReceive('execute')
@@ -664,7 +680,14 @@ it('resends ticket email on button click', function () {
     Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
         ->call('resendTicketEmail');
 
-    Notification::assertSentTo($this->volunteer, TicketResendNotification::class);
+    Notification::assertSentTo($this->volunteer, TicketResendNotification::class, function ($notification) {
+        $mail = $notification->toMail($this->volunteer);
+        $body = collect([...$mail->introLines, ...$mail->outroLines])->implode(' ');
+
+        expect($body)->not->toContain('72 Stunden gültig');
+
+        return true;
+    });
 });
 
 it('rate limits resend to once per 5 minutes', function () {

--- a/tests/Feature/Public/VolunteerTicketTest.php
+++ b/tests/Feature/Public/VolunteerTicketTest.php
@@ -26,7 +26,7 @@ beforeEach(function () {
     $this->magicLink = MagicLinkToken::factory()->create([
         'volunteer_id' => $this->volunteer->id,
         'token_hash' => HashedToken::fromPlaintext($this->plainToken)->hash,
-        'expires_at' => now()->addHours(24),
+        'expires_at' => null,
     ]);
 
     $this->job = VolunteerJob::factory()->for($this->event)->create(['name' => 'Gate Security']);
@@ -38,6 +38,18 @@ beforeEach(function () {
 });
 
 it('renders for valid magic link', function () {
+    $this->get(route('volunteer.ticket', $this->plainToken))
+        ->assertOk()
+        ->assertSeeLivewire(VolunteerTicket::class);
+});
+
+it('renders for a backfilled non-expiring magic link', function () {
+    $this->magicLink->forceFill([
+        'created_at' => now()->subYear(),
+        'updated_at' => now()->subYear(),
+        'expires_at' => null,
+    ])->save();
+
     $this->get(route('volunteer.ticket', $this->plainToken))
         ->assertOk()
         ->assertSeeLivewire(VolunteerTicket::class);


### PR DESCRIPTION
## Summary
- stop generating volunteer magic links with a time-based expiry and treat `expires_at = null` as non-expiring during verification
- add a migration that backfills existing `magic_link_tokens` rows to nullable expiry semantics and keeps rollback behavior deterministic
- update volunteer-facing notifications and coverage so portal/ticket access remains valid indefinitely without 72-hour wording

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Actions/GenerateMagicLinkTest.php tests/Feature/Actions/VerifyMagicLinkTest.php tests/Feature/Actions/RequestPortalAccessLinkTest.php tests/Feature/Public/VolunteerTicketTest.php tests/Feature/Livewire/VolunteerPortalTest.php
- vendor/bin/sail artisan test --compact tests/Feature/Actions/SignUpVolunteerForShiftsTest.php tests/Feature/Actions/SignUpVolunteerTest.php tests/Feature/Listeners/SendCancellationConfirmationTest.php tests/Feature/Actions/DeleteVolunteerProfileTest.php
- vendor/bin/sail artisan test --compact
- vendor/bin/sail bin pint --dirty --format agent

Closes #185