### PR TITLE
feat(scanner): add volunteer admin shift list

### DIFF
--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -86,9 +86,247 @@ vendor/bin/sail artisan tinker --execute="
 echo "Clearing Mailpit inbox..."
 curl -s -X DELETE http://localhost:8025/api/v1/messages
 
+# 7. Create deterministic Volunteer Admin scanner fixture for shift-list E2E
+echo "Creating volunteer-admin shift-list E2E fixture..."
+vendor/bin/sail artisan tinker --execute="
+  use App\Enums\GearItemType;
+  use App\Enums\ScannerMode;
+  use App\Enums\ScannerType;
+  use App\Models\Event;
+  use App\Models\Organization;
+  use App\Models\Project;
+  use App\Models\ProjectGearItem;
+  use App\Models\ProjectScanner;
+  use App\Models\Shift;
+  use App\Models\ShiftSignup;
+  use App\Models\Ticket;
+  use App\Models\Volunteer;
+  use App\Models\VolunteerGear;
+  use App\Models\VolunteerJob;
+
+  \Carbon\Carbon::setTestNow(now());
+
+  \DB::transaction(function () {
+    \App\Models\ProjectScanner::where('scanner_token', 'e2e-va-shift-list-token')->delete();
+
+    \App\Models\Event::where('name', 'E2E Volunteer Admin Shift Event')->delete();
+
+    \App\Models\Project::where('name', 'E2E Volunteer Admin Scanner Project')->delete();
+
+    \App\Models\Volunteer::whereIn('email', [
+      'lisa-shifts@example.com',
+      'tom-shifts@example.com',
+      'active-1@example.com',
+      'active-2@example.com',
+      'active-3@example.com',
+      'active-4@example.com',
+      'active-5@example.com',
+      'active-6@example.com',
+      'active-7@example.com',
+    ])->delete();
+
+    \$organization = Organization::firstOrFail();
+
+    \$project = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Volunteer Admin Scanner Project',
+    ]);
+
+    \$event = Event::factory()->for(\$organization)->for(\$project)->published()->create([
+      'name' => 'E2E Volunteer Admin Shift Event',
+      'slug' => 'e2e-volunteer-admin-shift-event',
+      'starts_at' => now()->subHours(2),
+      'ends_at' => now()->addHours(8),
+      'attendance_grace_minutes' => 15,
+    ]);
+
+    \$activeJob = VolunteerJob::factory()->create([
+      'event_id' => \$event->id,
+      'name' => 'Welcome Desk',
+    ]);
+
+    \$nextJob = VolunteerJob::factory()->create([
+      'event_id' => \$event->id,
+      'name' => 'Badge Check',
+    ]);
+
+    \$laterJob = VolunteerJob::factory()->create([
+      'event_id' => \$event->id,
+      'name' => 'Cleanup Crew',
+    ]);
+
+    \$activeShift = Shift::factory()->create([
+      'volunteer_job_id' => \$activeJob->id,
+      'shift_date' => now()->toDateString(),
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHour(),
+      'display_text' => now()->subHour()->format('M d, H:i').' - '.now()->addHour()->format('H:i'),
+    ]);
+
+    \$nextShift = Shift::factory()->create([
+      'volunteer_job_id' => \$nextJob->id,
+      'shift_date' => now()->toDateString(),
+      'starts_at' => now()->addHours(2),
+      'ends_at' => now()->addHours(4),
+      'display_text' => now()->addHours(2)->format('M d, H:i').' - '.now()->addHours(4)->format('H:i'),
+    ]);
+
+    \$laterShift = Shift::factory()->create([
+      'volunteer_job_id' => \$laterJob->id,
+      'shift_date' => now()->toDateString(),
+      'starts_at' => now()->addHours(5),
+      'ends_at' => now()->addHours(7),
+      'display_text' => now()->addHours(5)->format('M d, H:i').' - '.now()->addHours(7)->format('H:i'),
+    ]);
+
+    \$lisa = Volunteer::factory()->verified()->for(\$project)->create([
+      'first_name' => 'Lisa',
+      'last_name' => 'Mueller',
+      'email' => 'lisa-shifts@example.com',
+      'phone' => '+491701234567',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$project->id,
+      'volunteer_id' => \$lisa->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$lisa->id,
+      'shift_id' => \$activeShift->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$lisa->id,
+      'shift_id' => \$laterShift->id,
+    ]);
+
+    \$tom = Volunteer::factory()->verified()->for(\$project)->create([
+      'first_name' => 'Tom',
+      'last_name' => 'Weber',
+      'email' => 'tom-shifts@example.com',
+      'phone' => '+491701234568',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$project->id,
+      'volunteer_id' => \$tom->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$tom->id,
+      'shift_id' => \$nextShift->id,
+    ]);
+
+    foreach (range(1, 14) as \$index) {
+      \$volunteer = Volunteer::factory()->verified()->for(\$project)->create([
+        'first_name' => 'Active',
+        'last_name' => 'Helper '.\$index,
+        'email' => 'active-'.\$index.'@example.com',
+        'phone' => '+4917000000'.\$index,
+      ]);
+
+      Ticket::factory()->create([
+        'project_id' => \$project->id,
+        'volunteer_id' => \$volunteer->id,
+      ]);
+
+      ShiftSignup::factory()->create([
+        'volunteer_id' => \$volunteer->id,
+        'shift_id' => \$activeShift->id,
+      ]);
+    }
+
+    \$gearItem = ProjectGearItem::factory()->create([
+      'project_id' => \$project->id,
+      'name' => 'E2E Vest',
+      'type' => GearItemType::SizeSelection,
+      'requires_size' => true,
+      'available_sizes' => ['S', 'M', 'L'],
+      'sort_order' => 1,
+    ]);
+
+    VolunteerGear::factory()->create([
+      'volunteer_id' => \$lisa->id,
+      'project_gear_item_id' => \$gearItem->id,
+      'size' => 'M',
+      'quantity_entitled' => null,
+    ]);
+
+    ProjectScanner::factory()->active()->create([
+      'project_id' => \$project->id,
+      'event_id' => \$event->id,
+      'name' => 'E2E Volunteer Admin Scanner',
+      'type' => ScannerType::VolunteerAdmin,
+      'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
+      'scanner_token' => 'e2e-va-shift-list-token',
+      'auth_code' => '222222',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
+
+    \$pastProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Volunteer Admin Past Scanner Project',
+    ]);
+
+    \$pastEvent = Event::factory()->for(\$organization)->for(\$pastProject)->published()->create([
+      'name' => 'E2E Volunteer Admin Past Shift Event',
+      'slug' => 'e2e-volunteer-admin-past-shift-event',
+      'starts_at' => now()->subHours(10),
+      'ends_at' => now()->subHours(3),
+      'attendance_grace_minutes' => 15,
+    ]);
+
+    \$pastJob = VolunteerJob::factory()->create([
+      'event_id' => \$pastEvent->id,
+      'name' => 'Past Shift Team',
+    ]);
+
+    \$pastShift = Shift::factory()->create([
+      'volunteer_job_id' => \$pastJob->id,
+      'shift_date' => now()->subDay()->toDateString(),
+      'starts_at' => now()->subHours(8),
+      'ends_at' => now()->subHours(6),
+      'display_text' => now()->subHours(8)->format('M d, H:i').' - '.now()->subHours(6)->format('H:i'),
+    ]);
+
+    \$pastVolunteer = Volunteer::factory()->verified()->for(\$pastProject)->create([
+      'first_name' => 'Past',
+      'last_name' => 'Volunteer',
+      'email' => 'past-volunteer@example.com',
+      'phone' => '+491709999999',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$pastProject->id,
+      'volunteer_id' => \$pastVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$pastVolunteer->id,
+      'shift_id' => \$pastShift->id,
+    ]);
+
+    ProjectScanner::factory()->active()->create([
+      'project_id' => \$pastProject->id,
+      'event_id' => \$pastEvent->id,
+      'name' => 'E2E Volunteer Admin Past Scanner',
+      'type' => ScannerType::VolunteerAdmin,
+      'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
+      'scanner_token' => 'e2e-va-all-past-token',
+      'auth_code' => '444444',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
+  });
+
+  echo 'Volunteer admin shift-list fixture created';
+"
+
 echo ""
 echo "=== Setup complete ==="
 echo "Users available:"
 echo "  Organizer:      test@example.com / password"
 echo "  EntranceStaff:  entrance@example.com / password"
 echo "  Dashboard user: dashboard@example.com / password"
