### PR TITLE
feat(scanner): add entry staff volunteer lookup

### DIFF
--- a/app/Http/Controllers/ScannerDataController.php
+++ b/app/Http/Controllers/ScannerDataController.php
@@ -134,6 +134,7 @@ class ScannerDataController extends Controller
                     'id' => $signup->id,
                     'shift' => [
                         'id' => $signup->shift->id,
+                        'event_id' => $signup->shift->volunteerJob->event_id,
                         'shift_date' => $signup->shift->shift_date->toDateString(),
                         'starts_at' => $signup->shift->starts_at,
                         'ends_at' => $signup->shift->ends_at,

--- a/e2e/entry-scanner-volunteer-lookup.spec.ts
+++ b/e2e/entry-scanner-volunteer-lookup.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from '@playwright/test';
+
+test.use({
+    viewport: { width: 430, height: 820 },
+});
+
+async function prepareScannerPage(page: Page) {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+}
+
+test('entry staff volunteer lookup supports past-event volunteer check-in and offline cached search', async ({ page, context }) => {
+    await prepareScannerPage(page);
+
+    await page.goto('/s/e2e-entry-volunteer-lookup-token');
+    await page.getByLabel('Enter 6-digit code').fill('333333');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-entry-volunteer-lookup-token\/scan$/);
+
+    await page.getByRole('tab', { name: 'Volunteers' }).click();
+
+    const searchInput = page.getByPlaceholder('Search volunteers...');
+    await searchInput.fill('Past');
+
+    const pastVolunteerRow = page.locator('#tabpanel-volunteers button').filter({ hasText: 'Past Volunteer' }).first();
+    await expect(pastVolunteerRow).toBeVisible();
+    await pastVolunteerRow.click();
+
+    const volunteerPanel = page.locator('#tabpanel-volunteers').locator('div.rounded-xl.border.border-zinc-700.bg-zinc-800.p-4').last();
+    await expect(volunteerPanel.getByText('Past Volunteer')).toBeVisible();
+    await expect(volunteerPanel.getByText('entry-past@example.com')).toBeVisible();
+    await expect(volunteerPanel.getByText('+491701010101')).toBeVisible();
+    await expect(volunteerPanel.getByText('E2E Entry Past Event')).toBeVisible();
+    await expect(volunteerPanel.getByText('Ready to check in.')).toHaveCount(0);
+
+    await context.setOffline(true);
+    await page.getByRole('button', { name: 'Confirm Arrival' }).click();
+
+    await expect(volunteerPanel.getByText('Past Volunteer checked in successfully.')).toBeVisible();
+
+    const manualArrivalEntries = await page.evaluate(async () => {
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('voluntify-scanner');
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+
+        const transaction = database.transaction('outbox', 'readonly');
+        const store = transaction.objectStore('outbox');
+        const rows = await new Promise<any[]>((resolve, reject) => {
+            const request = store.getAll();
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+
+        return rows.filter((row) => row.type === 'arrival' && row.method === 'manual_lookup');
+    });
+
+    expect(manualArrivalEntries).toHaveLength(1);
+    expect(manualArrivalEntries[0].event_id).toBeGreaterThan(0);
+
+    await page.getByRole('button', { name: 'Done' }).click();
+    await searchInput.fill('Past');
+    await expect(page.locator('#tabpanel-volunteers button').filter({ hasText: 'Past Volunteer' }).first()).toContainText('Bereits eingecheckt');
+
+    await searchInput.fill('NoShift');
+    await expect(page.locator('#tabpanel-volunteers button').filter({ hasText: 'NoShift Volunteer' }).first()).toBeVisible();
+});
+
+test('entry staff volunteer lookup requires event choice for ambiguous project-wide volunteers', async ({ page }) => {
+    await prepareScannerPage(page);
+
+    await page.goto('/s/e2e-entry-volunteer-lookup-token');
+    await page.getByLabel('Enter 6-digit code').fill('333333');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-entry-volunteer-lookup-token\/scan$/);
+
+    await page.getByRole('tab', { name: 'Volunteers' }).click();
+    await page.getByPlaceholder('Search volunteers...').fill('Ambiguous');
+
+    await page.locator('#tabpanel-volunteers button').filter({ hasText: 'Ambiguous Volunteer' }).first().click();
+
+    const confirmButton = page.getByRole('button', { name: 'Confirm Arrival' });
+    const eventSelect = page.locator('#tabpanel-volunteers select');
+
+    await expect(page.getByText('Choose event')).toBeVisible();
+    await expect(eventSelect).toContainText('E2E Entry Past Event');
+    await expect(eventSelect).toContainText('E2E Entry Current Event');
+    await expect(confirmButton).toBeDisabled();
+
+    await eventSelect.selectOption({ label: 'E2E Entry Current Event' });
+    await expect(confirmButton).toBeEnabled();
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -322,6 +322,147 @@ vendor/bin/sail artisan tinker --execute="
   echo 'Volunteer admin shift-list fixture created';
 "
 
+# 8. Create deterministic Entry Staff scanner fixture for volunteer lookup E2E
+echo "Creating entry-staff volunteer lookup E2E fixture..."
+vendor/bin/sail artisan tinker --execute="
+  use App\Enums\ScannerMode;
+  use App\Enums\ScannerType;
+  use App\Models\Event;
+  use App\Models\Organization;
+  use App\Models\Project;
+  use App\Models\ProjectScanner;
+  use App\Models\Shift;
+  use App\Models\ShiftSignup;
+  use App\Models\Ticket;
+  use App\Models\Volunteer;
+  use App\Models\VolunteerJob;
+
+  \Carbon\Carbon::setTestNow(now());
+
+  \DB::transaction(function () {
+    \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-volunteer-lookup-token')->delete();
+
+    \App\Models\Project::where('name', 'E2E Entry Volunteer Lookup Project')->delete();
+
+    \App\Models\Volunteer::whereIn('email', [
+      'entry-past@example.com',
+      'entry-ambiguous@example.com',
+      'entry-noshift@example.com',
+    ])->delete();
+
+    \$organization = Organization::firstOrFail();
+
+    \$project = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Entry Volunteer Lookup Project',
+    ]);
+
+    \$currentEvent = Event::factory()->for(\$organization)->for(\$project)->published()->create([
+      'name' => 'E2E Entry Current Event',
+      'slug' => 'e2e-entry-current-event',
+      'starts_at' => now()->addHours(2),
+      'ends_at' => now()->addHours(8),
+    ]);
+
+    \$pastEvent = Event::factory()->for(\$organization)->for(\$project)->published()->create([
+      'name' => 'E2E Entry Past Event',
+      'slug' => 'e2e-entry-past-event',
+      'starts_at' => now()->subDays(30),
+      'ends_at' => now()->subDays(30)->addHours(4),
+    ]);
+
+    \$currentJob = VolunteerJob::factory()->create([
+      'event_id' => \$currentEvent->id,
+      'name' => 'Current Event Desk',
+    ]);
+
+    \$pastJob = VolunteerJob::factory()->create([
+      'event_id' => \$pastEvent->id,
+      'name' => 'Past Event Gate',
+    ]);
+
+    \$currentShift = Shift::factory()->create([
+      'volunteer_job_id' => \$currentJob->id,
+      'shift_date' => now()->toDateString(),
+      'starts_at' => now()->addHours(2),
+      'ends_at' => now()->addHours(4),
+      'display_text' => now()->addHours(2)->format('M d, H:i').' - '.now()->addHours(4)->format('H:i'),
+    ]);
+
+    \$pastShift = Shift::factory()->create([
+      'volunteer_job_id' => \$pastJob->id,
+      'shift_date' => now()->subDays(30)->toDateString(),
+      'starts_at' => now()->subDays(30)->addHours(1),
+      'ends_at' => now()->subDays(30)->addHours(3),
+      'display_text' => now()->subDays(30)->addHours(1)->format('M d, H:i').' - '.now()->subDays(30)->addHours(3)->format('H:i'),
+    ]);
+
+    \$pastVolunteer = Volunteer::factory()->verified()->for(\$project)->create([
+      'first_name' => 'Past',
+      'last_name' => 'Volunteer',
+      'email' => 'entry-past@example.com',
+      'phone' => '+491701010101',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$project->id,
+      'volunteer_id' => \$pastVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$pastVolunteer->id,
+      'shift_id' => \$pastShift->id,
+    ]);
+
+    \$ambiguousVolunteer = Volunteer::factory()->verified()->for(\$project)->create([
+      'first_name' => 'Ambiguous',
+      'last_name' => 'Volunteer',
+      'email' => 'entry-ambiguous@example.com',
+      'phone' => '+491702020202',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$project->id,
+      'volunteer_id' => \$ambiguousVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$ambiguousVolunteer->id,
+      'shift_id' => \$pastShift->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$ambiguousVolunteer->id,
+      'shift_id' => \$currentShift->id,
+    ]);
+
+    \$noShiftVolunteer = Volunteer::factory()->verified()->for(\$project)->create([
+      'first_name' => 'NoShift',
+      'last_name' => 'Volunteer',
+      'email' => 'entry-noshift@example.com',
+      'phone' => '+491703030303',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$project->id,
+      'volunteer_id' => \$noShiftVolunteer->id,
+    ]);
+
+    ProjectScanner::factory()->active()->create([
+      'project_id' => \$project->id,
+      'event_id' => null,
+      'name' => 'E2E Entry Volunteer Lookup Scanner',
+      'type' => ScannerType::EntryStaff,
+      'modes' => [ScannerMode::Checkin->value],
+      'scanner_token' => 'e2e-entry-volunteer-lookup-token',
+      'auth_code' => '333333',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
+  });
+
+  echo 'Entry staff volunteer lookup fixture created';
+"
+
 echo ""
 echo "=== Setup complete ==="
 echo "Users available:"
@@ -330,3 +471,4 @@ echo "  EntranceStaff:  entrance@example.com / password"
 echo "  Dashboard user: dashboard@example.com / password"
 echo "  VA scanner:     /s/e2e-va-shift-list-token with code 222222"
 echo "  VA all past:    /s/e2e-va-all-past-token with code 444444"
+echo "  Entry scanner:  /s/e2e-entry-volunteer-lookup-token with code 333333"

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -34,12 +34,20 @@ import {
     type ShiftGroup,
     type ShiftGroupVolunteerRow,
 } from './shift-context';
+import {
+    filterVolunteers,
+    hasVolunteerArrivalForEvent,
+    hasVolunteerArrivalInScope,
+    resolveManualArrivalTarget,
+    type ManualArrivalTarget,
+} from './volunteer-lookup';
 import { syncOutbox } from './sync';
-import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear, VolunteerGearPickup, GuestEntry } from './types';
+import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear, GuestEntry, ScannerEvent } from './types';
 
 type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | 'invalid' | 'confirmed';
 type ScannerTab = 'scanner' | 'volunteers' | 'guests' | 'shifts';
 type ScannerDataSource = 'network' | 'cache' | 'unavailable';
+type VolunteerSelectionContext = 'scanner' | 'volunteers' | null;
 
 interface SelectedShiftContext {
     volunteerId: number;
@@ -78,14 +86,18 @@ export function scannerApp(config: ScannerAppConfig) {
         outboxCount: 0,
         selectedVolunteer: null as Volunteer | null,
         selectedShiftContext: null as SelectedShiftContext | null,
+        selectedVolunteerContext: null as VolunteerSelectionContext,
+        selectedVolunteerEventId: null as number | null,
         scannerType: config.scannerType,
         cameraPaused: false,
         scannerDataSource: 'unavailable' as ScannerDataSource,
         shiftListNotice: '' as string,
+        volunteerLookupNotice: '' as string,
 
         // Internal state
         _scannerId: config.scannerId,
         _scannerToken: config.scannerToken,
+        _events: [] as ScannerEvent[],
         _volunteers: [] as Volunteer[],
         _arrivals: [] as ArrivalRecord[],
         _attendanceRecords: [] as AttendanceRecord[],
@@ -101,12 +113,14 @@ export function scannerApp(config: ScannerAppConfig) {
         _guestSyncUrl: config.guestSyncUrl,
         _guestGearPickupUrl: config.guestGearPickupUrl,
         _gearCooldowns: {} as Record<number, boolean>,
+        _submittingArrival: false,
         _inactivityTimer: null as ReturnType<typeof setTimeout> | null,
         _inactivityTimeout: 120000, // 2 minutes
         _video: null as HTMLVideoElement | null,
         _canvas: null as HTMLCanvasElement | null,
         activeTab: 'scanner' as ScannerTab,
         guestSearchQuery: '' as string,
+        volunteerSearchQuery: '' as string,
         shiftSearchQuery: '' as string,
         guestResult: null as GuestEntry | null,
 
@@ -143,6 +157,16 @@ export function scannerApp(config: ScannerAppConfig) {
             return this.scannerType === 'entry_staff';
         },
 
+        get filteredVolunteers(): Volunteer[] {
+            return filterVolunteers(this._volunteers, this.volunteerSearchQuery);
+        },
+
+        get shouldShowVolunteerSearchHint(): boolean {
+            const trimmedQuery = this.volunteerSearchQuery.trim();
+
+            return trimmedQuery.length > 0 && trimmedQuery.length < 2;
+        },
+
         get visibleShiftGroups(): ShiftGroup[] {
             if (!this.hasShiftListTab) {
                 return [];
@@ -176,6 +200,66 @@ export function scannerApp(config: ScannerAppConfig) {
                     || new Date(left.shift.starts_at).getTime() - new Date(right.shift.starts_at).getTime()
                     || left.id - right.id;
             });
+        },
+
+        get selectedVolunteerManualArrivalTarget(): ManualArrivalTarget | null {
+            if (!this.selectedVolunteer || this.selectedVolunteerContext !== 'volunteers') {
+                return null;
+            }
+
+            return resolveManualArrivalTarget(this.selectedVolunteer, this._events);
+        },
+
+        get selectedVolunteerEventOptions(): ScannerEvent[] {
+            const target = this.selectedVolunteerManualArrivalTarget;
+            if (!target || target.kind === 'unavailable') {
+                return [];
+            }
+
+            return target.eventIds
+                .map((eventId) => this._events.find((event) => event.id === eventId))
+                .filter((event): event is ScannerEvent => event !== undefined);
+        },
+
+        get resolvedSelectedVolunteerEventId(): number | null {
+            const target = this.selectedVolunteerManualArrivalTarget;
+            if (!target) {
+                return null;
+            }
+
+            if (target.kind === 'resolved') {
+                return target.eventId;
+            }
+
+            if (target.kind === 'choice_required' && this.selectedVolunteerEventId !== null && target.eventIds.includes(this.selectedVolunteerEventId)) {
+                return this.selectedVolunteerEventId;
+            }
+
+            return null;
+        },
+
+        get resolvedSelectedVolunteerEvent(): ScannerEvent | null {
+            const eventId = this.resolvedSelectedVolunteerEventId;
+            if (eventId === null) {
+                return null;
+            }
+
+            return this._events.find((event) => event.id === eventId) ?? null;
+        },
+
+        get isSelectedVolunteerCheckedInForResolvedEvent(): boolean {
+            if (!this.selectedVolunteer) {
+                return false;
+            }
+
+            return hasVolunteerArrivalForEvent(this._arrivals, this.selectedVolunteer.id, this.resolvedSelectedVolunteerEventId);
+        },
+
+        get canConfirmSelectedVolunteerArrival(): boolean {
+            return this.selectedVolunteerContext === 'volunteers'
+                && this.resolvedSelectedVolunteerEventId !== null
+                && !this.isSelectedVolunteerCheckedInForResolvedEvent
+                && !this._submittingArrival;
         },
 
         get canConfirmArrival(): boolean {
@@ -249,11 +333,14 @@ export function scannerApp(config: ScannerAppConfig) {
             };
         },
 
-        selectVolunteer(volunteer: Volunteer, options: { fromQr?: boolean; shiftContext?: SelectedShiftContext | null } = {}) {
+        selectVolunteer(volunteer: Volunteer, options: { fromQr?: boolean; shiftContext?: SelectedShiftContext | null; volunteerContext?: VolunteerSelectionContext } = {}) {
             this.selectedVolunteer = volunteer;
             this.selectedShiftContext = options.shiftContext ?? null;
+            this.selectedVolunteerContext = options.volunteerContext ?? 'scanner';
+            this.selectedVolunteerEventId = null;
             this.result = this.buildVolunteerResult(volunteer);
             this.guestResult = null;
+            this.volunteerLookupNotice = '';
 
             if (options.fromQr) {
                 const alreadyArrived = this._arrivals.some((arrival) => arrival.volunteer_id === volunteer.id);
@@ -283,6 +370,56 @@ export function scannerApp(config: ScannerAppConfig) {
             this.errorMessage = '';
         },
 
+        applySelectedVolunteerArrivalTarget() {
+            const target = this.selectedVolunteerManualArrivalTarget;
+
+            if (!target) {
+                this.selectedVolunteerEventId = null;
+                this.volunteerLookupNotice = '';
+                return;
+            }
+
+            if (target.kind === 'resolved') {
+                this.selectedVolunteerEventId = target.eventId;
+                this.volunteerLookupNotice = '';
+
+                return;
+            }
+
+            if (target.kind === 'choice_required') {
+                const missingEventOptions = target.eventIds.some((eventId) => !this._events.some((event) => event.id === eventId));
+                if (missingEventOptions) {
+                    this.selectedVolunteerEventId = null;
+                    this.volunteerLookupNotice = 'Event choices are unavailable in cached scanner data. Go online to refresh before confirming arrival.';
+
+                    return;
+                }
+
+                this.selectedVolunteerEventId = target.eventIds.length === 1 ? target.eventIds[0] : this.selectedVolunteerEventId;
+                this.volunteerLookupNotice = '';
+
+                return;
+            }
+
+            this.selectedVolunteerEventId = null;
+            this.volunteerLookupNotice = target.reason === 'missing_event_metadata'
+                ? 'Event context is missing in cached scanner data. Go online to refresh before confirming arrival.'
+                : 'No event is available for this volunteer.';
+        },
+
+        selectVolunteerFromLookup(volunteerId: number) {
+            const volunteer = this._volunteers.find((entry) => entry.id === volunteerId);
+            if (!volunteer) {
+                this.volunteerLookupNotice = 'Volunteer not found in scanner data.';
+                return;
+            }
+
+            this.selectVolunteer(volunteer, {
+                volunteerContext: 'volunteers',
+            });
+            this.applySelectedVolunteerArrivalTarget();
+        },
+
         selectVolunteerFromShift(row: ShiftGroupVolunteerRow) {
             const volunteer = this._volunteers.find((entry) => entry.id === row.volunteerId);
             if (!volunteer) {
@@ -297,6 +434,7 @@ export function scannerApp(config: ScannerAppConfig) {
                     signupId: row.signupId,
                     shiftId: row.shiftId,
                 },
+                volunteerContext: 'scanner',
             });
             this.activeTab = 'scanner';
         },
@@ -319,7 +457,10 @@ export function scannerApp(config: ScannerAppConfig) {
             const preservedState = options.preserveUiState ? {
                 activeTab: this.activeTab,
                 shiftSearchQuery: this.shiftSearchQuery,
+                volunteerSearchQuery: this.volunteerSearchQuery,
                 selectedVolunteerId: this.selectedVolunteer?.id ?? null,
+                selectedVolunteerContext: this.selectedVolunteerContext,
+                selectedVolunteerEventId: this.selectedVolunteerEventId,
                 selectedShiftContext: this.selectedShiftContext,
             } : null;
 
@@ -333,6 +474,7 @@ export function scannerApp(config: ScannerAppConfig) {
                 ? 'scanner'
                 : preservedState.activeTab;
             this.shiftSearchQuery = preservedState.shiftSearchQuery;
+            this.volunteerSearchQuery = preservedState.volunteerSearchQuery;
 
             if (!preservedState.selectedVolunteerId) {
                 return;
@@ -362,7 +504,13 @@ export function scannerApp(config: ScannerAppConfig) {
 
             this.selectVolunteer(volunteer, {
                 shiftContext: shiftContext ?? null,
+                volunteerContext: preservedState.selectedVolunteerContext,
             });
+
+            if (preservedState.selectedVolunteerContext === 'volunteers') {
+                this.selectedVolunteerEventId = preservedState.selectedVolunteerEventId;
+                this.applySelectedVolunteerArrivalTarget();
+            }
         },
 
         async _loadScannerData() {
@@ -379,12 +527,13 @@ export function scannerApp(config: ScannerAppConfig) {
                     if (response.ok) {
                         const data = await response.json();
                         loadedFromNetwork = true;
+                        this._events = data.events ?? [];
                         this._volunteers = data.volunteers;
                         this._arrivals = data.arrivals;
                         this._attendanceRecords = data.attendance_records ?? [];
                         this._gearItems = data.gear_items ?? [];
                         this._volunteerGear = data.volunteer_gear ?? {};
-                        this._eventIds = (data.events ?? []).map((e: { id: number }) => e.id);
+                        this._eventIds = this._events.map((event: ScannerEvent) => event.id);
                         this._graceMinutes = data.events?.[0]?.attendance_grace_minutes ?? null;
 
                         // Persist to IndexedDB for offline use
@@ -466,46 +615,80 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         async confirmArrival() {
+            await this._confirmArrival('qr_scan');
+        },
+
+        async confirmSelectedVolunteerArrival() {
+            await this._confirmArrival('manual_lookup', this.resolvedSelectedVolunteerEventId);
+        },
+
+        async _confirmArrival(method: 'qr_scan' | 'manual_lookup', eventIdOverride: number | null = null) {
             if (!this.result) {
                 return;
             }
 
-            const eventId = this._eventIds[0] ?? 0;
+            const eventId = eventIdOverride ?? this._eventIds[0] ?? 0;
+            if (!eventId) {
+                if (method === 'manual_lookup') {
+                    this.volunteerLookupNotice = 'Choose an event before confirming arrival.';
+                    return;
+                }
 
-            const entry = {
-                type: 'arrival' as const,
-                ticket_id: this.result.ticketId,
-                volunteer_id: this.result.volunteerId,
-                event_id: eventId,
-                method: 'qr_scan' as const,
-                scanned_at: new Date().toISOString().replace('T', ' ').substring(0, 19),
-            };
-
-            // Add to local arrivals tracking
-            this._arrivals.push({
-                id: 0,
-                ticket_id: entry.ticket_id,
-                volunteer_id: entry.volunteer_id,
-                event_id: eventId,
-                scanned_by: null,
-                scanned_at: entry.scanned_at,
-                method: entry.method,
-                flagged: false,
-                flag_reason: null,
-            });
-
-            // Save to outbox
-            await addOutboxEntry(this._scannerId, entry);
-            this.outboxCount = await getOutboxCount(this._scannerId);
-
-            this.state = 'confirmed';
-            this.resultMessage = `${this.result.name} checked in successfully.`;
-
-            // Try to sync immediately if online
-            if (this.isOnline) {
-                await this._sync();
+                this.state = 'invalid';
+                this.errorMessage = 'No event available for arrival.';
+                return;
             }
 
+            if (method === 'manual_lookup' && this.selectedVolunteer && hasVolunteerArrivalForEvent(this._arrivals, this.selectedVolunteer.id, eventId)) {
+                this.volunteerLookupNotice = 'Volunteer is already checked in for the selected event.';
+                return;
+            }
+
+            this._submittingArrival = true;
+
+            try {
+                const entry = {
+                    type: 'arrival' as const,
+                    ticket_id: this.result.ticketId,
+                    volunteer_id: this.result.volunteerId,
+                    event_id: eventId,
+                    method,
+                    scanned_at: new Date().toISOString().replace('T', ' ').substring(0, 19),
+                };
+
+                await addOutboxEntry(this._scannerId, entry);
+                this.outboxCount = await getOutboxCount(this._scannerId);
+
+                this._arrivals.push({
+                    id: 0,
+                    ticket_id: entry.ticket_id,
+                    volunteer_id: entry.volunteer_id,
+                    event_id: eventId,
+                    scanned_by: null,
+                    scanned_at: entry.scanned_at,
+                    method: entry.method,
+                    flagged: false,
+                    flag_reason: null,
+                });
+
+                this.state = 'confirmed';
+                this.resultMessage = `${this.result.name} checked in successfully.`;
+                this.volunteerLookupNotice = '';
+
+                if (this.isOnline) {
+                    await this._sync();
+                }
+            } catch (error) {
+                if (method === 'manual_lookup') {
+                    this.volunteerLookupNotice = 'Arrival could not be saved locally. Please try again.';
+                } else {
+                    this.state = 'invalid';
+                    this.errorMessage = 'Arrival could not be saved locally. Please try again.';
+                }
+                console.error('Arrival confirmation failed:', error);
+            } finally {
+                this._submittingArrival = false;
+            }
         },
 
         async confirmAttendance(shiftSignupId: number) {
@@ -657,6 +840,10 @@ export function scannerApp(config: ScannerAppConfig) {
             return this.selectedShiftContext?.signupId === shiftSignupId;
         },
 
+        isVolunteerCheckedInInScope(volunteerId: number): boolean {
+            return hasVolunteerArrivalInScope(this._arrivals, volunteerId, this._eventIds);
+        },
+
         shiftGroupBadgeLabel(group: ShiftGroup): string {
             if (group.groupStatus === 'active') {
                 return 'Laeuft jetzt';
@@ -707,7 +894,10 @@ export function scannerApp(config: ScannerAppConfig) {
             this.result = null;
             this.guestResult = null;
             this.selectedVolunteer = null;
+            this.selectedVolunteerContext = null;
+            this.selectedVolunteerEventId = null;
             this.selectedShiftContext = null;
+            this.volunteerLookupNotice = '';
             this.resultMessage = '';
             this.errorMessage = '';
             this._resetInactivityTimer();
@@ -716,7 +906,10 @@ export function scannerApp(config: ScannerAppConfig) {
         _handleGuestQr(entry: GuestEntry) {
             const alreadyCheckedIn = entry.checked_in_at !== null;
             this.selectedVolunteer = null;
+            this.selectedVolunteerContext = null;
+            this.selectedVolunteerEventId = null;
             this.selectedShiftContext = null;
+            this.volunteerLookupNotice = '';
             this.result = null;
             this.guestResult = entry;
 

--- a/resources/js/scanner/idb-store.ts
+++ b/resources/js/scanner/idb-store.ts
@@ -97,7 +97,12 @@ export async function getVolunteers(scannerId: number): Promise<Volunteer[]> {
 export async function searchVolunteers(scannerId: number, query: string): Promise<Volunteer[]> {
     const volunteers = await getVolunteers(scannerId);
     const lowerQuery = query.toLowerCase();
-    return volunteers.filter((v) => v.name.toLowerCase().includes(lowerQuery));
+
+    return volunteers.filter((volunteer) => {
+        return volunteer.first_name.toLowerCase().includes(lowerQuery)
+            || volunteer.last_name.toLowerCase().includes(lowerQuery)
+            || volunteer.email.toLowerCase().includes(lowerQuery);
+    });
 }
 
 export async function storeKeys(scannerId: number, keys: ScannerKeys): Promise<void> {

--- a/resources/js/scanner/types.ts
+++ b/resources/js/scanner/types.ts
@@ -3,8 +3,15 @@ export interface VolunteerJob {
     name: string;
 }
 
+export interface ScannerEvent {
+    id: number;
+    name: string;
+    attendance_grace_minutes: number | null;
+}
+
 export interface Shift {
     id: number;
+    event_id?: number | null;
     shift_date: string;
     starts_at: string;
     ends_at: string;

--- a/resources/js/scanner/volunteer-lookup.ts
+++ b/resources/js/scanner/volunteer-lookup.ts
@@ -1,0 +1,73 @@
+import type { ArrivalRecord, ScannerEvent, Volunteer } from './types';
+
+export type ManualArrivalTarget =
+    | { kind: 'resolved'; eventId: number; eventIds: number[] }
+    | { kind: 'choice_required'; eventIds: number[] }
+    | { kind: 'unavailable'; reason: 'missing_event_metadata' | 'no_events' };
+
+function uniqueSorted(values: number[]): number[] {
+    return [...new Set(values)].sort((left, right) => left - right);
+}
+
+export function filterVolunteers(volunteers: Volunteer[], query: string): Volunteer[] {
+    const trimmedQuery = query.trim().toLowerCase();
+
+    if (trimmedQuery.length < 2) {
+        return [];
+    }
+
+    return volunteers
+        .filter((volunteer) => {
+            return volunteer.first_name.toLowerCase().includes(trimmedQuery)
+                || volunteer.last_name.toLowerCase().includes(trimmedQuery)
+                || volunteer.email.toLowerCase().includes(trimmedQuery);
+        })
+        .sort((left, right) => {
+            return left.name.localeCompare(right.name)
+                || left.email.localeCompare(right.email)
+                || left.id - right.id;
+        });
+}
+
+export function resolveManualArrivalTarget(volunteer: Volunteer, scannerEvents: ScannerEvent[]): ManualArrivalTarget {
+    const scannerEventIds = uniqueSorted(scannerEvents.map((event) => event.id));
+    const signupEventIds = uniqueSorted(
+        volunteer.shift_signups
+            .map((signup) => signup.shift.event_id)
+            .filter((eventId): eventId is number => typeof eventId === 'number')
+    );
+
+    if (volunteer.shift_signups.length > 0 && signupEventIds.length === 0) {
+        return { kind: 'unavailable', reason: 'missing_event_metadata' };
+    }
+
+    if (signupEventIds.length === 1) {
+        return { kind: 'resolved', eventId: signupEventIds[0], eventIds: signupEventIds };
+    }
+
+    if (signupEventIds.length > 1) {
+        return { kind: 'choice_required', eventIds: signupEventIds };
+    }
+
+    if (scannerEventIds.length === 0) {
+        return { kind: 'unavailable', reason: 'no_events' };
+    }
+
+    if (scannerEventIds.length === 1) {
+        return { kind: 'resolved', eventId: scannerEventIds[0], eventIds: scannerEventIds };
+    }
+
+    return { kind: 'choice_required', eventIds: scannerEventIds };
+}
+
+export function hasVolunteerArrivalInScope(arrivals: ArrivalRecord[], volunteerId: number, eventIds: number[]): boolean {
+    return arrivals.some((arrival) => arrival.volunteer_id === volunteerId && eventIds.includes(arrival.event_id));
+}
+
+export function hasVolunteerArrivalForEvent(arrivals: ArrivalRecord[], volunteerId: number, eventId: number | null): boolean {
+    if (eventId === null) {
+        return false;
+    }
+
+    return arrivals.some((arrival) => arrival.volunteer_id === volunteerId && arrival.event_id === eventId);
+}

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -95,7 +95,7 @@
 
                 {{-- Result panel (volunteer) --}}
                 <div
-                    x-show="['result', 'duplicate', 'invalid', 'confirmed', 'loading'].includes(state) && !guestResult"
+                    x-show="selectedVolunteerContext === 'scanner' && ['result', 'duplicate', 'invalid', 'confirmed', 'loading'].includes(state) && !guestResult"
                     x-transition
                     role="alert"
                     aria-live="assertive"
@@ -181,9 +181,111 @@
                 </div>
             </div>
 
-            {{-- Volunteers tab (placeholder) --}}
-            <div id="tabpanel-volunteers" role="tabpanel" aria-labelledby="tab-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col items-center justify-center">
-                <p class="text-sm text-zinc-400">{{ __('Use QR scanner or manual lookup for volunteer check-in.') }}</p>
+            {{-- Volunteers tab --}}
+            <div id="tabpanel-volunteers" role="tabpanel" aria-labelledby="tab-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col space-y-4">
+                <div class="px-1">
+                    <input
+                        type="text"
+                        x-model.debounce.300ms="volunteerSearchQuery"
+                        placeholder="Search volunteers..."
+                        aria-label="{{ __('Search volunteers') }}"
+                        class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-base text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+                </div>
+
+                <div class="space-y-3 overflow-y-auto px-1">
+                    <template x-if="shouldShowVolunteerSearchHint">
+                        <p class="py-8 text-center text-sm text-zinc-500">Mindestens 2 Zeichen eingeben.</p>
+                    </template>
+
+                    <template x-if="!shouldShowVolunteerSearchHint && volunteerSearchQuery.trim().length >= 2 && filteredVolunteers.length === 0">
+                        <p class="py-8 text-center text-sm text-zinc-500">No volunteers found.</p>
+                    </template>
+
+                    <template x-for="volunteer in filteredVolunteers" :key="volunteer.id">
+                        <button
+                            type="button"
+                            class="flex min-h-12 w-full items-center justify-between rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-3 text-left transition hover:bg-zinc-700"
+                            @click="selectVolunteerFromLookup(volunteer.id)"
+                        >
+                            <div class="min-w-0 flex-1">
+                                <p class="text-sm font-semibold text-white" x-text="volunteer.name"></p>
+                                <p class="text-xs text-zinc-400" x-text="volunteer.email"></p>
+                                <p class="text-xs text-zinc-500" x-show="volunteer.phone" x-text="volunteer.phone"></p>
+                            </div>
+
+                            <template x-if="isVolunteerCheckedInInScope(volunteer.id)">
+                                <span class="ml-3 shrink-0 rounded-full bg-amber-500/20 px-3 py-1 text-xs font-medium text-amber-300">Bereits eingecheckt</span>
+                            </template>
+                        </button>
+                    </template>
+                </div>
+
+                <template x-if="selectedVolunteer && selectedVolunteerContext === 'volunteers'">
+                    <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                        <p class="text-center text-lg font-semibold text-white" x-text="selectedVolunteer.name"></p>
+                        <p class="mt-1 text-center text-sm text-zinc-300" x-text="selectedVolunteer.email"></p>
+                        <p class="mt-1 text-center text-xs text-zinc-400" x-show="selectedVolunteer.phone" x-text="selectedVolunteer.phone"></p>
+                        <p class="mt-1 text-center text-xs text-zinc-400" x-show="!selectedVolunteer.phone">{{ __('No phone number') }}</p>
+
+                        <div class="mt-4 space-y-3">
+                            <template x-if="selectedVolunteerEventOptions.length === 1 && resolvedSelectedVolunteerEvent">
+                                <div class="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+                                    <p class="text-xs uppercase tracking-wide text-zinc-500">Target event</p>
+                                    <p class="mt-1 text-sm font-medium text-white" x-text="resolvedSelectedVolunteerEvent.name"></p>
+                                </div>
+                            </template>
+
+                            <template x-if="selectedVolunteerEventOptions.length > 1">
+                                <label class="block text-sm text-zinc-300">
+                                    <span class="mb-2 block">Choose event</span>
+                                    <select
+                                        x-model.number="selectedVolunteerEventId"
+                                        class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-base text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                                    >
+                                        <option value="">Select event...</option>
+                                        <template x-for="event in selectedVolunteerEventOptions" :key="event.id">
+                                            <option :value="event.id" x-text="event.name"></option>
+                                        </template>
+                                    </select>
+                                </label>
+                            </template>
+
+                            <template x-if="volunteerLookupNotice">
+                                <div class="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm text-zinc-300" x-text="volunteerLookupNotice"></div>
+                            </template>
+
+                            <template x-if="isSelectedVolunteerCheckedInForResolvedEvent">
+                                <div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                                    Volunteer is already checked in for the selected event.
+                                </div>
+                            </template>
+
+                            <template x-if="state === 'confirmed' && resultMessage">
+                                <div class="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200" x-text="resultMessage"></div>
+                            </template>
+                        </div>
+
+                        <div class="mt-4 flex flex-col gap-3">
+                            <button
+                                type="button"
+                                class="min-h-12 w-full rounded-lg bg-emerald-600 px-4 py-3 text-base font-medium text-white hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                @click="confirmSelectedVolunteerArrival()"
+                                :disabled="!canConfirmSelectedVolunteerArrival"
+                            >
+                                {{ __('Confirm Arrival') }}
+                            </button>
+
+                            <button
+                                type="button"
+                                class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                                @click="dismiss()"
+                            >
+                                {{ __('Done') }}
+                            </button>
+                        </div>
+                    </div>
+                </template>
             </div>
 
             {{-- Gastliste tab --}}

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -167,11 +167,90 @@ it('returns volunteer shift payload fields required for volunteer admin shift li
         ->assertJsonPath('volunteers.0.phone', '+4911111111')
         ->assertJsonPath('volunteers.0.shift_signups.0.id', $signup->id)
         ->assertJsonPath('volunteers.0.shift_signups.0.shift.id', $shift->id)
+        ->assertJsonPath('volunteers.0.shift_signups.0.shift.event_id', $this->event->id)
         ->assertJsonPath('volunteers.0.shift_signups.0.shift.starts_at', Carbon::parse('2026-07-01 13:00:00')->toJSON())
         ->assertJsonPath('volunteers.0.shift_signups.0.shift.ends_at', Carbon::parse('2026-07-01 17:00:00')->toJSON())
         ->assertJsonPath('volunteers.0.shift_signups.0.shift.display_text', 'Jul 01, 13:00 - 17:00')
         ->assertJsonPath('volunteers.0.shift_signups.0.shift.volunteer_job.name', 'Stage Setup')
         ->assertJsonPath('volunteers.0.shift_signups.0.attendance_record.status', 'on_time');
+});
+
+it('includes project-wide volunteers from past events and volunteers without shifts', function () {
+    $pastEvent = Event::factory()->for($this->project)->create([
+        'name' => 'Past Event',
+        'starts_at' => Carbon::parse('2025-07-01 12:00:00'),
+        'ends_at' => Carbon::parse('2025-07-01 18:00:00'),
+    ]);
+
+    $scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'event_id' => null,
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $pastVolunteer = Volunteer::factory()->create([
+        'project_id' => $this->project->id,
+        'first_name' => 'Past',
+        'last_name' => 'Volunteer',
+        'email' => 'past-volunteer@example.com',
+    ]);
+    Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $pastVolunteer->id,
+    ]);
+
+    $pastJob = VolunteerJob::factory()->create([
+        'event_id' => $pastEvent->id,
+        'name' => 'Legacy Shift',
+    ]);
+
+    $pastShift = Shift::factory()->create([
+        'volunteer_job_id' => $pastJob->id,
+        'shift_date' => '2025-07-01',
+        'starts_at' => Carbon::parse('2025-07-01 13:00:00'),
+        'ends_at' => Carbon::parse('2025-07-01 15:00:00'),
+        'display_text' => 'Jul 01, 13:00 - 15:00',
+    ]);
+
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $pastVolunteer->id,
+        'shift_id' => $pastShift->id,
+    ]);
+
+    $noShiftVolunteer = Volunteer::factory()->create([
+        'project_id' => $this->project->id,
+        'first_name' => 'NoShift',
+        'last_name' => 'Volunteer',
+        'email' => 'noshift@example.com',
+    ]);
+    Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $noShiftVolunteer->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $pastVolunteerPayload = collect($response->json('volunteers'))
+        ->firstWhere('id', $pastVolunteer->id);
+
+    $response->assertOk()
+        ->assertJsonFragment([
+            'id' => $pastVolunteer->id,
+            'first_name' => 'Past',
+            'last_name' => 'Volunteer',
+            'email' => 'past-volunteer@example.com',
+        ])
+        ->assertJsonFragment([
+            'id' => $noShiftVolunteer->id,
+            'first_name' => 'NoShift',
+            'last_name' => 'Volunteer',
+            'email' => 'noshift@example.com',
+        ]);
+
+    expect($pastVolunteerPayload)->not->toBeNull();
+    expect($pastVolunteerPayload['shift_signups'][0]['shift']['event_id'])->toBe($pastEvent->id);
 });
 
 it('returns default states for projects with null attendance_states', function () {

--- a/tests/Feature/Livewire/ScannerAppTest.php
+++ b/tests/Feature/Livewire/ScannerAppTest.php
@@ -196,6 +196,20 @@ it('renders phone display in entry staff template', function () {
         ->assertSee(__('No phone number'));
 });
 
+it('renders volunteer lookup UI for entry staff scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->create([
+        'type' => ScannerType::EntryStaff,
+        'modes' => [ScannerMode::Checkin->value],
+    ]);
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSee('Search volunteers...')
+        ->assertSee('Mindestens 2 Zeichen eingeben.')
+        ->assertSeeHtml('selectVolunteerFromLookup(volunteer.id)')
+        ->assertDontSee('Use QR scanner or manual lookup for volunteer check-in.');
+});
+
 it('renders phone display in volunteer admin template', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
     session(['scanner_id' => $scanner->id]);

--- a/tests/js/scanner/idb-store.test.ts
+++ b/tests/js/scanner/idb-store.test.ts
@@ -74,6 +74,17 @@ describe('idb-store (DB_VERSION 3 — scannerId keys)', () => {
         expect(result[0].name).toBe('Alice Johnson');
     });
 
+    it('searches volunteers by first name, last name, and email substring', async () => {
+        await storeVolunteers(1, [
+            makeVolunteer(),
+            makeVolunteer({ id: 2, first_name: 'Bob', last_name: 'Smith', name: 'Bob Smith', email: 'bob@example.com' }),
+        ]);
+
+        await expect(searchVolunteers(1, 'ali')).resolves.toHaveLength(1);
+        await expect(searchVolunteers(1, 'smi')).resolves.toHaveLength(1);
+        await expect(searchVolunteers(1, 'bob@example')).resolves.toHaveLength(1);
+    });
+
     it('adds and retrieves outbox entries by scannerId', async () => {
         const entry: OutboxEntry = {
             type: 'arrival',

--- a/tests/js/scanner/volunteer-lookup.test.ts
+++ b/tests/js/scanner/volunteer-lookup.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterVolunteers,
+    hasVolunteerArrivalForEvent,
+    hasVolunteerArrivalInScope,
+    resolveManualArrivalTarget,
+} from '../../../resources/js/scanner/volunteer-lookup';
+import type { ArrivalRecord, ScannerEvent, Volunteer, ShiftSignup } from '../../../resources/js/scanner/types';
+
+function makeSignup(overrides: Partial<ShiftSignup> & { eventId?: number | null } = {}): ShiftSignup {
+    const eventId = Object.prototype.hasOwnProperty.call(overrides, 'eventId')
+        ? overrides.eventId ?? null
+        : 101;
+
+    return {
+        id: overrides.id ?? 1,
+        shift: {
+            id: overrides.shift?.id ?? 11,
+            event_id: eventId,
+            shift_date: overrides.shift?.shift_date ?? '2026-07-01',
+            starts_at: overrides.shift?.starts_at ?? '2026-07-01T10:00:00Z',
+            ends_at: overrides.shift?.ends_at ?? '2026-07-01T12:00:00Z',
+            display_text: overrides.shift?.display_text ?? 'Jul 01, 10:00 - 12:00',
+            volunteer_job: overrides.shift?.volunteer_job ?? { id: 1, name: 'Entry' },
+        },
+        attendance_record: overrides.attendance_record ?? null,
+    };
+}
+
+function makeVolunteer(overrides: Partial<Volunteer> = {}): Volunteer {
+    return {
+        id: overrides.id ?? 1,
+        first_name: overrides.first_name ?? 'Lisa',
+        last_name: overrides.last_name ?? 'Mueller',
+        name: overrides.name ?? 'Lisa Mueller',
+        email: overrides.email ?? 'lisa@example.com',
+        phone: overrides.phone ?? '+491701234567',
+        ticket: overrides.ticket ?? {
+            id: 10,
+            jwt_token: 'jwt-token',
+            volunteer_id: overrides.id ?? 1,
+            project_id: 1,
+        },
+        shift_signups: overrides.shift_signups ?? [],
+    };
+}
+
+function makeEvent(overrides: Partial<ScannerEvent> = {}): ScannerEvent {
+    return {
+        id: overrides.id ?? 101,
+        name: overrides.name ?? 'Sommerfest 2026',
+        attendance_grace_minutes: overrides.attendance_grace_minutes ?? 15,
+    };
+}
+
+describe('filterVolunteers', () => {
+    const volunteers = [
+        makeVolunteer(),
+        makeVolunteer({
+            id: 2,
+            first_name: 'Tom',
+            last_name: 'Schneider',
+            name: 'Tom Schneider',
+            email: 'tom@example.com',
+        }),
+    ];
+
+    it('returns no volunteers for queries shorter than two characters', () => {
+        expect(filterVolunteers(volunteers, 'L')).toEqual([]);
+    });
+
+    it('filters by first name, last name, and email case-insensitively', () => {
+        expect(filterVolunteers(volunteers, 'lisa').map((volunteer) => volunteer.id)).toEqual([1]);
+        expect(filterVolunteers(volunteers, 'SCHNEI').map((volunteer) => volunteer.id)).toEqual([2]);
+        expect(filterVolunteers(volunteers, 'tom@example').map((volunteer) => volunteer.id)).toEqual([2]);
+    });
+
+    it('keeps volunteers without shift signups searchable', () => {
+        const volunteer = makeVolunteer({ id: 3, first_name: 'NoShift', last_name: 'Volunteer', shift_signups: [] });
+
+        expect(filterVolunteers([...volunteers, volunteer], 'NoShift').map((entry) => entry.id)).toContain(3);
+    });
+});
+
+describe('resolveManualArrivalTarget', () => {
+    it('resolves directly when the volunteer has exactly one signup event', () => {
+        const volunteer = makeVolunteer({ shift_signups: [makeSignup({ eventId: 101 })] });
+
+        expect(resolveManualArrivalTarget(volunteer, [makeEvent({ id: 101 })])).toEqual({
+            kind: 'resolved',
+            eventId: 101,
+            eventIds: [101],
+        });
+    });
+
+    it('requires operator choice when the volunteer has signups across multiple events', () => {
+        const volunteer = makeVolunteer({
+            shift_signups: [
+                makeSignup({ id: 1, eventId: 101 }),
+                makeSignup({ id: 2, eventId: 202 }),
+            ],
+        });
+
+        expect(resolveManualArrivalTarget(volunteer, [makeEvent({ id: 101 }), makeEvent({ id: 202 })])).toEqual({
+            kind: 'choice_required',
+            eventIds: [101, 202],
+        });
+    });
+
+    it('falls back to the only scanner event when a volunteer has no shifts and only one event is loaded', () => {
+        const volunteer = makeVolunteer({ shift_signups: [] });
+
+        expect(resolveManualArrivalTarget(volunteer, [makeEvent({ id: 101 })])).toEqual({
+            kind: 'resolved',
+            eventId: 101,
+            eventIds: [101],
+        });
+    });
+
+    it('requires operator choice when a volunteer has no shifts and multiple project events exist', () => {
+        const volunteer = makeVolunteer({ shift_signups: [] });
+
+        expect(resolveManualArrivalTarget(volunteer, [makeEvent({ id: 101 }), makeEvent({ id: 202 })])).toEqual({
+            kind: 'choice_required',
+            eventIds: [101, 202],
+        });
+    });
+
+    it('blocks confirmation when stale shift data is missing event ids', () => {
+        const volunteer = makeVolunteer({
+            shift_signups: [makeSignup({ eventId: null })],
+        });
+
+        expect(resolveManualArrivalTarget(volunteer, [makeEvent({ id: 101 })])).toEqual({
+            kind: 'unavailable',
+            reason: 'missing_event_metadata',
+        });
+    });
+});
+
+describe('arrival helpers', () => {
+    const arrivals: ArrivalRecord[] = [
+        {
+            id: 1,
+            ticket_id: 10,
+            volunteer_id: 1,
+            event_id: 101,
+            scanned_by: null,
+            scanned_at: '2026-07-01 10:00:00',
+            method: 'manual_lookup',
+            flagged: false,
+            flag_reason: null,
+        },
+    ];
+
+    it('detects arrivals within scanner scope', () => {
+        expect(hasVolunteerArrivalInScope(arrivals, 1, [101, 202])).toBe(true);
+        expect(hasVolunteerArrivalInScope(arrivals, 1, [202])).toBe(false);
+    });
+
+    it('detects arrivals for a single resolved event', () => {
+        expect(hasVolunteerArrivalForEvent(arrivals, 1, 101)).toBe(true);
+        expect(hasVolunteerArrivalForEvent(arrivals, 1, 202)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- replace the Entry Staff volunteers tab placeholder with real manual volunteer lookup that searches cached scanner data and reuses the existing arrival flow
- add safe project-wide arrival routing by exposing `shift.event_id` and requiring explicit event choice only when a volunteer maps to multiple possible events
- add Pest, Vitest, and Playwright coverage for past-event volunteers, volunteers without shifts, manual outbox writes, and the ambiguous multi-event browser flow

Closes #195.

## Testing
- `vendor/bin/sail artisan test --compact --filter=ScannerApp`
- `vendor/bin/sail artisan test --compact tests/Feature/Http/ScannerDataControllerTest.php`
- `vendor/bin/sail npm run test -- scanner`
- `vendor/bin/sail npm run build`
- `vendor/bin/sail npm run test:e2e -- e2e/entry-scanner-volunteer-lookup.spec.ts`
- `vendor/bin/sail bin pint --dirty --format agent`