### PR TITLE
fix(announcement): include token-verified recipients

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "M19 complete — issue #185 implemented and fully tested"
-current_milestone: m19-non-expiring-magic-links
+current_focus: "Issue #175 complete — announcement recipients now honor verified token history and all tests are green"
+current_milestone: issue-175-announcement-recipient-resilience
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-28T15:50:40+02:00"
+last_updated: "2026-04-28T16:46:00+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -36,6 +36,7 @@ last_updated: "2026-04-28T15:50:40+02:00"
 | m17-reliability-quick-wins | Reliability & Quick Wins | #112 immed. cancel notify, #113 retry strategy, #114 idempotency, #122 tz picker, #135 gear counter, #136 camera pause, #140 signup nav, #143 deletion guard | m16 | complete |
 | m18-signup-custom-fields | Signup & Custom Fields Rework | #139 checkbox options + single/multi choice, #134 signup step rework | m17 | complete |
 | m19-non-expiring-magic-links | Non-Expiring Volunteer Magic Links | #185 make volunteer portal/ticket magic links non-expiring | m15, m17 | complete |
+| issue-175-announcement-recipient-resilience | Announcement Recipient Resilience | #175 token-backed verified recipient resolution for announcements | m13, m18, m19 | complete |
 
 ## Artifacts
 
@@ -54,6 +55,7 @@ last_updated: "2026-04-28T15:50:40+02:00"
 | `.tall-pipeline/m17-reliability-quick-wins.md` | plan+impl | m17 | M17 plan + implementation tracking | complete |
 | `.tall-pipeline/m18-signup-custom-fields.md` | all | m18 | M18 plan+implement+test+security: custom field enhancements + signup step rework | complete |
 | `.tall-pipeline/m19-non-expiring-magic-links.md` | plan+implement+test | m19 | Issue #185 plan + implementation tracking for volunteer magic link expiry removal | complete |
+| `.tall-pipeline/issue-175-announcement-recipient-resilience.md` | plan+implement+test | issue-175 | Issue #175 plan + implementation tracking for resilient announcement recipients | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-175-announcement-recipient-resilience.md
+++ b/.tall-pipeline/issue-175-announcement-recipient-resilience.md
@@ -1,0 +1,40 @@
+# Milestone: issue-175-announcement-recipient-resilience — Announcement Recipient Resilience
+
+**GitHub Issue:** [#175](https://github.com/reneweiser/voluntify/issues/175)
+**Features:** #175
+**Dependencies:** m13-polish, m18-signup-custom-fields, m19-non-expiring-magic-links
+
+## Plan
+- **Status:** complete
+- **Gate summary:** keep verified-only announcement policy, but resolve recipients from persisted volunteer verification or matching verified email-token history
+
+### Scope
+- Extract one shared announcement recipient query for preview and send
+- Preserve current event/job/shift filtering semantics
+- Treat volunteers as eligible when `email_verified_at` is present or a matching verified `email_verification_tokens` row exists
+- Protect counts against duplicate token rows with a correlated existence check
+- Add regression tests for preview/send parity and token-backed eligibility
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] AC-1: Write failing preview-count tests for token-backed eligible volunteers and excluded unverified volunteers
+  - [x] AC-2: Write failing send-action tests for token-backed recipients, exclusion of unverified recipients, and preview/send parity
+  - [x] AC-3: Implement shared recipient query and reuse it in `AnnouncementComposer` and `SendAnnouncement`
+  - [x] AC-4: Add duplicate-token regression coverage to lock in `whereExists` behavior
+  - [x] Verify: run targeted Sail tests, Pint, and full Sail test suite
+- **Gate summary:** shared token-aware recipient scope shipped, targeted announcement coverage green, full suite green (`1925` tests)
+
+## Test
+- **Status:** complete
+- **Gate summary:** RED confirmed on preview/send under-targeting, GREEN verified with focused suite, full regression suite green after refactor
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Livewire | Projects\AnnouncementComposer |
+| Actions | SendAnnouncement, CreateAnnouncement |
+| Models | Volunteer, Announcement, EmailVerificationToken, ShiftSignup |
+| Tests | AnnouncementComposerTest, SendAnnouncementTest |

--- a/app/Actions/SendAnnouncement.php
+++ b/app/Actions/SendAnnouncement.php
@@ -15,26 +15,14 @@ class SendAnnouncement
             return;
         }
 