+echo "  VA scanner:     /s/e2e-va-shift-list-token with code 222222"
+echo "  VA all past:    /s/e2e-va-all-past-token with code 444444"

--- a/e2e/va-scanner-shift-list.spec.ts
+++ b/e2e/va-scanner-shift-list.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    viewport: { width: 430, height: 520 },
+});
+
+test('volunteer admin scanner shift list supports browse, jump, search, and detail handoff', async ({ page }) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+
+    await page.goto('/s/e2e-va-shift-list-token');
+
+    await page.getByLabel('Enter 6-digit code').fill('222222');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-va-shift-list-token\/scan$/);
+    await expect(page.getByRole('tab', { name: 'Scanner' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Schichtliste' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Schichtliste' }).click();
+    await expect(page.getByText('Welcome Desk')).toBeVisible();
+
+    const groupHeadings = await page.locator('#tabpanel-shifts p.text-sm.font-semibold.text-white').allTextContents();
+    expect(groupHeadings).toEqual(['Welcome Desk', 'Badge Check', 'Cleanup Crew']);
+
+    await expect(page.getByText('Laeuft jetzt')).toBeVisible();
+    await expect(page.getByText('Als Naechstes')).toBeVisible();
+
+    const lisaRows = page.locator('#tabpanel-shifts button').filter({ hasText: 'Lisa Mueller' });
+    await expect(lisaRows).toHaveCount(2);
+
+    const nextUpcomingTopBefore = await page.getByText('Badge Check').evaluate((element) => element.getBoundingClientRect().top);
+
+    await page.getByRole('button', { name: 'Jetzt' }).click();
+
+    await expect
+        .poll(async () => page.getByText('Badge Check').evaluate((element) => element.getBoundingClientRect().top))
+        .toBeLessThan(nextUpcomingTopBefore);
+
+    const searchInput = page.getByPlaceholder('Search shifts or volunteers...');
+    await searchInput.fill('L');
+    await expect(page.getByText('Mindestens 2 Zeichen eingeben.')).toBeVisible();
+
+    await searchInput.fill('Lisa');
+    await expect(lisaRows).toHaveCount(2);
+    await expect(page.getByText('Badge Check')).not.toBeVisible();
+    await expect(page.locator('#tabpanel-shifts button').filter({ hasText: 'Tom Weber' })).toHaveCount(0);
+
+    await lisaRows.first().click();
+
+    const scannerTabPanel = page.locator('#tabpanel-va-scanner');
+
+    await expect(page.getByRole('tab', { name: 'Scanner' })).toHaveAttribute('aria-selected', 'true');
+    await expect(scannerTabPanel.getByText('Lisa Mueller').first()).toBeVisible();
+    await expect(scannerTabPanel.getByText('lisa-shifts@example.com')).toBeVisible();
+    await expect(scannerTabPanel.getByText('+491701234567')).toBeVisible();
+    await expect(scannerTabPanel.getByRole('heading', { name: 'Shifts' })).toBeVisible();
+    await expect(scannerTabPanel.getByRole('heading', { name: 'Gear' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Attendance' }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Pick Up E2E Vest' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Attendance' }).first().click();
+    await page.getByRole('tab', { name: 'Schichtliste' }).click();
+
+    const lisaRecordedRow = page.locator('#tabpanel-shifts button').filter({ hasText: 'Lisa Mueller' }).first();
+    await expect(lisaRecordedRow).toContainText('Recorded');
+});
+
+test('volunteer admin shift list disables Jetzt when all visible shifts are over', async ({ page }) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+
+    await page.goto('/s/e2e-va-all-past-token');
+
+    await page.getByLabel('Enter 6-digit code').fill('444444');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-va-all-past-token\/scan$/);
+
+    await page.getByRole('tab', { name: 'Schichtliste' }).click();
+
+    await expect(page.getByText('No active or upcoming shifts.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Jetzt' })).toBeDisabled();
+});

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -19,15 +19,33 @@ import {
     getKeys,
     getVolunteers,
     getGuestEntries,
+    getAttendanceRecords,
     addOutboxEntry,
     getOutboxCount,
 } from './idb-store';
 import { validateJwt } from './jwt-validator';
-import { classifyShifts, type ClassifiedShift } from './shift-context';
+import {
+    classifyShifts,
+    filterShiftGroups,
+    findNextUpcomingShiftGroup,
+    groupSignupsByShift,
+    requiresShiftSearchHint,
+    type ClassifiedShift,
+    type ShiftGroup,
+    type ShiftGroupVolunteerRow,
+} from './shift-context';
 import { syncOutbox } from './sync';
 import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear, VolunteerGearPickup, GuestEntry } from './types';
 
 type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | 'invalid' | 'confirmed';
