### PR TITLE
fix(portal): scope volunteer announcement visibility

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #175 complete — announcement recipients now honor verified token history and all tests are green"
-current_milestone: issue-175-announcement-recipient-resilience
+current_focus: "Issue #190 complete — volunteer portal announcements are null-safe and scoped to the volunteer's actual targeting"
+current_milestone: issue-190-portal-announcement-visibility
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-28T16:46:00+02:00"
+last_updated: "2026-04-28T20:41:27+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -37,6 +37,7 @@ last_updated: "2026-04-28T16:46:00+02:00"
 | m18-signup-custom-fields | Signup & Custom Fields Rework | #139 checkbox options + single/multi choice, #134 signup step rework | m17 | complete |
 | m19-non-expiring-magic-links | Non-Expiring Volunteer Magic Links | #185 make volunteer portal/ticket magic links non-expiring | m15, m17 | complete |
 | issue-175-announcement-recipient-resilience | Announcement Recipient Resilience | #175 token-backed verified recipient resolution for announcements | m13, m18, m19 | complete |
+| issue-190-portal-announcement-visibility | Portal Announcement Visibility | #190 null-safe volunteer portal announcements + targeted visibility filtering | m15, issue-175-announcement-recipient-resilience | complete |
 
 ## Artifacts
 
@@ -56,6 +57,7 @@ last_updated: "2026-04-28T16:46:00+02:00"
 | `.tall-pipeline/m18-signup-custom-fields.md` | all | m18 | M18 plan+implement+test+security: custom field enhancements + signup step rework | complete |
 | `.tall-pipeline/m19-non-expiring-magic-links.md` | plan+implement+test | m19 | Issue #185 plan + implementation tracking for volunteer magic link expiry removal | complete |
 | `.tall-pipeline/issue-175-announcement-recipient-resilience.md` | plan+implement+test | issue-175 | Issue #175 plan + implementation tracking for resilient announcement recipients | complete |
+| `.tall-pipeline/issue-190-portal-announcement-visibility.md` | plan+implement+test | issue-190 | Issue #190 tracking for null-safe volunteer portal announcements and targeted visibility | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-190-portal-announcement-visibility.md
+++ b/.tall-pipeline/issue-190-portal-announcement-visibility.md
@@ -1,0 +1,41 @@
+# Milestone: issue-190-portal-announcement-visibility — Portal Announcement Visibility
+
+**GitHub Issue:** [#190](https://github.com/reneweiser/voluntify/issues/190)
+**Features:** #190
+**Dependencies:** m15-volunteer-portal-enhancements, issue-175-announcement-recipient-resilience
+**Branch:** fix/portal-announcement-visibility
+
+## Plan
+- **Status:** complete
+- **Gate summary:** make portal announcement metadata null-safe, align portal visibility with project/event/job/shift targeting, and prevent future deleted targets from broadening into project-wide announcements
+
+### Scope
+- Add a persisted `is_project_wide` marker to distinguish true project-wide announcements from targeted announcements whose foreign keys may later be nulled
+- Scope volunteer portal announcements to the volunteer's non-cancelled signup targets
+- Render timestamp-only metadata when an announcement has no event relation
+- Add regression coverage for project-wide, matching targeted, mismatched targeted, and orphaned-target portal scenarios
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] AC-1: Write failing portal tests for project-wide timestamp-only rendering and targeted visibility filtering
+  - [x] AC-2: Write failing composer tests for persisted `is_project_wide` behavior
+  - [x] AC-3: Add the `is_project_wide` migration with backfill for true project-wide announcements
+  - [x] AC-4: Update `Announcement` creation defaults and portal visibility query to use the persisted marker plus signup target matching
+  - [x] AC-5: Make portal announcement metadata null-safe in Blade
+  - [x] Verify: run focused Sail tests, Pint, and the full Sail test suite
+- **Gate summary:** portal announcement visibility now mirrors target semantics, null-event announcements no longer crash the portal, and future orphaned targeted announcements remain hidden. Full Sail suite green (`1933` tests).
+
+## Test
+- **Status:** complete
+- **Gate summary:** RED confirmed on missing `is_project_wide` persistence and portal visibility gaps; GREEN verified with `VolunteerPortalTest`, `AnnouncementComposerTest`, `SendAnnouncementTest`, then full-suite regression coverage
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Livewire | Public\VolunteerPortal, Projects\AnnouncementComposer |
+| Models | Announcement, Volunteer, ShiftSignup |
+| Views | `resources/views/livewire/public/volunteer-portal.blade.php` |
+| Tests | VolunteerPortalTest, AnnouncementComposerTest, SendAnnouncementTest |