-        $query = Volunteer::where('project_id', $announcement->project_id)
-            ->whereNotNull('email_verified_at');
-
-        if ($announcement->event_id) {
-            $query->whereHas('shiftSignups', function ($q) use ($announcement) {
-                $q->active()->whereHas('shift.volunteerJob', function ($jq) use ($announcement) {
-                    $jq->where('event_id', $announcement->event_id);
-
-                    if ($announcement->job_id) {
-                        $jq->where('id', $announcement->job_id);
-                    }
-                });
-
-                if ($announcement->shift_id) {
-                    $q->where('shift_id', $announcement->shift_id);
-                }
-            });
-        }
-
-        $volunteers = $query->get();
+        $volunteers = Volunteer::query()
+            ->forAnnouncementRecipients(
+                projectId: $announcement->project_id,
+                eventId: $announcement->event_id,
+                jobId: $announcement->job_id,
+                shiftId: $announcement->shift_id,
+            )
+            ->get();
 
         foreach ($volunteers as $volunteer) {
             $volunteer->notify(new AnnouncementNotification($announcement));

--- a/app/Livewire/Projects/AnnouncementComposer.php
+++ b/app/Livewire/Projects/AnnouncementComposer.php
@@ -81,26 +81,14 @@ class AnnouncementComposer extends Component
     #[Computed]
     public function recipientCount(): int
     {
-        $query = Volunteer::where('project_id', $this->project->id)
-            ->whereNotNull('email_verified_at');
-
-        if ($this->selectedEventId) {
-            $query->whereHas('shiftSignups', function ($q) {
-                $q->active()->whereHas('shift.volunteerJob', function ($jq) {
-                    $jq->where('event_id', (int) $this->selectedEventId);
-
-                    if ($this->selectedJobId) {
-                        $jq->where('id', (int) $this->selectedJobId);
-                    }
-                });
-
-                if ($this->selectedShiftId) {
-                    $q->where('shift_id', (int) $this->selectedShiftId);
-                }
-            });
-        }
-
-        return $query->count();
+        return Volunteer::query()
+            ->forAnnouncementRecipients(
+                projectId: $this->project->id,
+                eventId: $this->selectedEventId !== '' ? (int) $this->selectedEventId : null,
+                jobId: $this->selectedJobId !== '' ? (int) $this->selectedJobId : null,
+                shiftId: $this->selectedShiftId !== '' ? (int) $this->selectedShiftId : null,
+            )
+            ->count();
     }
 
     #[Computed]

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -114,6 +114,47 @@ class Volunteer extends Model
         $query->where('project_id', $projectId);
     }
 
