### PR TITLE
docs(volunteer): clarify volunteer-record lifecycle vs. verified-only

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -28,6 +28,8 @@ This glossary defines the shared vocabulary used throughout Voluntify. Consisten
 
 > Example: A volunteer signs up for "Hochschulball 2026" and selects shifts at both the "Aufbautag" and "Hauptabend" events -- they remain one volunteer record in the project.
 
+> **Wann existiert ein Volunteer-Record?** Erst, wenn der Signup-Flow vollständig abgeschlossen wird (Schritt 5 "Verbindlich anmelden" in UC-04). Wer nur die E-Mail verifiziert, danach aber abbricht, hat **keinen** Volunteer-Record im Projekt. Folge: Magic-Link-Anfragen für solche E-Mails laufen ins Leere (siehe UC-16, Sonderfall "Verifiziert, aber nicht angemeldet"). Der `EmailVerificationToken` wird nach 7 Tagen automatisch geprunt -- es bleibt also kein Datenmüll.
+
 ## Projects & Events
 
 **Project** -- The mandatory top-level container for organising events. Every event belongs to a project. A project groups related events (e.g. all events for a festival), holds shared resources (Gear, Custom Fields, Scanner configs, Volunteers), and has its own public website.

--- a/docs/use-cases/uc-16-ticket-zugang-anfordern.md
+++ b/docs/use-cases/uc-16-ticket-zugang-anfordern.md
@@ -5,7 +5,7 @@
 
 ## Vorbedingungen
 
-- Volunteer ist im Projekt registriert
+- Volunteer ist im Projekt registriert (= Signup-Flow vollständig abgeschlossen, siehe UC-04 Schritt 5)
 - Volunteer hat keinen Zugang mehr (E-Mail gelöscht, Link abgelaufen)
 
 ## Ablauf
@@ -28,6 +28,12 @@
 
 - Rate-Limiting: max. 3 Anfragen pro E-Mail pro Stunde
 - Keine Info-Leaks (immer gleiche Meldung)
+
+## Sonderfall: "Verifiziert, aber nicht angemeldet"
+
+Hat ein Interessent zwar die E-Mail-Verifikation durchlaufen (UC-04 Schritt 1), den Signup-Flow danach aber nicht bis Schritt 5 abgeschlossen, existiert **kein Volunteer-Record**. Die Magic-Link-Anfrage greift dann den Privacy-Stillegang in [`RequestPortalAccessLink`](../../app/Actions/RequestPortalAccessLink.php) -- der User sieht die generische Bestätigungsmeldung, bekommt aber keine E-Mail.
+
+Support-Antwort in dem Fall: "Deine Anmeldung wurde nicht abgeschlossen, du bist nicht im System -- bitte den Signup-Flow erneut starten." Es gibt nichts zu löschen und nichts an Schichten anzuzeigen.
 
 ## Referenz
 


### PR DESCRIPTION
## Summary
- Add a note to the **Volunteer** glossary entry in [docs/ubiquitous-language.md](docs/ubiquitous-language.md) explaining that a Volunteer record only exists once the signup flow is completed (UC-04 step 5), not at email verification.
- Add a new **"Verifiziert, aber nicht angemeldet"** edge-case section to [UC-16](docs/use-cases/uc-16-ticket-zugang-anfordern.md) so support knows why magic-link requests stay silent for users who verified but never booked a shift, plus a ready support reply.
- Tighten UC-16's "Vorbedingungen" line to reference UC-04 step 5 explicitly.

## Test plan
- [ ] Read both edited docs and confirm wording is clear and accurate.
- [ ] Cross-check the lifecycle claim against [`ProcessVolunteerSignup::execute`](app/Actions/ProcessVolunteerSignup.php) (firstOrCreate at signup) and [`RequestPortalAccessLink`](app/Actions/RequestPortalAccessLink.php) (silent return when no Volunteer found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)