### PR TITLE
fix(volunteers): backfill signup email verification

### DIFF
--- a/database/migrations/2026_04_28_165639_backfill_email_verified_at_for_volunteers_with_shift_signups.php
+++ b/database/migrations/2026_04_28_165639_backfill_email_verified_at_for_volunteers_with_shift_signups.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('volunteers')
+            ->whereNull('email_verified_at')
+            ->whereExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('shift_signups')
+                    ->whereColumn('shift_signups.volunteer_id', 'volunteers.id');
+            })
+            ->update([
+                'email_verified_at' => DB::raw('(select min(shift_signups.signed_up_at) from shift_signups where shift_signups.volunteer_id = volunteers.id)'),
+            ]);
+    }
+
+    public function down(): void {}
+};

--- a/tests/Feature/BackfillVolunteerEmailVerificationMigrationTest.php
+++ b/tests/Feature/BackfillVolunteerEmailVerificationMigrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\ShiftSignup;
+use App\Models\Volunteer;
+
+it('backfills email verification from the earliest shift signup timestamp', function () {
+    $verifiedAt = now()->subDays(3);
+    $earliestSignupAt = now()->subDays(10)->startOfMinute();
+    $latestSignupAt = now()->subDays(5)->startOfMinute();
+
+    $volunteer = Volunteer::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    ShiftSignup::factory()->for($volunteer)->create([
+        'signed_up_at' => $latestSignupAt,
+    ]);
+    ShiftSignup::factory()->for($volunteer)->create([
+        'signed_up_at' => $earliestSignupAt,
+    ]);
+
+    $alreadyVerifiedVolunteer = Volunteer::factory()->verified()->create([
+        'email_verified_at' => $verifiedAt,
+    ]);
+
+    ShiftSignup::factory()->for($alreadyVerifiedVolunteer)->create([
+        'signed_up_at' => now()->subDays(20),
+    ]);
+
+    $volunteerWithoutSignups = Volunteer::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $migration = require base_path('database/migrations/2026_04_28_165639_backfill_email_verified_at_for_volunteers_with_shift_signups.php');
+    $migration->up();
+
+    expect($volunteer->fresh()->email_verified_at?->toDateTimeString())
+        ->toBe($earliestSignupAt->toDateTimeString())
+        ->and($alreadyVerifiedVolunteer->fresh()->email_verified_at?->toDateTimeString())
+        ->toBe($verifiedAt->toDateTimeString())
+        ->and($volunteerWithoutSignups->fresh()->email_verified_at)
+        ->toBeNull();
+});


### PR DESCRIPTION
## Summary
- backfill missing `volunteers.email_verified_at` values from each volunteer's earliest `shift_signups.signed_up_at`
- add regression coverage so already-verified volunteers stay unchanged and volunteers without signups remain unverified
- validate the imported production data after the migration and confirm the announcement recipient undercount is gone

## Testing
- `vendor/bin/sail bin pint --dirty --format agent`
- `vendor/bin/sail artisan test --compact tests/Feature/BackfillVolunteerEmailVerificationMigrationTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Livewire/Projects/AnnouncementComposerTest.php tests/Feature/Actions/SendAnnouncementTest.php`