--- a/app/Livewire/Public/VolunteerPortal.php
+++ b/app/Livewire/Public/VolunteerPortal.php
@@ -178,10 +178,29 @@ class VolunteerPortal extends Component
             return new Collection;
         }
 
-        $eventIds = $this->volunteerEventIds();
+        $activeSignups = $this->activeVolunteerSignups();
+
+        $eventIds = array_values(array_unique($activeSignups->pluck('shift.volunteerJob.event_id')->filter()->all()));
+        $jobIds = array_values(array_unique($activeSignups->pluck('shift.volunteerJob.id')->filter()->all()));
+        $shiftIds = array_values(array_unique($activeSignups->pluck('shift_id')->filter()->all()));
 
         return Announcement::where('project_id', $this->volunteer->project_id)
             ->whereNotNull('sent_at')
+            ->where(function ($query) use ($eventIds, $jobIds, $shiftIds) {
+                $query->where('is_project_wide', true)
+                    ->orWhere(function ($targetedQuery) use ($eventIds, $jobIds, $shiftIds) {
+                        $targetedQuery->where('is_project_wide', false)
+                            ->whereIn('event_id', $eventIds)
+                            ->where(function ($jobQuery) use ($jobIds) {
+                                $jobQuery->whereNull('job_id')
+                                    ->orWhereIn('job_id', $jobIds);
+                            })
+                            ->where(function ($shiftQuery) use ($shiftIds) {
+                                $shiftQuery->whereNull('shift_id')
+                                    ->orWhereIn('shift_id', $shiftIds);
+                            });
+                    });
+            })
             ->with('event')
             ->latest('sent_at')
             ->get();
@@ -208,15 +227,26 @@ class VolunteerPortal extends Component
         return app(HintTextResolver::class)->resolve($location, $this->volunteer->project);
     }
 
-    /** @return \Illuminate\Support\Collection<int, int> */
-    private function volunteerEventIds(): \Illuminate\Support\Collection
+    private function activeVolunteerSignups(): Collection
     {
+        if (! $this->volunteer) {
+            return new Collection;
+        }
+
         return $this->volunteer->shiftSignups()
             ->active()
             ->with('shift.volunteerJob')
-            ->get()
+            ->get();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, int> */
+    private function volunteerEventIds(): \Illuminate\Support\Collection
+    {
+        return $this->activeVolunteerSignups()
             ->pluck('shift.volunteerJob.event_id')
-            ->unique();
+            ->filter()
+            ->unique()
+            ->values();
     }
 
     public function confirmCancel(int $signupId): void

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -17,6 +17,7 @@ class Announcement extends Model
         'event_id',
         'job_id',
         'shift_id',
+        'is_project_wide',
         'subject',
         'body',
         'send_at',
@@ -28,10 +29,24 @@ class Announcement extends Model
     protected function casts(): array
     {
         return [
+            'is_project_wide' => 'boolean',
             'send_at' => 'datetime',
             'sent_at' => 'datetime',
             'recipient_count' => 'integer',
         ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (Announcement $announcement): void {
+            if ($announcement->is_project_wide !== null) {
+                return;
+            }
+
+            $announcement->is_project_wide = $announcement->event_id === null
+                && $announcement->job_id === null
+                && $announcement->shift_id === null;
+        });
     }
 
     public function project(): BelongsTo

--- a/database/migrations/2026_04_28_183518_add_is_project_wide_to_announcements_table.php
+++ b/database/migrations/2026_04_28_183518_add_is_project_wide_to_announcements_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('announcements', function (Blueprint $table) {
+            $table->boolean('is_project_wide')->default(false)->after('shift_id');
+        });
+
+        DB::table('announcements')
+            ->whereNull('event_id')
+            ->whereNull('job_id')
+            ->whereNull('shift_id')
+            ->update(['is_project_wide' => true]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('announcements', function (Blueprint $table) {
+            $table->dropColumn('is_project_wide');
+        });
+    }
+};