+    public function scopeForAnnouncementRecipients(
+        Builder $query,
+        int $projectId,
+        ?int $eventId = null,
+        ?int $jobId = null,
+        ?int $shiftId = null,
+    ): void {
+        $query
+            ->forProject($projectId)
+            ->where(function (Builder $verificationQuery) {
+                $verificationQuery
+                    ->whereNotNull('email_verified_at')
+                    ->orWhereExists(function ($tokenQuery) {
+                        $tokenQuery->selectRaw('1')
+                            ->from('email_verification_tokens')
+                            ->whereColumn('email_verification_tokens.project_id', 'volunteers.project_id')
+                            ->whereColumn('email_verification_tokens.email', 'volunteers.email')
+                            ->whereNotNull('email_verification_tokens.verified_at');
+                    });
+            });
+
+        if ($eventId === null) {
+            return;
+        }
+
+        $query->whereHas('shiftSignups', function (Builder $signupQuery) use ($eventId, $jobId, $shiftId) {
+            $signupQuery->active()
+                ->whereHas('shift.volunteerJob', function (Builder $jobQuery) use ($eventId, $jobId) {
+                    $jobQuery->where('event_id', $eventId);
+
+                    if ($jobId !== null) {
+                        $jobQuery->where('id', $jobId);
+                    }
+                });
+
+            if ($shiftId !== null) {
+                $signupQuery->where('shift_id', $shiftId);
+            }
+        });
+    }
+
     public function scopeForEvent(Builder $query, int $eventId): void
     {
         $query->where(function (Builder $q) use ($eventId) {

--- a/tests/Feature/Actions/SendAnnouncementTest.php
+++ b/tests/Feature/Actions/SendAnnouncementTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\SendAnnouncement;
 use App\Models\Announcement;
+use App\Models\EmailVerificationToken;
 use App\Models\Event;
 use App\Models\Organization;
 use App\Models\Project;
@@ -11,7 +12,9 @@ use App\Models\User;
 use App\Models\Volunteer;
 use App\Models\VolunteerJob;
 use App\Notifications\AnnouncementNotification;
+use App\ValueObjects\HashedToken;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 
 beforeEach(function () {
     Notification::fake();
@@ -105,6 +108,78 @@ it('filters by event + job + shift', function () {
 
     Notification::assertSentTo($included, AnnouncementNotification::class);
     Notification::assertNotSentTo($excluded, AnnouncementNotification::class);
+});
+
+it('sends to token-backed eligible volunteers with active matching signups', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $eligibleVolunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'token-backed@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($eligibleVolunteer)->for($shift)->create();
+
+    EmailVerificationToken::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $event->id,
+        'email' => $eligibleVolunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $excludedVolunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'still-unverified@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($excludedVolunteer)->for($shift)->create();
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'job_id' => $job->id,
+        'shift_id' => $shift->id,
+        'created_by' => $this->creator->id,
+    ]);
+
+    $this->action->execute($announcement);
+
+    Notification::assertSentTo($eligibleVolunteer, AnnouncementNotification::class);
+    Notification::assertNotSentTo($excludedVolunteer, AnnouncementNotification::class);
+    expect($announcement->fresh()->recipient_count)->toBe(1);
+});
+
+it('sends to token-backed volunteers only once when multiple verified tokens exist', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $eligibleVolunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'duplicate-token@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($eligibleVolunteer)->for($shift)->create();
+
+    EmailVerificationToken::factory()->count(2)->create([
+        'project_id' => $this->project->id,
+        'event_id' => $event->id,
+        'email' => $eligibleVolunteer->email,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'job_id' => $job->id,
+        'shift_id' => $shift->id,
+        'created_by' => $this->creator->id,
+    ]);
+
+    $this->action->execute($announcement);
+
+    Notification::assertSentToTimes($eligibleVolunteer, AnnouncementNotification::class, 1);
+    expect($announcement->fresh()->recipient_count)->toBe(1);
 });
 
 it('skips unverified volunteers', function () {

--- a/tests/Feature/Livewire/Projects/AnnouncementComposerTest.php
+++ b/tests/Feature/Livewire/Projects/AnnouncementComposerTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Actions\SendAnnouncement;
 use App\Enums\StaffRole;
 use App\Jobs\SendAnnouncementJob;
 use App\Livewire\Projects\AnnouncementComposer;
 use App\Models\Announcement;
+use App\Models\EmailVerificationToken;
 use App\Models\Event;
 use App\Models\Organization;
 use App\Models\Project;
@@ -12,7 +14,9 @@ use App\Models\ShiftSignup;
 use App\Models\User;
 use App\Models\Volunteer;
 use App\Models\VolunteerJob;
+use App\ValueObjects\HashedToken;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -66,6 +70,108 @@ it('updates recipient count when event filter changes', function () {
     // Filter to event
     $component->set('selectedEventId', (string) $event->id);
     expect($component->get('recipientCount'))->toBe(1);
+});
+
+it('counts token-backed recipients when event filter changes', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $tokenBackedVolunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'token-backed@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($tokenBackedVolunteer)->for($shift)->create();
+
+    EmailVerificationToken::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $event->id,
+        'email' => $tokenBackedVolunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    Volunteer::factory()->for($this->project)->create([
+        'email_verified_at' => null,
+        'email' => 'unverified@example.com',
+    ]);
+
+    $component = Livewire::actingAs($this->organizer)
+        ->test(AnnouncementComposer::class, ['projectId' => $this->project->id]);
+
+    $component->set('selectedEventId', (string) $event->id);
+
+    expect($component->get('recipientCount'))->toBe(1);
+});
+
+it('counts token-backed recipients only once when multiple verified tokens exist', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'duplicate-token@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($volunteer)->for($shift)->create();
+
+    EmailVerificationToken::factory()->count(2)->create([
+        'project_id' => $this->project->id,
+        'event_id' => $event->id,
+        'email' => $volunteer->email,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $component = Livewire::actingAs($this->organizer)
+        ->test(AnnouncementComposer::class, ['projectId' => $this->project->id]);
+
+    $component->set('selectedEventId', (string) $event->id);
+
+    expect($component->get('recipientCount'))->toBe(1);
+});
+
+it('keeps preview count and send recipient count in sync for token-backed volunteers', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'email' => 'parity@example.com',
+        'email_verified_at' => null,
+    ]);
+    ShiftSignup::factory()->for($volunteer)->for($shift)->create();
+
+    EmailVerificationToken::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $event->id,
+        'email' => $volunteer->email,
+        'token_hash' => HashedToken::fromPlaintext(Str::random(64))->hash,
+        'expires_at' => now()->addDay(),
+        'verified_at' => now()->subMinute(),
+    ]);
+
+    $component = Livewire::actingAs($this->organizer)
+        ->test(AnnouncementComposer::class, ['projectId' => $this->project->id]);
+
+    $component
+        ->set('selectedEventId', (string) $event->id)
+        ->set('selectedJobId', (string) $job->id)
+        ->set('selectedShiftId', (string) $shift->id);
+
+    expect($component->get('recipientCount'))->toBe(1);
+
+    $announcement = Announcement::factory()->for($this->project)->create([
+        'event_id' => $event->id,
+        'job_id' => $job->id,
+        'shift_id' => $shift->id,
+        'created_by' => $this->organizer->id,
+    ]);
+
+    app(SendAnnouncement::class)->execute($announcement);
+
+    expect($announcement->fresh()->recipient_count)->toBe(1);
 });
 
 it('sends announcement immediately', function () {


### PR DESCRIPTION
## Summary
- make announcement recipient eligibility resilient to stale `volunteers.email_verified_at` values by also honoring verified email-token history
- reuse one shared `Volunteer` recipient query for both announcement preview counts and actual delivery so they stay in sync
- add regression coverage for token-backed recipients, duplicate verified tokens, and preview/send parity

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Livewire/Projects/AnnouncementComposerTest.php tests/Feature/Actions/SendAnnouncementTest.php`
- `vendor/bin/sail bin pint --dirty --format agent`
- `vendor/bin/sail artisan test --compact`