+type ScannerTab = 'scanner' | 'volunteers' | 'guests' | 'shifts';
+type ScannerDataSource = 'network' | 'cache' | 'unavailable';
+
+interface SelectedShiftContext {
+    volunteerId: number;
+    signupId: number;
+    shiftId: number;
+}
 
 interface ScannerResult {
     name: string;
@@ -59,8 +77,11 @@ export function scannerApp(config: ScannerAppConfig) {
         isOnline: navigator.onLine,
         outboxCount: 0,
         selectedVolunteer: null as Volunteer | null,
+        selectedShiftContext: null as SelectedShiftContext | null,
         scannerType: config.scannerType,
         cameraPaused: false,
+        scannerDataSource: 'unavailable' as ScannerDataSource,
+        shiftListNotice: '' as string,
 
         // Internal state
         _scannerId: config.scannerId,
@@ -84,8 +105,9 @@ export function scannerApp(config: ScannerAppConfig) {
         _inactivityTimeout: 120000, // 2 minutes
         _video: null as HTMLVideoElement | null,
         _canvas: null as HTMLCanvasElement | null,
-        activeTab: 'scanner' as 'scanner' | 'volunteers' | 'guests',
+        activeTab: 'scanner' as ScannerTab,
         guestSearchQuery: '' as string,
+        shiftSearchQuery: '' as string,
         guestResult: null as GuestEntry | null,
 
         get filteredGuestGroups(): { label: string; guestCount: number; entries: GuestEntry[] }[] {
@@ -113,6 +135,49 @@ export function scannerApp(config: ScannerAppConfig) {
             return Array.from(groups.values());
         },
 
+        get hasShiftListTab(): boolean {
+            return this.scannerType === 'volunteer_admin' && config.modes.includes('checkin');
+        },
+
+        get hasGuestListTab(): boolean {
+            return this.scannerType === 'entry_staff';
+        },
+
+        get visibleShiftGroups(): ShiftGroup[] {
+            if (!this.hasShiftListTab) {
+                return [];
+            }
+
+            return groupSignupsByShift(this._volunteers, new Date()).filter((group) => group.groupStatus !== 'past');
+        },
+
+        get filteredShiftGroups(): ShiftGroup[] {
+            return filterShiftGroups(this.visibleShiftGroups, this.shiftSearchQuery);
+        },
+
+        get shouldShowShiftSearchHint(): boolean {
+            return requiresShiftSearchHint(this.shiftSearchQuery);
+        },
+
+        get nextUpcomingShiftGroupId(): number | null {
+            return findNextUpcomingShiftGroup(this.filteredShiftGroups, new Date())?.shiftId ?? null;
+        },
+
+        get selectedVolunteerShiftSignups() {
+            if (!this.selectedVolunteer) {
+                return [];
+            }
+
+            return [...this.selectedVolunteer.shift_signups].sort((left, right) => {
+                const leftIsSelected = this.selectedShiftContext?.signupId === left.id ? 1 : 0;
+                const rightIsSelected = this.selectedShiftContext?.signupId === right.id ? 1 : 0;
+
+                return rightIsSelected - leftIsSelected
+                    || new Date(left.shift.starts_at).getTime() - new Date(right.shift.starts_at).getTime()
+                    || left.id - right.id;
+            });
+        },
+
         get canConfirmArrival(): boolean {
             return config.scannerType === 'entry_staff';
         },
@@ -125,13 +190,20 @@ export function scannerApp(config: ScannerAppConfig) {
             return config.scannerType === 'volunteer_admin';
         },
 
+        get canReloadScannerData(): boolean {
+            return this.hasShiftListTab;
+        },
+
         async init() {
             await openScannerDb();
 
             // Online/offline listeners
-            window.addEventListener('online', () => {
+            window.addEventListener('online', async () => {
                 this.isOnline = true;
-                this._sync();
+                await this._sync();
+                if (this.canReloadScannerData && (this.activeTab === 'shifts' || this.selectedShiftContext !== null)) {
+                    await this.reloadScannerData({ preserveUiState: true });
+                }
             });
             window.addEventListener('offline', () => {
                 this.isOnline = false;
@@ -146,7 +218,7 @@ export function scannerApp(config: ScannerAppConfig) {
 
             // Load data
             this.state = 'loading';
-            await this._loadScannerData();
+            await this.reloadScannerData({ preserveUiState: false });
 
             // Start camera
             this._video = document.getElementById('scanner-video') as HTMLVideoElement | null;
@@ -162,7 +234,140 @@ export function scannerApp(config: ScannerAppConfig) {
             }
         },
 
+        buildVolunteerResult(volunteer: Volunteer): ScannerResult {
+            return {
+                name: volunteer.name,
+                email: volunteer.email,
+                volunteerId: volunteer.id,
+                ticketId: volunteer.ticket.id,
+                shifts: classifyShifts(volunteer.shift_signups, new Date()),
+                shiftSignups: volunteer.shift_signups.map((signup) => ({
+                    id: signup.id,
+                    shiftId: signup.shift.id,
+                    startsAt: signup.shift.starts_at,
+                })),
+            };
+        },
+
+        selectVolunteer(volunteer: Volunteer, options: { fromQr?: boolean; shiftContext?: SelectedShiftContext | null } = {}) {
+            this.selectedVolunteer = volunteer;
+            this.selectedShiftContext = options.shiftContext ?? null;
+            this.result = this.buildVolunteerResult(volunteer);
+            this.guestResult = null;
+
+            if (options.fromQr) {
+                const alreadyArrived = this._arrivals.some((arrival) => arrival.volunteer_id === volunteer.id);
+
+                if (alreadyArrived) {
+                    const arrival = this._arrivals.find((entry) => entry.volunteer_id === volunteer.id);
+                    const lastScan = arrival?.scanned_at
+                        ? new Date(arrival.scanned_at).toLocaleTimeString()
+                        : '';
+
+                    this.state = 'duplicate';
+                    this.resultMessage = lastScan
+                        ? `Already checked in at ${lastScan}.`
+                        : 'Already checked in.';
+
+                    return;
+                }
+
+                this.state = 'result';
+                this.resultMessage = 'Ready to check in.';
+
+                return;
+            }
+
+            this.state = 'scanning';
+            this.resultMessage = '';
+            this.errorMessage = '';
+        },
+
+        selectVolunteerFromShift(row: ShiftGroupVolunteerRow) {
+            const volunteer = this._volunteers.find((entry) => entry.id === row.volunteerId);
+            if (!volunteer) {
+                this.shiftListNotice = 'Volunteer details are no longer available. Reload scanner data and try again.';
+                return;
+            }
+
+            this.shiftListNotice = '';
+            this.selectVolunteer(volunteer, {
+                shiftContext: {
+                    volunteerId: row.volunteerId,
+                    signupId: row.signupId,
+                    shiftId: row.shiftId,
+                },
+            });
+            this.activeTab = 'scanner';
+        },
+
+        async setActiveTab(tab: ScannerTab) {
+            if (tab === 'shifts' && !this.hasShiftListTab) {
+                return;
+            }
+
+            this.activeTab = tab;
+
+            if (tab === 'shifts' && this.canReloadScannerData && this.isOnline) {
+                await this.reloadScannerData({ preserveUiState: true });
+            }
+        },
+
+        async reloadScannerData(options: { preserveUiState: boolean }) {
+            this.shiftListNotice = '';
+
+            const preservedState = options.preserveUiState ? {
+                activeTab: this.activeTab,
+                shiftSearchQuery: this.shiftSearchQuery,
+                selectedVolunteerId: this.selectedVolunteer?.id ?? null,
+                selectedShiftContext: this.selectedShiftContext,
+            } : null;
+
+            await this._loadScannerData();
+
+            if (!preservedState) {
+                return;
+            }
+
+            this.activeTab = preservedState.activeTab === 'shifts' && !this.hasShiftListTab
+                ? 'scanner'
+                : preservedState.activeTab;
+            this.shiftSearchQuery = preservedState.shiftSearchQuery;
+
+            if (!preservedState.selectedVolunteerId) {
+                return;
+            }
+
+            const volunteer = this._volunteers.find((entry) => entry.id === preservedState.selectedVolunteerId);
+            if (!volunteer) {
+                this.selectedVolunteer = null;
+                this.selectedShiftContext = null;
+                this.result = null;
+                this.shiftListNotice = 'Selected volunteer is no longer available in the latest scanner data.';
+                return;
+            }
+
+            const shiftContext = preservedState.selectedShiftContext;
+            if (shiftContext) {
+                const hasMatchingSignup = volunteer.shift_signups.some((signup) => {
+                    return signup.id === shiftContext.signupId && signup.shift.id === shiftContext.shiftId;
+                });
+
+                if (!hasMatchingSignup) {
+                    this.shiftListNotice = 'Selected shift is no longer available in the latest scanner data.';
+                    this.selectVolunteer(volunteer);
+                    return;
+                }
+            }
+
+            this.selectVolunteer(volunteer, {
+                shiftContext: shiftContext ?? null,
+            });
+        },
+
         async _loadScannerData() {
+            let loadedFromNetwork = false;
+
             if (this.isOnline) {
                 try {
                     const headers: Record<string, string> = {
@@ -173,6 +378,7 @@ export function scannerApp(config: ScannerAppConfig) {
                     const response = await fetch(this._dataUrl, { headers });
                     if (response.ok) {
                         const data = await response.json();
+                        loadedFromNetwork = true;
                         this._volunteers = data.volunteers;
                         this._arrivals = data.arrivals;
                         this._attendanceRecords = data.attendance_records ?? [];
@@ -189,6 +395,8 @@ export function scannerApp(config: ScannerAppConfig) {
                         if (data.attendance_records) {
                             await storeAttendanceRecords(this._scannerId, data.attendance_records);
                         }
+
+                        this.scannerDataSource = 'network';
                     }
                 } catch {
                     // Network error — fall through to IDB cache
@@ -196,11 +404,13 @@ export function scannerApp(config: ScannerAppConfig) {
             }
 
             // Fallback: load from IndexedDB
-            if (this._volunteers.length === 0) {
+            if (!loadedFromNetwork) {
                 this._volunteers = await getVolunteers(this._scannerId);
-            }
-            if (this._guestEntries.length === 0) {
                 this._guestEntries = await getGuestEntries(this._scannerId);
+                this._attendanceRecords = await getAttendanceRecords(this._scannerId);
+                this.scannerDataSource = this._volunteers.length > 0 || this._guestEntries.length > 0
+                    ? 'cache'
+                    : 'unavailable';
             }
 
             this.outboxCount = await getOutboxCount(this._scannerId);
@@ -246,36 +456,7 @@ export function scannerApp(config: ScannerAppConfig) {
                     return;
                 }
 
-                // Check for existing arrival
-                const alreadyArrived = this._arrivals.some((a) => a.volunteer_id === volunteer.id);
-
-                this.selectedVolunteer = volunteer;
-                this.result = {
-                    name: volunteer.name,
-                    email: volunteer.email,
-                    volunteerId: volunteer.id,
-                    ticketId: volunteer.ticket.id,
-                    shifts: classifyShifts(volunteer.shift_signups, new Date()),
-                    shiftSignups: volunteer.shift_signups.map((s) => ({
-                        id: s.id,
-                        shiftId: s.shift.id,
-                        startsAt: s.shift.starts_at,
-                    })),
-                };
-
-                if (alreadyArrived) {
-                    const arrival = this._arrivals.find((a) => a.volunteer_id === volunteer.id);
-                    const lastScan = arrival?.scanned_at
-                        ? new Date(arrival.scanned_at).toLocaleTimeString()
-                        : '';
-                    this.state = 'duplicate';
-                    this.resultMessage = lastScan
-                        ? `Already checked in at ${lastScan}.`
-                        : 'Already checked in.';
-                } else {
-                    this.state = 'result';
-                    this.resultMessage = 'Ready to check in.';
-                }
+                this.selectVolunteer(volunteer, { fromQr: true });
             } finally {
                 // Brief cooldown to prevent rapid re-scans
                 setTimeout(() => {
@@ -376,6 +557,15 @@ export function scannerApp(config: ScannerAppConfig) {
                 status,
             });
 
+            const selectedSignup = this.selectedVolunteer?.shift_signups.find((entry) => entry.id === shiftSignupId);
+            if (selectedSignup) {
+                selectedSignup.attendance_record = {
+                    id: 0,
+                    shift_signup_id: shiftSignupId,
+                    status,
+                };
+            }
+
             if (this.result) {
                 const shift = this.result.shifts.find((s) => s.signupId === shiftSignupId);
                 if (shift) {
@@ -463,6 +653,50 @@ export function scannerApp(config: ScannerAppConfig) {
             return this._gearCooldowns[gearId] ?? false;
         },
 
+        isSelectedShiftSignup(shiftSignupId: number): boolean {
+            return this.selectedShiftContext?.signupId === shiftSignupId;
+        },
+
+        shiftGroupBadgeLabel(group: ShiftGroup): string {
+            if (group.groupStatus === 'active') {
+                return 'Laeuft jetzt';
+            }
+
+            if (group.isNextUpcoming) {
+                return 'Als Naechstes';
+            }
+
+            return '';
+        },
+
+        shiftStatusLabel(status: ClassifiedShift['status']): string {
+            switch (status) {
+                case 'attended':
+                    return 'Recorded';
+                case 'missed':
+                    return 'Missed';
+                case 'active':
+                    return 'Active';
+                default:
+                    return 'Upcoming';
+            }
+        },
+
+        async jumpToNextShift() {
+            const nextShiftGroupId = this.nextUpcomingShiftGroupId;
+            if (!nextShiftGroupId) {
+                return;
+            }
+
+            const element = document.getElementById(`shift-group-${nextShiftGroupId}`);
+            if (!element) {
+                console.warn('Shift jump target missing from DOM.', nextShiftGroupId);
+                return;
+            }
+
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        },
+
         async _sync() {
             await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken, this._guestSyncUrl);
             this.outboxCount = await getOutboxCount(this._scannerId);
@@ -473,6 +707,7 @@ export function scannerApp(config: ScannerAppConfig) {
             this.result = null;
             this.guestResult = null;
             this.selectedVolunteer = null;
+            this.selectedShiftContext = null;
             this.resultMessage = '';
             this.errorMessage = '';
             this._resetInactivityTimer();
@@ -480,6 +715,9 @@ export function scannerApp(config: ScannerAppConfig) {
 
         _handleGuestQr(entry: GuestEntry) {
             const alreadyCheckedIn = entry.checked_in_at !== null;
+            this.selectedVolunteer = null;
+            this.selectedShiftContext = null;
+            this.result = null;
             this.guestResult = entry;
 
             const label = `${entry.group_label} ${entry.number}/${entry.group_guest_count}`;

--- a/resources/js/scanner/idb-store.ts
+++ b/resources/js/scanner/idb-store.ts
@@ -154,6 +154,14 @@ export async function storeAttendanceRecords(scannerId: number, records: Attenda
     }
 }
 
+export async function getAttendanceRecords(scannerId: number): Promise<AttendanceRecord[]> {
+    const store = await tx('attendance', 'readonly');
+    const index = store.index('byScanner');
+    const results = await reqToPromise(index.getAll(scannerId));
+
+    return results.map(({ scannerId: _, ...record }) => record as AttendanceRecord);
+}
+
 export async function storeGuestEntries(scannerId: number, entries: GuestEntry[]): Promise<void> {
     const store = await tx('guest_entries', 'readwrite');
     const index = store.index('byScanner');

--- a/resources/js/scanner/shift-context.ts
+++ b/resources/js/scanner/shift-context.ts
@@ -1,6 +1,7 @@
-import type { ShiftSignup } from './types';
+import type { ShiftSignup, Volunteer } from './types';
 
 export type ShiftStatus = 'attended' | 'missed' | 'active' | 'upcoming';
+export type ShiftGroupStatus = 'past' | 'active' | 'upcoming';
 
 export interface ClassifiedShift {
     signupId: number;
@@ -10,29 +11,168 @@ export interface ClassifiedShift {
     status: ShiftStatus;
 }
 
+export interface ShiftGroupVolunteerRow {
+    volunteerId: number;
+    firstName: string;
+    lastName: string;
+    name: string;
+    email: string;
+    phone: string | null;
+    signupId: number;
+    shiftId: number;
+    status: ShiftStatus;
+}
+
+export interface ShiftGroup {
+    shiftId: number;
+    jobName: string;
+    displayText: string;
+    startsAt: string;
+    endsAt: string;
+    groupStatus: ShiftGroupStatus;
+    isNextUpcoming: boolean;
+    volunteers: ShiftGroupVolunteerRow[];
+}
+
+function classifySignup(signup: ShiftSignup, now: Date): ClassifiedShift {
+    const startsAt = new Date(signup.shift.starts_at);
+    const endsAt = new Date(signup.shift.ends_at);
+
+    let status: ShiftStatus;
+
+    if (signup.attendance_record) {
+        status = signup.attendance_record.status === 'no_show' ? 'missed' : 'attended';
+    } else if (now >= endsAt) {
+        status = 'missed';
+    } else if (now >= startsAt) {
+        status = 'active';
+    } else {
+        status = 'upcoming';
+    }
+
+    return {
+        signupId: signup.id,
+        jobName: signup.shift.volunteer_job.name,
+        startsAt: signup.shift.starts_at,
+        endsAt: signup.shift.ends_at,
+        status,
+    };
+}
+
+function getShiftGroupStatus(startsAt: string, endsAt: string, now: Date): ShiftGroupStatus {
+    const startsAtDate = new Date(startsAt);
+    const endsAtDate = new Date(endsAt);
+
+    if (now >= endsAtDate) {
+        return 'past';
+    }
+
+    if (now >= startsAtDate) {
+        return 'active';
+    }
+
+    return 'upcoming';
+}
+
 export function classifyShifts(signups: ShiftSignup[], now: Date): ClassifiedShift[] {
-    return signups.map((signup) => {
-        const startsAt = new Date(signup.shift.starts_at);
-        const endsAt = new Date(signup.shift.ends_at);
+    return signups.map((signup) => classifySignup(signup, now));
+}
 
-        let status: ShiftStatus;
+export function groupSignupsByShift(volunteers: Volunteer[], now: Date): ShiftGroup[] {
+    const groups = new Map<number, ShiftGroup>();
 
-        if (signup.attendance_record) {
-            status = signup.attendance_record.status === 'no_show' ? 'missed' : 'attended';
-        } else if (now >= endsAt) {
-            status = 'missed';
-        } else if (now >= startsAt) {
-            status = 'active';
-        } else {
-            status = 'upcoming';
+    for (const volunteer of volunteers) {
+        const shiftsBySignupId = new Map(
+            classifyShifts(volunteer.shift_signups, now).map((shift) => [shift.signupId, shift])
+        );
+
+        for (const signup of volunteer.shift_signups) {
+            const classifiedShift = shiftsBySignupId.get(signup.id);
+            if (!classifiedShift) {
+                continue;
+            }
+
+            const shiftId = signup.shift.id;
+            if (!groups.has(shiftId)) {
+                groups.set(shiftId, {
+                    shiftId,
+                    jobName: signup.shift.volunteer_job.name,
+                    displayText: signup.shift.display_text,
+                    startsAt: signup.shift.starts_at,
+                    endsAt: signup.shift.ends_at,
+                    groupStatus: getShiftGroupStatus(signup.shift.starts_at, signup.shift.ends_at, now),
+                    isNextUpcoming: false,
+                    volunteers: [],
+                });
+            }
+
+            groups.get(shiftId)?.volunteers.push({
+                volunteerId: volunteer.id,
+                firstName: volunteer.first_name,
+                lastName: volunteer.last_name,
+                name: volunteer.name,
+                email: volunteer.email,
+                phone: volunteer.phone,
+                signupId: signup.id,
+                shiftId,
+                status: classifiedShift.status,
+            });
         }
+    }
 
-        return {
-            signupId: signup.id,
-            jobName: signup.shift.volunteer_job.name,
-            startsAt: signup.shift.starts_at,
-            endsAt: signup.shift.ends_at,
-            status,
-        };
-    });
+    const sortedGroups = Array.from(groups.values())
+        .map((group) => ({
+            ...group,
+            volunteers: [...group.volunteers].sort((left, right) => {
+                return left.name.localeCompare(right.name)
+                    || left.email.localeCompare(right.email)
+                    || left.signupId - right.signupId;
+            }),
+        }))
+        .sort((left, right) => {
+            return new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime()
+                || new Date(left.endsAt).getTime() - new Date(right.endsAt).getTime()
+                || left.jobName.localeCompare(right.jobName)
+                || left.shiftId - right.shiftId;
+        });
+
+    const nextUpcomingShift = findNextUpcomingShiftGroup(sortedGroups, now);
+
+    return sortedGroups.map((group) => ({
+        ...group,
+        isNextUpcoming: nextUpcomingShift?.shiftId === group.shiftId,
+    }));
+}
+
+export function requiresShiftSearchHint(query: string): boolean {
+    const trimmedQuery = query.trim();
+
+    return trimmedQuery.length > 0 && trimmedQuery.length < 2;
+}
+
+export function filterShiftGroups(groups: ShiftGroup[], query: string): ShiftGroup[] {
+    const trimmedQuery = query.trim().toLowerCase();
+
+    if (trimmedQuery.length === 0) {
+        return groups;
+    }
+
+    if (requiresShiftSearchHint(query)) {
+        return [];
+    }
+
+    return groups
+        .map((group) => ({
+            ...group,
+            volunteers: group.volunteers.filter((volunteer) => {
+                return volunteer.firstName.toLowerCase().includes(trimmedQuery)
+                    || volunteer.lastName.toLowerCase().includes(trimmedQuery)
+                    || volunteer.email.toLowerCase().includes(trimmedQuery);
+            }),
+        }))
+        .filter((group) => group.volunteers.length > 0);
+}
+
+export function findNextUpcomingShiftGroup(groups: ShiftGroup[], now: Date): ShiftGroup | null {
+    return groups.find((group) => new Date(group.startsAt) > now) ?? null;
 }

--- a/resources/js/scanner/types.ts
+++ b/resources/js/scanner/types.ts
@@ -5,8 +5,10 @@ export interface VolunteerJob {
 
 export interface Shift {
     id: number;
+    shift_date: string;
     starts_at: string;
     ends_at: string;
+    display_text: string;
     volunteer_job: VolunteerJob;
 }
 
@@ -120,4 +122,3 @@ export interface OutboxEntry {
     status?: 'on_time' | 'late' | 'no_show';
     guest_entry_id?: number;
 }
-

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -45,7 +45,7 @@
                     aria-controls="tabpanel-scanner"
                     class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
                     :class="activeTab === 'scanner' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
-                    @click="activeTab = 'scanner'"
+                    @click="setActiveTab('scanner')"
                 >
                     Scanner
                 </button>
@@ -57,7 +57,7 @@
                     aria-controls="tabpanel-volunteers"
                     class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
                     :class="activeTab === 'volunteers' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
-                    @click="activeTab = 'volunteers'"
+                    @click="setActiveTab('volunteers')"
                 >
                     Volunteers
                 </button>
@@ -69,7 +69,7 @@
                     aria-controls="tabpanel-guests"
                     class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
                     :class="activeTab === 'guests' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
-                    @click="activeTab = 'guests'"
+                    @click="setActiveTab('guests')"
                 >
                     Gastliste
                 </button>
@@ -240,8 +240,37 @@
                 </div>
             </div>
         @else
+            @if (in_array('checkin', $modes))
+                <div role="tablist" class="mb-4 flex border-b border-zinc-700">
+                    <button
+                        type="button"
+                        role="tab"
+                        id="tab-va-scanner"
+                        :aria-selected="activeTab === 'scanner'"
+                        aria-controls="tabpanel-va-scanner"
+                        class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
+                        :class="activeTab === 'scanner' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
+                        @click="setActiveTab('scanner')"
+                    >
+                        Scanner
+                    </button>
+                    <button
+                        type="button"
+                        role="tab"
+                        id="tab-shifts"
+                        :aria-selected="activeTab === 'shifts'"
+                        aria-controls="tabpanel-shifts"
+                        class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
+                        :class="activeTab === 'shifts' ? 'text-white border-b-2 border-emerald-500' : 'text-zinc-400 hover:text-zinc-200'"
+                        @click="setActiveTab('shifts')"
+                    >
+                        Schichtliste
+                    </button>
+                </div>
+            @endif
+
             {{-- Volunteer Admin: QR viewfinder + volunteer panel + gear pickup --}}
-            <div class="flex flex-1 flex-col items-center space-y-4">
+            <div id="tabpanel-va-scanner" role="tabpanel" aria-labelledby="tab-va-scanner" x-show="activeTab === 'scanner'" x-cloak class="flex flex-1 flex-col items-center space-y-4">
                 <div id="scanner-viewfinder" class="relative aspect-square w-full max-w-sm overflow-hidden rounded-xl bg-black" @click="cameraPaused && resumeCamera()">
                     <video id="scanner-video" class="h-full w-full object-cover" aria-label="{{ __('QR code camera viewfinder') }}" playsinline></video>
                     <div
@@ -296,8 +325,8 @@
                             <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
                                 <h3 class="mb-3 text-sm font-semibold text-zinc-300">{{ __('Shifts') }}</h3>
                                 <div class="space-y-2">
-                                    <template x-for="signup in selectedVolunteer.shift_signups" :key="signup.id">
-                                        <div class="flex min-h-12 items-center justify-between rounded-lg bg-zinc-900 px-4 py-3">
+                                    <template x-for="signup in selectedVolunteerShiftSignups" :key="signup.id">
+                                        <div class="flex min-h-12 items-center justify-between rounded-lg bg-zinc-900 px-4 py-3" :class="isSelectedShiftSignup(signup.id) ? 'ring-1 ring-emerald-500/60' : ''">
                                             <div class="min-w-0 flex-1">
                                                 <p class="text-sm font-medium text-white" x-text="signup.shift.volunteer_job.name"></p>
                                                 <p class="text-xs text-zinc-400" x-text="signup.shift.display_text"></p>
@@ -371,6 +400,96 @@
                     </button>
                 </div>
             </div>
+
+            @if (in_array('checkin', $modes))
+                <div id="tabpanel-shifts" role="tabpanel" aria-labelledby="tab-shifts" x-show="activeTab === 'shifts'" x-cloak class="flex flex-1 flex-col space-y-4">
+                    <div class="space-y-3 px-1">
+                        <input
+                            type="text"
+                            x-model.debounce.300ms="shiftSearchQuery"
+                            placeholder="{{ __('Search shifts or volunteers...') }}"
+                            aria-label="{{ __('Search volunteers in shift list') }}"
+                            class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-base text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        />
+
+                        <button
+                            type="button"
+                            class="min-h-12 w-full rounded-lg bg-blue-600 px-4 py-3 text-base font-medium text-white hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                            @click="jumpToNextShift()"
+                            :disabled="nextUpcomingShiftGroupId === null"
+                        >
+                            Jetzt
+                        </button>
+
+                        <template x-if="scannerDataSource === 'cache'">
+                            <div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                                Offline - showing cached shift data.
+                            </div>
+                        </template>
+
+                        <template x-if="shiftListNotice">
+                            <div class="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-sm text-zinc-300" x-text="shiftListNotice"></div>
+                        </template>
+                    </div>
+
+                    <div class="space-y-3 overflow-y-auto px-1">
+                        <template x-if="scannerDataSource === 'unavailable'">
+                            <p class="py-8 text-center text-sm text-zinc-500">Shift data is unavailable right now.</p>
+                        </template>
+
+                        <template x-if="scannerDataSource !== 'unavailable' && shouldShowShiftSearchHint">
+                            <p class="py-8 text-center text-sm text-zinc-500">Mindestens 2 Zeichen eingeben.</p>
+                        </template>
+
+                        <template x-if="scannerDataSource !== 'unavailable' && !shouldShowShiftSearchHint && filteredShiftGroups.length === 0 && shiftSearchQuery.trim().length === 0">
+                            <p class="py-8 text-center text-sm text-zinc-500">No active or upcoming shifts.</p>
+                        </template>
+
+                        <template x-if="scannerDataSource !== 'unavailable' && !shouldShowShiftSearchHint && filteredShiftGroups.length === 0 && shiftSearchQuery.trim().length >= 2">
+                            <p class="py-8 text-center text-sm text-zinc-500">No matching volunteers found.</p>
+                        </template>
+
+                        <template x-for="group in filteredShiftGroups" :key="group.shiftId">
+                            <div :id="`shift-group-${group.shiftId}`" class="rounded-xl border border-zinc-700 bg-zinc-800 p-3">
+                                <div class="mb-3 flex items-start justify-between gap-3">
+                                    <div>
+                                        <p class="text-sm font-semibold text-white" x-text="group.jobName"></p>
+                                        <p class="text-xs text-zinc-400" x-text="group.displayText"></p>
+                                    </div>
+                                    <template x-if="shiftGroupBadgeLabel(group)">
+                                        <span class="rounded-full px-3 py-1 text-xs font-medium" :class="group.groupStatus === 'active' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-blue-500/20 text-blue-300'" x-text="shiftGroupBadgeLabel(group)"></span>
+                                    </template>
+                                </div>
+
+                                <div class="space-y-2">
+                                    <template x-for="row in group.volunteers" :key="`${row.signupId}-${row.volunteerId}`">
+                                        <button
+                                            type="button"
+                                            class="flex min-h-12 w-full items-center justify-between rounded-lg bg-zinc-900 px-4 py-3 text-left transition hover:bg-zinc-950"
+                                            @click="selectVolunteerFromShift(row)"
+                                        >
+                                            <div class="min-w-0 flex-1">
+                                                <p class="text-sm font-medium text-white" x-text="row.name"></p>
+                                                <p class="text-xs text-zinc-400" x-text="row.email"></p>
+                                            </div>
+                                            <span
+                                                class="ml-3 shrink-0 rounded-full px-3 py-1 text-xs font-medium"
+                                                :class="{
+                                                    'bg-emerald-500/20 text-emerald-300': row.status === 'attended',
+                                                    'bg-amber-500/20 text-amber-300': row.status === 'active',
+                                                    'bg-zinc-700 text-zinc-200': row.status === 'upcoming',
+                                                    'bg-red-500/20 text-red-300': row.status === 'missed'
+                                                }"
+                                                x-text="shiftStatusLabel(row.status)"
+                                            ></span>
+                                        </button>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            @endif
         @endif
     </main>
 </div>

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -5,10 +5,13 @@ use App\Models\Event;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
 use App\Models\VolunteerGearPickup;
+use App\Models\VolunteerJob;
 use Carbon\Carbon;
 
 beforeEach(function () {
@@ -105,6 +108,70 @@ it('includes attendance_states in data response', function () {
     $response->assertOk()
         ->assertJsonStructure(['attendance_states'])
         ->assertJsonCount(5, 'attendance_states');
+});
+
+it('returns volunteer shift payload fields required for volunteer admin shift list', function () {
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+        'project_id' => $this->project->id,
+        'event_id' => $this->event->id,
+    ]);
+
+    $volunteer = Volunteer::factory()->create([
+        'project_id' => $this->project->id,
+        'first_name' => 'Lisa',
+        'last_name' => 'Mueller',
+        'email' => 'lisa@example.com',
+        'phone' => '+4911111111',
+    ]);
+
+    Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+        'name' => 'Stage Setup',
+    ]);
+
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+        'shift_date' => '2026-07-01',
+        'starts_at' => Carbon::parse('2026-07-01 13:00:00'),
+        'ends_at' => Carbon::parse('2026-07-01 17:00:00'),
+        'display_text' => 'Jul 01, 13:00 - 17:00',
+    ]);
+
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    $this->postJson(route('scanner-api.attendance', $scanner->id), [
+        'shift_signup_id' => $signup->id,
+        'status' => 'on_time',
+        'scanned_at' => now()->toISOString(),
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ])->assertOk();
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('volunteers.0.id', $volunteer->id)
+        ->assertJsonPath('volunteers.0.first_name', 'Lisa')
+        ->assertJsonPath('volunteers.0.last_name', 'Mueller')
+        ->assertJsonPath('volunteers.0.email', 'lisa@example.com')
+        ->assertJsonPath('volunteers.0.phone', '+4911111111')
+        ->assertJsonPath('volunteers.0.shift_signups.0.id', $signup->id)
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.id', $shift->id)
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.starts_at', Carbon::parse('2026-07-01 13:00:00')->toJSON())
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.ends_at', Carbon::parse('2026-07-01 17:00:00')->toJSON())
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.display_text', 'Jul 01, 13:00 - 17:00')
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.volunteer_job.name', 'Stage Setup')
+        ->assertJsonPath('volunteers.0.shift_signups.0.attendance_record.status', 'on_time');
 });
 
 it('returns default states for projects with null attendance_states', function () {

--- a/tests/Feature/Livewire/ScannerAppTest.php
+++ b/tests/Feature/Livewire/ScannerAppTest.php
@@ -72,6 +72,16 @@ it('loads volunteer admin scanner properties correctly', function () {
         ->assertSet('modes', [ScannerMode::Checkin->value, ScannerMode::GearPickup->value]);
 });
 
+it('renders scanner and shift-list tabs for volunteer admin scanners with checkin mode', function () {
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSee('Scanner')
+        ->assertSee('Schichtliste')
+        ->assertSeeHtml("setActiveTab('shifts')");
+});
+
 it('hides shifts section for VA scanner with gear_pickup only mode', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'type' => ScannerType::VolunteerAdmin,
@@ -81,6 +91,18 @@ it('hides shifts section for VA scanner with gear_pickup only mode', function ()
 
     Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
         ->assertDontSee(__('Shifts'));
+});
+
+it('does not render shift-list tab for gear-only volunteer admin scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->create([
+        'type' => ScannerType::VolunteerAdmin,
+        'modes' => [ScannerMode::GearPickup->value],
+    ]);
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertDontSee('Schichtliste')
+        ->assertDontSeeHtml('tabpanel-shifts');
 });
 
 it('shows shifts section for VA scanner with checkin mode', function () {
@@ -181,4 +203,16 @@ it('renders phone display in volunteer admin template', function () {
     Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
         ->assertSeeHtml('selectedVolunteer?.phone')
         ->assertSee(__('No phone number'));
+});
+
+it('renders shift-list states and shared scanner helpers in volunteer admin template', function () {
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSee('Mindestens 2 Zeichen eingeben.')
+        ->assertSee('Offline - showing cached shift data.')
+        ->assertSeeHtml('selectedVolunteerShiftSignups')
+        ->assertSeeHtml('selectVolunteerFromShift(row)')
+        ->assertSeeHtml('jumpToNextShift()');
 });

--- a/tests/js/scanner/idb-store.test.ts
+++ b/tests/js/scanner/idb-store.test.ts
@@ -7,6 +7,8 @@ import {
     searchVolunteers,
     storeKeys,
     getKeys,
+    storeAttendanceRecords,
+    getAttendanceRecords,
     addOutboxEntry,
     getOutboxEntries,
     clearOutbox,
@@ -138,5 +140,18 @@ describe('idb-store (DB_VERSION 3 — scannerId keys)', () => {
         });
 
         expect(await getOutboxCount(1)).toBe(2);
+    });
+
+    it('stores and retrieves attendance records by scannerId', async () => {
+        await storeAttendanceRecords(1, [
+            { id: 1, shift_signup_id: 10, status: 'on_time' },
+            { id: 2, shift_signup_id: 11, status: 'late' },
+        ]);
+
+        const records = await getAttendanceRecords(1);
+
+        expect(records).toHaveLength(2);
+        expect(records[0].shift_signup_id).toBe(10);
+        expect(records[1].status).toBe('late');
     });
 });

--- a/tests/js/scanner/shift-context.test.ts
+++ b/tests/js/scanner/shift-context.test.ts
@@ -1,23 +1,51 @@
 import { describe, it, expect } from 'vitest';
-import { classifyShifts, type ClassifiedShift } from '../../../resources/js/scanner/shift-context';
-import type { ShiftSignup } from '../../../resources/js/scanner/types';
+import {
+    classifyShifts,
+    filterShiftGroups,
+    findNextUpcomingShiftGroup,
+    groupSignupsByShift,
+    requiresShiftSearchHint,
+} from '../../../resources/js/scanner/shift-context';
+import type { ShiftSignup, Volunteer } from '../../../resources/js/scanner/types';
 
 function makeSignup(overrides: Partial<{
     id: number;
+    shiftId: number;
     startsAt: string;
     endsAt: string;
     jobName: string;
+    displayText: string;
     attendanceRecord: ShiftSignup['attendance_record'];
 }>): ShiftSignup {
     return {
         id: overrides.id ?? 1,
         shift: {
-            id: 1,
+            id: overrides.shiftId ?? 1,
+            shift_date: '2026-03-14',
             starts_at: overrides.startsAt ?? '2026-03-14T10:00:00Z',
             ends_at: overrides.endsAt ?? '2026-03-14T12:00:00Z',
+            display_text: overrides.displayText ?? 'Mar 14, 10:00 - 12:00',
             volunteer_job: { id: 1, name: overrides.jobName ?? 'Gate Watch' },
         },
         attendance_record: overrides.attendanceRecord ?? null,
+    };
+}
+
+function makeVolunteer(overrides: Partial<Volunteer> = {}): Volunteer {
+    return {
+        id: overrides.id ?? 1,
+        first_name: overrides.first_name ?? 'Alice',
+        last_name: overrides.last_name ?? 'Johnson',
+        name: overrides.name ?? 'Alice Johnson',
+        email: overrides.email ?? 'alice@example.com',
+        phone: overrides.phone ?? null,
+        ticket: overrides.ticket ?? {
+            id: 10,
+            jwt_token: 'jwt-token',
+            volunteer_id: overrides.id ?? 1,
+            project_id: 1,
+        },
+        shift_signups: overrides.shift_signups ?? [],
     };
 }
 
@@ -125,5 +153,124 @@ describe('classifyShifts', () => {
         const result = classifyShifts(signups, now);
 
         expect(result.map((r) => r.status)).toEqual(['missed', 'active', 'upcoming']);
+    });
+});
+
+describe('groupSignupsByShift', () => {
+    it('groups volunteer signups chronologically by shift', () => {
+        const volunteers = [
+            makeVolunteer({
+                shift_signups: [
+                    makeSignup({ id: 1, shiftId: 2, startsAt: '2026-03-14T14:00:00Z', endsAt: '2026-03-14T16:00:00Z', jobName: 'Bar' }),
+                    makeSignup({ id: 2, shiftId: 1, startsAt: '2026-03-14T10:00:00Z', endsAt: '2026-03-14T12:00:00Z', jobName: 'Stage' }),
+                ],
+            }),
+        ];
+
+        const groups = groupSignupsByShift(volunteers, new Date('2026-03-14T08:00:00Z'));
+
+        expect(groups.map((group) => group.shiftId)).toEqual([1, 2]);
+        expect(groups.map((group) => group.jobName)).toEqual(['Stage', 'Bar']);
+    });
+
+    it('keeps the same volunteer in multiple shift groups', () => {
+        const volunteer = makeVolunteer({
+            shift_signups: [
+                makeSignup({ id: 1, shiftId: 10, jobName: 'Setup', startsAt: '2026-03-14T07:00:00Z', endsAt: '2026-03-14T09:00:00Z' }),
+                makeSignup({ id: 2, shiftId: 20, jobName: 'Breakdown', startsAt: '2026-03-14T18:00:00Z', endsAt: '2026-03-14T20:00:00Z' }),
+            ],
+        });
+
+        const groups = groupSignupsByShift([volunteer], new Date('2026-03-14T06:00:00Z'));
+
+        expect(groups).toHaveLength(2);
+        expect(groups[0].volunteers[0].name).toBe('Alice Johnson');
+        expect(groups[1].volunteers[0].name).toBe('Alice Johnson');
+        expect(groups.map((group) => group.volunteers[0].signupId)).toEqual([1, 2]);
+    });
+
+    it('marks only the first future group as next upcoming', () => {
+        const volunteer = makeVolunteer({
+            shift_signups: [
+                makeSignup({ id: 1, shiftId: 10, startsAt: '2026-03-14T10:00:00Z', endsAt: '2026-03-14T12:00:00Z' }),
+                makeSignup({ id: 2, shiftId: 20, startsAt: '2026-03-14T14:00:00Z', endsAt: '2026-03-14T16:00:00Z' }),
+            ],
+        });
+
+        const groups = groupSignupsByShift([volunteer], new Date('2026-03-14T09:00:00Z'));
+
+        expect(groups.map((group) => group.isNextUpcoming)).toEqual([true, false]);
+    });
+});
+
+describe('filterShiftGroups', () => {
+    const groups = groupSignupsByShift([
+        makeVolunteer({
+            shift_signups: [
+                makeSignup({ id: 1, shiftId: 10, jobName: 'Setup', startsAt: '2026-03-14T10:00:00Z', endsAt: '2026-03-14T12:00:00Z' }),
+            ],
+        }),
+        makeVolunteer({
+            id: 2,
+            first_name: 'Lisa',
+            last_name: 'Mueller',
+            name: 'Lisa Mueller',
+            email: 'lisa@example.com',
+            shift_signups: [
+                makeSignup({ id: 2, shiftId: 20, jobName: 'Bar', startsAt: '2026-03-14T14:00:00Z', endsAt: '2026-03-14T16:00:00Z' }),
+            ],
+        }),
+    ], new Date('2026-03-14T08:00:00Z'));
+
+    it('returns all groups for an empty query', () => {
+        expect(filterShiftGroups(groups, '')).toHaveLength(2);
+    });
+
+    it('requires a search hint for a one-character query', () => {
+        expect(requiresShiftSearchHint('L')).toBe(true);
+        expect(filterShiftGroups(groups, 'L')).toEqual([]);
+    });
+
+    it('filters by volunteer first name', () => {
+        const filtered = filterShiftGroups(groups, 'Lisa');
+
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0].volunteers[0].name).toBe('Lisa Mueller');
+    });
+
+    it('filters by volunteer email', () => {
+        const filtered = filterShiftGroups(groups, 'alice@example.com');
+
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0].volunteers[0].email).toBe('alice@example.com');
+    });
+});
+
+describe('findNextUpcomingShiftGroup', () => {
+    it('skips active groups and returns the next future shift', () => {
+        const groups = groupSignupsByShift([
+            makeVolunteer({
+                shift_signups: [
+                    makeSignup({ id: 1, shiftId: 10, startsAt: '2026-03-14T09:00:00Z', endsAt: '2026-03-14T11:00:00Z' }),
+                    makeSignup({ id: 2, shiftId: 20, startsAt: '2026-03-14T13:00:00Z', endsAt: '2026-03-14T15:00:00Z' }),
+                ],
+            }),
+        ], new Date('2026-03-14T10:00:00Z'));
+
+        const nextUpcoming = findNextUpcomingShiftGroup(groups, new Date('2026-03-14T10:00:00Z'));
+
+        expect(nextUpcoming?.shiftId).toBe(20);
+    });
+
+    it('returns null when all groups are in the past', () => {
+        const groups = groupSignupsByShift([
+            makeVolunteer({
+                shift_signups: [
+                    makeSignup({ id: 1, shiftId: 10, startsAt: '2026-03-14T07:00:00Z', endsAt: '2026-03-14T08:00:00Z' }),
+                ],
+            }),
+        ], new Date('2026-03-14T10:00:00Z'));
+
+        expect(findNextUpcomingShiftGroup(groups, new Date('2026-03-14T10:00:00Z'))).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- add a Volunteer Admin `Schichtliste` tab that groups active and upcoming shifts, supports volunteer search, and jumps to the next upcoming shift
- reuse the existing scanner detail panel through a small shared scanner refactor so row selection preserves the correct volunteer and shift context
- add feature, unit, and Playwright coverage for scanner payloads, shift grouping, cached scanner data, and the end-to-end shift-list flow

Closes #197.

## Testing
- `vendor/bin/sail npm run test -- scanner`
- `vendor/bin/sail artisan test --compact --filter=ScannerApp`
- `vendor/bin/sail artisan test --compact --filter=ScannerDataController`
- `vendor/bin/sail bin pint --dirty --format agent`
- `vendor/bin/sail npm run build`
- `vendor/bin/sail npm run test:e2e -- e2e/va-scanner-shift-list.spec.ts`