--- a/resources/views/livewire/public/volunteer-portal.blade.php
+++ b/resources/views/livewire/public/volunteer-portal.blade.php
@@ -210,7 +210,10 @@
                             <div class="font-medium text-white">{{ $announcement->subject }}</div>
                             <p class="mt-2 text-sm" style="color: #a1a1aa;">{{ $announcement->body }}</p>
                             <div class="mt-2 text-xs" style="color: #9a9a9a;">
-                                {{ $announcement->event->name }} &middot; {{ $announcement->sent_at->diffForHumans() }}
+                                @if ($announcement->event)
+                                    {{ $announcement->event->name }} &middot;
+                                @endif
+                                {{ $announcement->sent_at->diffForHumans() }}
                             </div>
                         </div>
                     @endforeach

--- a/tests/Feature/Livewire/Projects/AnnouncementComposerTest.php
+++ b/tests/Feature/Livewire/Projects/AnnouncementComposerTest.php
@@ -186,7 +186,33 @@ it('sends announcement immediately', function () {
         ->call('send')
         ->assertDispatched('announcement-sent');
 
-    expect(Announcement::count())->toBe(1);
+    expect(Announcement::count())->toBe(1)
+        ->and(Announcement::query()->sole()->is_project_wide)->toBeTrue();
+
+    Queue::assertPushed(SendAnnouncementJob::class);
+});
+
+it('stores targeted announcements as not project-wide', function () {
+    Queue::fake();
+
+    $event = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    $job = VolunteerJob::factory()->for($event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->create();
+
+    Livewire::actingAs($this->organizer)
+        ->test(AnnouncementComposer::class, ['projectId' => $this->project->id])
+        ->set('selectedEventId', (string) $event->id)
+        ->set('selectedJobId', (string) $job->id)
+        ->set('selectedShiftId', (string) $shift->id)
+        ->set('subject', 'Shift-only announcement')
+        ->set('body', 'Bring safety shoes.')
+        ->call('confirmSend')
+        ->call('send')
+        ->assertDispatched('announcement-sent');
+
+    expect(Announcement::count())->toBe(1)
+        ->and(Announcement::query()->sole()->is_project_wide)->toBeFalse();
+
     Queue::assertPushed(SendAnnouncementJob::class);
 });
 

--- a/tests/Feature/Livewire/VolunteerPortalTest.php
+++ b/tests/Feature/Livewire/VolunteerPortalTest.php
@@ -24,6 +24,7 @@ use App\Models\VolunteerGearPickup;
 use App\Models\VolunteerJob;
 use App\Notifications\TicketResendNotification;
 use App\ValueObjects\HashedToken;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
@@ -45,6 +46,8 @@ beforeEach(function () {
     ]);
     $this->volunteer = Volunteer::factory()->for($this->project)->create(['first_name' => 'Test', 'last_name' => 'Volunteer']);
 });
+
+afterEach(fn () => Carbon::setTestNow());
 
 it('renders successfully with valid magic link', function () {
     $this->mock(VerifyMagicLink::class)
@@ -341,6 +344,167 @@ it('shows announcements for volunteers events', function () {
     Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
         ->assertSee('Important Parking Update')
         ->assertSee('Parking has moved to lot B.');
+});
+
+it('shows project-wide announcements without signups and renders timestamp-only metadata', function () {
+    Carbon::setTestNow('2026-04-28 18:14:49');
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'subject' => 'General Update',
+        'body' => 'Please check your email before arrival.',
+        'sent_at' => now()->subHour(),
+        'created_by' => User::factory(),
+        'is_project_wide' => true,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('General Update')
+        ->assertSee('Please check your email before arrival.')
+        ->assertSee(now()->subHour()->diffForHumans())
+        ->assertDontSee($this->event->name);
+});
+
+it('shows announcements targeted to a volunteers matching event job and shift', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+        'job_id' => $this->job->id,
+        'shift_id' => $this->futureShift->id,
+        'subject' => 'Matched Shift Update',
+        'body' => 'Bring work gloves.',
+        'sent_at' => now(),
+        'created_by' => User::factory(),
+        'is_project_wide' => false,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertSee('Matched Shift Update')
+        ->assertSee('Bring work gloves.');
+});
+
+it('hides announcements targeted to a different event', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $otherEvent->id,
+        'subject' => 'Other Event Update',
+        'body' => 'Wrong audience.',
+        'sent_at' => now(),
+        'created_by' => User::factory(),
+        'is_project_wide' => false,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Other Event Update')
+        ->assertDontSee('Wrong audience.');
+});
+
+it('hides announcements targeted to a different job within the same event', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $otherJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Cleanup Crew']);
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+        'job_id' => $otherJob->id,
+        'subject' => 'Cleanup Update',
+        'body' => 'Only for cleanup crew.',
+        'sent_at' => now(),
+        'created_by' => User::factory(),
+        'is_project_wide' => false,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Cleanup Update')
+        ->assertDontSee('Only for cleanup crew.');
+});
+
+it('hides announcements targeted to a different shift within the same event and job', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    $otherShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'starts_at' => now()->addDays(5),
+        'ends_at' => now()->addDays(5)->addHours(2),
+    ]);
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+        'job_id' => $this->job->id,
+        'shift_id' => $otherShift->id,
+        'subject' => 'Other Shift Update',
+        'body' => 'Only for another shift.',
+        'sent_at' => now(),
+        'created_by' => User::factory(),
+        'is_project_wide' => false,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Other Shift Update')
+        ->assertDontSee('Only for another shift.');
+});
+
+it('hides orphaned targeted announcements after their target ids are nulled', function () {
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $this->volunteer->id,
+        'shift_id' => $this->futureShift->id,
+    ]);
+
+    Announcement::factory()->create([
+        'project_id' => $this->project->id,
+        'subject' => 'Formerly Targeted Update',
+        'body' => 'This should stay hidden.',
+        'sent_at' => now(),
+        'created_by' => User::factory(),
+        'is_project_wide' => false,
+    ]);
+
+    $this->mock(VerifyMagicLink::class)
+        ->shouldReceive('execute')
+        ->andReturn($this->volunteer);
+
+    Livewire::test(VolunteerPortal::class, ['magicToken' => 'token'])
+        ->assertDontSee('Formerly Targeted Update')
+        ->assertDontSee('This should stay hidden.');
 });
 
 it('shows empty states when no upcoming shifts and no announcements', function () {


### PR DESCRIPTION
## Summary
- add a persisted `is_project_wide` marker so volunteer portal visibility can distinguish true project-wide announcements from targeted ones
- scope portal announcements to the volunteer's non-cancelled event, job, and shift signups while keeping null-event metadata rendering safe
- add regression coverage for project-wide, targeted, mismatched, and orphaned-target announcement scenarios

## Testing
- `vendor/bin/sail artisan test --compact --filter=VolunteerPortalTest`
- `vendor/bin/sail artisan test --compact --filter=AnnouncementComposerTest`
- `vendor/bin/sail artisan test --compact --filter=SendAnnouncementTest`
- `vendor/bin/sail bin pint --dirty --format agent`
- `vendor/bin/sail artisan test --compact`

Closes #190