### PR TITLE
feat(scanner): split scanner entry and pool events

### DIFF
--- a/app/Actions/CloneProject.php
+++ b/app/Actions/CloneProject.php
@@ -16,6 +16,7 @@ class CloneProject
     {
         return DB::transaction(function () use ($project, $causer, $dateOffsetDays) {
             $project->load(['events', 'gearItems', 'customRegistrationFields', 'hintTexts', 'scanners']);
+            $eventMap = [];
 
             $clonedProject = $project->replicate([
                 'id',
@@ -32,7 +33,8 @@ class CloneProject
             $clonedProject->save();
 
             foreach ($project->events as $event) {
-                $this->cloneEvent->execute($event, $causer, targetProjectId: $clonedProject->id, dateOffsetDays: $dateOffsetDays);
+                $clonedEvent = $this->cloneEvent->execute($event, $causer, targetProjectId: $clonedProject->id, dateOffsetDays: $dateOffsetDays);
+                $eventMap[$event->id] = $clonedEvent->id;
             }
 
             foreach ($project->gearItems as $gearItem) {
@@ -65,7 +67,14 @@ class CloneProject
                 ]);
                 $clonedScanner->project_id = $clonedProject->id;
                 $clonedScanner->scanner_token = bin2hex(random_bytes(32));
-                $clonedScanner->event_id = null;
+                $clonedScanner->entry_event_id = $scanner->entry_event_id !== null ? ($eventMap[$scanner->entry_event_id] ?? null) : null;
+                $clonedScanner->pool_event_ids = is_array($scanner->pool_event_ids)
+                    ? collect($scanner->pool_event_ids)
+                        ->map(fn ($eventId) => $eventMap[(int) $eventId] ?? null)
+                        ->filter()
+                        ->values()
+                        ->all()
+                    : null;
                 $clonedScanner->save();
             }
 

--- a/app/Actions/CreateProjectScanner.php
+++ b/app/Actions/CreateProjectScanner.php
@@ -10,9 +10,13 @@ class CreateProjectScanner
     public function execute(Project $project, array $data): ProjectScanner
     {
         $rawCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+        $entryEventId = (int) $data['entry_event_id'];
+        $poolEventIds = array_values(array_unique(array_map('intval', $data['pool_event_ids'])));
 
         return $project->scanners()->create([
-            'event_id' => $data['event_id'] ?? null,
+            'entry_event_id' => $entryEventId,
+            'pool_event_ids' => $poolEventIds,
+            'requires_configuration_review' => false,
             'name' => $data['name'],
             'type' => $data['type'],
             'modes' => $data['modes'] ?? null,

--- a/app/Actions/RecordArrival.php
+++ b/app/Actions/RecordArrival.php
@@ -9,6 +9,7 @@ use App\Models\EventArrival;
 use App\Models\Ticket;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class RecordArrival
 {
@@ -19,25 +20,39 @@ class RecordArrival
         ArrivalMethod $method,
         ?Carbon $scannedAt = null,
     ): EventArrival {
-        $existingArrival = EventArrival::where('ticket_id', $ticket->id)
-            ->where('event_id', $event->id)
-            ->first();
+        return DB::transaction(function () use ($ticket, $event, $scannedBy, $method, $scannedAt) {
+            $lockedTicket = Ticket::query()
+                ->whereKey($ticket->id)
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        $flagged = $existingArrival !== null;
+            $existingArrival = EventArrival::query()
+                ->where('ticket_id', $lockedTicket->id)
+                ->where('event_id', $event->id)
+                ->lockForUpdate()
+                ->first();
 
-        $arrival = EventArrival::create([
-            'ticket_id' => $ticket->id,
-            'volunteer_id' => $ticket->volunteer_id,
-            'event_id' => $event->id,
-            'scanned_by' => $scannedBy?->id,
-            'scanned_at' => $scannedAt ?? now(),
-            'method' => $method,
-            'flagged' => $flagged,
-            'flag_reason' => $flagged ? 'Duplicate scan — volunteer already checked in.' : null,
-        ]);
+            if ($existingArrival instanceof EventArrival) {
+                $existingArrival->setAttribute('duplicate_detected', true);
+                $existingArrival->setAttribute('duplicate_message', 'Duplicate scan - volunteer already checked in.');
 
-        ArrivalScanned::dispatch($arrival, $scannedBy);
+                return $existingArrival;
+            }
 
-        return $arrival;
+            $arrival = EventArrival::create([
+                'ticket_id' => $lockedTicket->id,
+                'volunteer_id' => $lockedTicket->volunteer_id,
+                'event_id' => $event->id,
+                'scanned_by' => $scannedBy?->id,
+                'scanned_at' => $scannedAt ?? now(),
+                'method' => $method,
+                'flagged' => false,
+                'flag_reason' => null,
+            ]);
+
+            ArrivalScanned::dispatch($arrival, $scannedBy);
+
+            return $arrival;
+        });
     }
 }

--- a/app/Actions/UpdateProjectScanner.php
+++ b/app/Actions/UpdateProjectScanner.php
@@ -8,11 +8,18 @@ class UpdateProjectScanner
 {
     public function execute(ProjectScanner $scanner, array $data): ProjectScanner
     {
+        $entryEventId = isset($data['entry_event_id']) ? (int) $data['entry_event_id'] : $scanner->entry_event_id;
+        $poolEventIds = isset($data['pool_event_ids']) && is_array($data['pool_event_ids'])
+            ? array_values(array_unique(array_map('intval', $data['pool_event_ids'])))
+            : $scanner->configuredPoolEventIds();
+
         $scanner->update([
             'name' => $data['name'] ?? $scanner->name,
             'type' => $data['type'] ?? $scanner->type,
             'modes' => $data['modes'] ?? $scanner->modes,
-            'event_id' => array_key_exists('event_id', $data) ? $data['event_id'] : $scanner->event_id,
+            'entry_event_id' => $entryEventId,
+            'pool_event_ids' => $poolEventIds,
+            'requires_configuration_review' => $this->shouldClearReviewFlag($entryEventId, $poolEventIds) ? false : $scanner->requires_configuration_review,
             'gear_item_ids' => array_key_exists('gear_item_ids', $data) ? $data['gear_item_ids'] : $scanner->gear_item_ids,
             'hint_text' => array_key_exists('hint_text', $data) ? $data['hint_text'] : $scanner->hint_text,
             'starts_at' => $data['starts_at'] ?? $scanner->starts_at,
@@ -20,5 +27,12 @@ class UpdateProjectScanner
         ]);
 
         return $scanner;
+    }
+
+    /** @param  array<int, int>  $poolEventIds */
+    private function shouldClearReviewFlag(int $entryEventId, array $poolEventIds): bool
+    {
+        return $poolEventIds !== []
+            && in_array($entryEventId, $poolEventIds, true);
     }
 }

--- a/app/Http/Controllers/ScannerDataController.php
+++ b/app/Http/Controllers/ScannerDataController.php
@@ -40,20 +40,15 @@ class ScannerDataController extends Controller
         }
 
         $projectId = $scanner->project_id;
-        $eventId = $scanner->event_id;
+        $entryEventId = $scanner->entry_event_id;
+        $poolEventIds = $scanner->configuredPoolEventIds();
 
-        $volunteerQuery = $eventId
-            ? Volunteer::forEvent($eventId)
-            : Volunteer::where('project_id', $projectId);
+        $volunteerQuery = Volunteer::forEvents($poolEventIds);
 
         $eagerLoads = [
             'tickets' => fn ($q) => $q->where('project_id', $projectId),
-            'shiftSignups' => function ($q) use ($eventId, $projectId) {
-                if ($eventId) {
-                    $q->whereHas('shift.volunteerJob', fn ($sq) => $sq->where('event_id', $eventId));
-                } else {
-                    $q->whereHas('shift.volunteerJob.event', fn ($sq) => $sq->where('project_id', $projectId));
-                }
+            'shiftSignups' => function ($q) use ($poolEventIds) {
+                $q->whereHas('shift.volunteerJob', fn ($sq) => $sq->whereIn('event_id', $poolEventIds));
             },
             'shiftSignups.shift.volunteerJob',
             'shiftSignups.attendanceRecord',
@@ -67,12 +62,12 @@ class ScannerDataController extends Controller
 
         $volunteers = $volunteerQuery->with($eagerLoads)->get();
 
-        $events = $eventId
-            ? Event::where('id', $eventId)->get()
-            : Event::where('project_id', $projectId)->get();
+        $events = Event::whereIn('id', $poolEventIds)
+            ->orderBy('starts_at')
+            ->orderBy('name')
+            ->get();
 
-        $eventIds = $events->pluck('id');
-        $arrivals = EventArrival::whereIn('event_id', $eventIds)->get();
+        $arrivals = EventArrival::where('event_id', $entryEventId)->get();
 
         $shiftSignupIds = $volunteers->flatMap(fn ($v) => $v->shiftSignups->pluck('id'));
         $attendanceRecords = AttendanceRecord::whereIn('shift_signup_id', $shiftSignupIds)->get();
@@ -116,6 +111,10 @@ class ScannerDataController extends Controller
                 'id' => $scanner->id,
                 'type' => $scanner->type->value,
                 'modes' => $scanner->modes,
+                'entry_event_id' => $entryEventId,
+                'pool_event_ids' => $poolEventIds,
+                'contract_version' => ProjectScanner::CONTRACT_VERSION,
+                'requires_configuration_review' => $scanner->requires_configuration_review,
             ],
             'events' => $events->map(fn ($e) => [
                 'id' => $e->id,
@@ -177,6 +176,7 @@ class ScannerDataController extends Controller
         }
 
         $validated = $request->validate([
+            'contract_version' => ['required', 'integer', Rule::in([ProjectScanner::CONTRACT_VERSION])],
             'arrivals' => ['required', 'array', 'min:1'],
             'arrivals.*.ticket_id' => ['required', 'integer', 'exists:tickets,id'],
             'arrivals.*.event_id' => ['nullable', 'integer', 'exists:events,id'],
@@ -184,16 +184,17 @@ class ScannerDataController extends Controller
             'arrivals.*.scanned_at' => ['required', 'date'],
         ]);
 
-        $eventIds = $scanner->event_id
-            ? [$scanner->event_id]
-            : Event::where('project_id', $scanner->project_id)->pluck('id')->toArray();
+        if ($scanner->requires_configuration_review) {
+            return response()->json([
+                'error' => 'Scanner configuration must be reviewed before volunteer check-in can be used.',
+            ], 409);
+        }
+
+        $event = Event::where('project_id', $scanner->project_id)->findOrFail($scanner->entry_event_id);
 
         foreach ($validated['arrivals'] as $arrivalData) {
             $ticket = Ticket::where('project_id', $scanner->project_id)
                 ->findOrFail($arrivalData['ticket_id']);
-
-            $eventId = $arrivalData['event_id'] ?? $scanner->event_id;
-            $event = Event::whereIn('id', $eventIds)->findOrFail($eventId);
 
             $recordArrival->execute(
                 ticket: $ticket,
@@ -204,7 +205,7 @@ class ScannerDataController extends Controller
             );
         }
 
-        $arrivals = EventArrival::whereIn('event_id', $eventIds)->get();
+        $arrivals = EventArrival::where('event_id', $event->id)->get();
 
         return response()->json([
             'arrivals' => $arrivals,

--- a/app/Livewire/Forms/ScannerForm.php
+++ b/app/Livewire/Forms/ScannerForm.php
@@ -17,7 +17,9 @@ class ScannerForm extends Form
     #[Validate('required|array|min:1')]
     public array $modes = ['checkin'];
 
-    public ?int $eventId = null;
+    public ?int $entryEventId = null;
+
+    public array $poolEventIds = [];
 
     public array $gearItemIds = [];
 
@@ -38,7 +40,19 @@ class ScannerForm extends Form
     {
         return [
             'modes.*' => ['string', 'in:checkin,gear_pickup'],
-            'eventId' => ['nullable', Rule::exists('events', 'id')->where('project_id', $this->component->projectId)],
+            'entryEventId' => ['required', 'integer', Rule::exists('events', 'id')->where('project_id', $this->component->projectId)],
+            'poolEventIds' => ['required', 'array', 'min:1', function (string $attribute, mixed $value, $fail): void {
+                if (! is_array($value)) {
+                    return;
+                }
+
+                $poolEventIds = array_values(array_unique(array_map('intval', $value)));
+
+                if ($this->entryEventId === null || ! in_array($this->entryEventId, $poolEventIds, true)) {
+                    $fail('The selected entry event must be included in the pool events.');
+                }
+            }],
+            'poolEventIds.*' => ['integer', Rule::exists('events', 'id')->where('project_id', $this->component->projectId)],
         ];
     }
 
@@ -52,11 +66,25 @@ class ScannerForm extends Form
         $this->name = $data['name'];
         $this->type = $data['type'];
         $this->modes = $data['modes'];
-        $this->eventId = $data['eventId'];
+        $this->entryEventId = $data['entryEventId'];
+        $this->poolEventIds = $data['poolEventIds'];
         $this->gearItemIds = $data['gearItemIds'];
         $this->hintText = $data['hintText'];
         $this->startsAt = $data['startsAt'];
         $this->endsAt = $data['endsAt'];
+    }
+
+    public function setDefaultScope(?int $eventId): void
+    {
+        if ($eventId === null) {
+            return;
+        }
+
+        $this->entryEventId ??= $eventId;
+
+        if ($this->poolEventIds === []) {
+            $this->poolEventIds = [$this->entryEventId];
+        }
     }
 
     /**
@@ -70,7 +98,8 @@ class ScannerForm extends Form
             'name' => $this->name,
             'type' => $this->type,
             'modes' => $this->modes,
-            'event_id' => $this->eventId,
+            'entry_event_id' => $this->entryEventId,
+            'pool_event_ids' => array_values(array_unique(array_map('intval', $this->poolEventIds))),
             'gear_item_ids' => ! empty($this->gearItemIds) ? $this->gearItemIds : null,
             'hint_text' => $this->hintText ?: null,
             'starts_at' => $this->startsAt,

--- a/app/Livewire/Projects/ScannerManagement.php
+++ b/app/Livewire/Projects/ScannerManagement.php
@@ -53,13 +53,55 @@ class ScannerManagement extends Component
         $this->projectId = $projectId;
 
         Gate::authorize('manageScanners', $this->project);
+
+        $this->resetForm();
     }
 
     public function updatedFormType(string $value): void
     {
         if ($value === ScannerType::EntryStaff->value) {
             $this->form->modes = [ScannerMode::Checkin->value];
+
+            $this->ensureEntryEventIsIncludedInPool();
+
+            return;
         }
+
+        $this->synchronizeVolunteerAdminPool();
+    }
+
+    public function updatedFormEntryEventId(?int $value): void
+    {
+        if ($value === null) {
+            $this->form->poolEventIds = [];
+
+            return;
+        }
+
+        if ($this->form->type === ScannerType::VolunteerAdmin->value) {
+            $this->form->poolEventIds = [$value];
+
+            return;
+        }
+
+        $poolEventIds = array_values(array_unique(array_map('intval', $this->form->poolEventIds)));
+
+        if (! in_array($value, $poolEventIds, true)) {
+            $poolEventIds[] = $value;
+        }
+
+        $this->form->poolEventIds = $poolEventIds;
+    }
+
+    public function updatedFormPoolEventIds(): void
+    {
+        if ($this->form->type === ScannerType::VolunteerAdmin->value) {
+            $this->synchronizeVolunteerAdminPool();
+
+            return;
+        }
+
+        $this->ensureEntryEventIsIncludedInPool();
     }
 
     /** @return Collection<int, ProjectScanner> */
@@ -67,7 +109,7 @@ class ScannerManagement extends Component
     public function scanners(): Collection
     {
         return ProjectScanner::where('project_id', $this->projectId)
-            ->with('assignees')
+            ->with(['assignees', 'entryEvent'])
             ->orderBy('starts_at')
             ->get();
     }
@@ -76,7 +118,19 @@ class ScannerManagement extends Component
     #[Computed]
     public function events(): Collection
     {
-        return Event::where('project_id', $this->projectId)->orderBy('name')->get();
+        return Event::where('project_id', $this->projectId)
+            ->orderBy('starts_at')
+            ->orderBy('name')
+            ->get();
+    }
+
+    /** @return array<int, string> */
+    #[Computed]
+    public function eventNamesById(): array
+    {
+        return $this->events
+            ->mapWithKeys(fn (Event $event) => [$event->id => $event->name])
+            ->all();
     }
 
     /** @return Collection<int, ProjectGearItem> */
@@ -88,6 +142,12 @@ class ScannerManagement extends Component
 
     public function createScanner(): void
     {
+        if ($this->events->isEmpty()) {
+            $this->addError('form.entryEventId', 'Create an event before configuring scanners.');
+
+            return;
+        }
+
         $this->form->validate();
 
         $tz = $this->project->timezone ?? 'UTC';
@@ -104,9 +164,15 @@ class ScannerManagement extends Component
             (new SendScannerLinks)->execute($scanner);
         }
 
-        $this->form->reset();
+        $this->resetForm();
         $this->showCreateModal = false;
         unset($this->scanners);
+    }
+
+    public function showCreateScannerModal(): void
+    {
+        $this->resetForm();
+        $this->showCreateModal = true;
     }
 
     public function editScanner(int $scannerId): void
@@ -115,11 +181,15 @@ class ScannerManagement extends Component
 
         $this->editingScannerId = $scannerId;
         $tz = $this->project->timezone ?? 'UTC';
+        $entryEventId = $scanner->entry_event_id;
+        $poolEventIds = $scanner->configuredPoolEventIds();
+
         $this->form->fillFromScanner([
             'name' => $scanner->name,
             'type' => $scanner->type->value,
             'modes' => $scanner->modes ?? ['checkin'],
-            'eventId' => $scanner->event_id,
+            'entryEventId' => $entryEventId,
+            'poolEventIds' => $poolEventIds,
             'gearItemIds' => $scanner->gear_item_ids ?? [],
             'hintText' => $scanner->hint_text ?? '',
             'startsAt' => $this->toLocal($scanner->starts_at, $tz),
@@ -143,7 +213,7 @@ class ScannerManagement extends Component
         $action = new UpdateProjectScanner;
         $action->execute($scanner, $data);
 
-        $this->form->reset();
+        $this->resetForm();
         $this->showCreateModal = false;
         $this->editingScannerId = null;
         unset($this->scanners);
@@ -239,5 +309,46 @@ class ScannerManagement extends Component
         ScannerAssigneeRemoved::dispatch($scanner, $email, auth()->user());
 
         unset($this->scanners);
+    }
+
+    private function resetForm(): void
+    {
+        $this->form->reset();
+        $this->editingScannerId = null;
+        $this->form->type = ScannerType::EntryStaff->value;
+        $this->form->modes = [ScannerMode::Checkin->value];
+        $this->form->setDefaultScope($this->firstEventId());
+        $this->ensureEntryEventIsIncludedInPool();
+    }
+
+    private function firstEventId(): ?int
+    {
+        return $this->events->first()?->id;
+    }
+
+    private function ensureEntryEventIsIncludedInPool(): void
+    {
+        if ($this->form->entryEventId === null) {
+            return;
+        }
+
+        $poolEventIds = array_values(array_unique(array_map('intval', $this->form->poolEventIds)));
+
+        if (! in_array($this->form->entryEventId, $poolEventIds, true)) {
+            $poolEventIds[] = $this->form->entryEventId;
+        }
+
+        $this->form->poolEventIds = $poolEventIds;
+    }
+
+    private function synchronizeVolunteerAdminPool(): void
+    {
+        if ($this->form->entryEventId === null) {
+            $this->form->entryEventId = $this->firstEventId();
+        }
+
+        $this->form->poolEventIds = $this->form->entryEventId !== null
+            ? [$this->form->entryEventId]
+            : [];
     }
 }

--- a/app/Livewire/ScannerApp.php
+++ b/app/Livewire/ScannerApp.php
@@ -31,6 +31,12 @@ class ScannerApp extends Component
     #[Locked]
     public ?int $eventId = null;
 
+    #[Locked]
+    public int $contractVersion = ProjectScanner::CONTRACT_VERSION;
+
+    #[Locked]
+    public bool $requiresConfigurationReview = false;
+
     public string $scannerName = '';
 
     public ?string $hintText = null;
@@ -52,7 +58,9 @@ class ScannerApp extends Component
         $this->projectId = $scanner->project_id;
         $this->scannerType = $scanner->type->value;
         $this->modes = $scanner->modes ?? [];
-        $this->eventId = $scanner->event_id;
+        $this->eventId = $scanner->entry_event_id;
+        $this->contractVersion = ProjectScanner::CONTRACT_VERSION;
+        $this->requiresConfigurationReview = $scanner->requires_configuration_review;
         $this->scannerName = $scanner->name;
         $this->hintText = $scanner->hint_text;
     }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -95,6 +95,10 @@ class Project extends Model
                 $project->public_token = PublicToken::generate()->value;
             }
         });
+
+        static::deleting(function (Project $project): void {
+            $project->guestLists()->delete();
+        });
     }
 
     public function organization(): BelongsTo

--- a/app/Models/ProjectScanner.php
+++ b/app/Models/ProjectScanner.php
@@ -15,9 +15,13 @@ class ProjectScanner extends Model
     /** @use HasFactory<ProjectScannerFactory> */
     use HasFactory;
 
+    public const CONTRACT_VERSION = 1;
+
     protected $fillable = [
         'project_id',
-        'event_id',
+        'entry_event_id',
+        'pool_event_ids',
+        'requires_configuration_review',
         'name',
         'type',
         'modes',
@@ -39,6 +43,8 @@ class ProjectScanner extends Model
             'type' => ScannerType::class,
             'modes' => 'array',
             'gear_item_ids' => 'array',
+            'pool_event_ids' => 'array',
+            'requires_configuration_review' => 'boolean',
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
         ];
@@ -49,9 +55,9 @@ class ProjectScanner extends Model
         return $this->belongsTo(Project::class);
     }
 
-    public function event(): BelongsTo
+    public function entryEvent(): BelongsTo
     {
-        return $this->belongsTo(Event::class);
+        return $this->belongsTo(Event::class, 'entry_event_id');
     }
 
     public function assignees(): HasMany
@@ -101,6 +107,17 @@ class ProjectScanner extends Model
     public function hasMode(string $mode): bool
     {
         return in_array($mode, $this->modes ?? [], true);
+    }
+
+    /** @return array<int, int> */
+    public function configuredPoolEventIds(): array
+    {
+        return array_values(array_map('intval', $this->pool_event_ids ?? []));
+    }
+
+    public function includesEvent(int $eventId): bool
+    {
+        return in_array($eventId, $this->configuredPoolEventIds(), true);
     }
 
     /**

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -157,9 +157,23 @@ class Volunteer extends Model
 
     public function scopeForEvent(Builder $query, int $eventId): void
     {
-        $query->where(function (Builder $q) use ($eventId) {
-            $q->whereHas('shiftSignups', fn (Builder $sq) => $sq->whereHas('shift.volunteerJob', fn (Builder $jq) => $jq->where('event_id', $eventId))
-            )->orWhereHas('eventArrivals', fn (Builder $eq) => $eq->where('event_id', $eventId));
+        $query->forEvents([$eventId]);
+    }
+
+    /** @param  array<int, int>  $eventIds */
+    public function scopeForEvents(Builder $query, array $eventIds): void
+    {
+        $eventIds = array_values(array_unique(array_map('intval', $eventIds)));
+
+        if ($eventIds === []) {
+            $query->whereRaw('0 = 1');
+
+            return;
+        }
+
+        $query->where(function (Builder $builder) use ($eventIds) {
+            $builder->whereHas('shiftSignups', fn (Builder $signupQuery) => $signupQuery->whereHas('shift.volunteerJob', fn (Builder $jobQuery) => $jobQuery->whereIn('event_id', $eventIds))
+            )->orWhereHas('eventArrivals', fn (Builder $arrivalQuery) => $arrivalQuery->whereIn('event_id', $eventIds));
         });
     }
 

--- a/database/factories/ProjectScannerFactory.php
+++ b/database/factories/ProjectScannerFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Enums\ScannerMode;
 use App\Enums\ScannerType;
+use App\Models\Event;
 use App\Models\Project;
 use App\Models\ProjectScanner;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -13,13 +14,30 @@ class ProjectScannerFactory extends Factory
 {
     protected $model = ProjectScanner::class;
 
+    public function configure(): static
+    {
+        return $this->afterMaking(function (ProjectScanner $scanner): void {
+            if ($scanner->entry_event_id !== null && is_array($scanner->pool_event_ids) && $scanner->pool_event_ids !== []) {
+                return;
+            }
+
+            $project = Project::query()->findOrFail($scanner->project_id);
+            $event = Event::factory()->for($project)->create();
+
+            $scanner->entry_event_id = $scanner->entry_event_id ?? $event->id;
+            $scanner->pool_event_ids = $scanner->pool_event_ids ?? [$scanner->entry_event_id];
+        });
+    }
+
     public function definition(): array
     {
         $code = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
 
         return [
             'project_id' => Project::factory(),
-            'event_id' => null,
+            'entry_event_id' => null,
+            'pool_event_ids' => null,
+            'requires_configuration_review' => false,
             'name' => fake()->words(2, true),
             'type' => ScannerType::EntryStaff,
             'modes' => [ScannerMode::Checkin->value],
@@ -61,6 +79,32 @@ class ProjectScannerFactory extends Factory
         return $this->state(fn () => [
             'type' => ScannerType::VolunteerAdmin,
             'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
+        ]);
+    }
+
+    public function forEntryEvent(Event $event): static
+    {
+        return $this->state(fn () => [
+            'project_id' => $event->project_id,
+            'entry_event_id' => $event->id,
+            'pool_event_ids' => [$event->id],
+        ]);
+    }
+
+    /** @param  array<int, int>  $poolEventIds */
+    public function withPoolEvents(Event $entryEvent, array $poolEventIds): static
+    {
+        return $this->state(fn () => [
+            'project_id' => $entryEvent->project_id,
+            'entry_event_id' => $entryEvent->id,
+            'pool_event_ids' => array_values(array_unique(array_map('intval', $poolEventIds))),
+        ]);
+    }
+
+    public function requiresConfigurationReview(): static
+    {
+        return $this->state(fn () => [
+            'requires_configuration_review' => true,
         ]);
     }
 

--- a/database/migrations/2026_04_29_163912_add_scanner_event_configuration_to_project_scanners_table.php
+++ b/database/migrations/2026_04_29_163912_add_scanner_event_configuration_to_project_scanners_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->foreignId('entry_event_id')->nullable()->after('event_id')->constrained('events')->nullOnDelete();
+            $table->json('pool_event_ids')->nullable()->after('entry_event_id');
+            $table->boolean('requires_configuration_review')->default(false)->after('pool_event_ids');
+        });
+
+        DB::table('project_scanners')
+            ->orderBy('id')
+            ->chunkById(100, function ($scanners): void {
+                foreach ($scanners as $scanner) {
+                    $poolEventIds = $scanner->event_id !== null
+                        ? [(int) $scanner->event_id]
+                        : DB::table('events')
+                            ->where('project_id', $scanner->project_id)
+                            ->whereNull('deletion_requested_at')
+                            ->orderBy('starts_at')
+                            ->orderBy('id')
+                            ->pluck('id')
+                            ->map(fn ($eventId) => (int) $eventId)
+                            ->all();
+
+                    DB::table('project_scanners')
+                        ->where('id', $scanner->id)
+                        ->update([
+                            'entry_event_id' => $scanner->event_id !== null ? (int) $scanner->event_id : ($poolEventIds[0] ?? null),
+                            'pool_event_ids' => json_encode($poolEventIds, JSON_THROW_ON_ERROR),
+                            'requires_configuration_review' => $scanner->event_id === null,
+                        ]);
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('entry_event_id');
+            $table->dropColumn(['pool_event_ids', 'requires_configuration_review']);
+        });
+    }
+};

--- a/database/migrations/2026_04_29_170317_finalize_scanner_event_configuration.php
+++ b/database/migrations/2026_04_29_170317_finalize_scanner_event_configuration.php
@@ -26,7 +26,7 @@ return new class extends Migration
         });
 
         Schema::table('project_scanners', function (Blueprint $table) {
-            $table->foreign('entry_event_id')->references('id')->on('events')->restrictOnDelete();
+            $table->foreign('entry_event_id')->references('id')->on('events')->cascadeOnDelete();
             $table->dropConstrainedForeignId('event_id');
         });
 

--- a/database/migrations/2026_04_29_170317_finalize_scanner_event_configuration.php
+++ b/database/migrations/2026_04_29_170317_finalize_scanner_event_configuration.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->assertScannerConfigurationIsClean();
+        $this->deduplicateArrivals();
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->dropForeign(['entry_event_id']);
+        });
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->unsignedBigInteger('entry_event_id')->nullable(false)->change();
+            $table->json('pool_event_ids')->nullable(false)->change();
+        });
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->foreign('entry_event_id')->references('id')->on('events')->restrictOnDelete();
+            $table->dropConstrainedForeignId('event_id');
+        });
+
+        Schema::table('event_arrivals', function (Blueprint $table) {
+            $table->unique(['ticket_id', 'event_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->foreignId('event_id')->nullable()->after('project_id')->constrained()->nullOnDelete();
+        });
+
+        DB::table('project_scanners')->update([
+            'event_id' => DB::raw('entry_event_id'),
+        ]);
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->dropForeign(['entry_event_id']);
+        });
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->unsignedBigInteger('entry_event_id')->nullable()->change();
+            $table->json('pool_event_ids')->nullable()->change();
+        });
+
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->foreign('entry_event_id')->references('id')->on('events')->nullOnDelete();
+        });
+
+        Schema::table('event_arrivals', function (Blueprint $table) {
+            $table->dropUnique(['ticket_id', 'event_id']);
+        });
+    }
+
+    private function assertScannerConfigurationIsClean(): void
+    {
+        $invalidScanners = DB::table('project_scanners')
+            ->select(['id', 'entry_event_id', 'pool_event_ids', 'requires_configuration_review'])
+            ->get()
+            ->filter(function (object $scanner): bool {
+                $poolEventIds = json_decode((string) $scanner->pool_event_ids, true);
+
+                return $scanner->requires_configuration_review
+                    || $scanner->entry_event_id === null
+                    || ! is_array($poolEventIds)
+                    || $poolEventIds === []
+                    || ! in_array((int) $scanner->entry_event_id, array_map('intval', $poolEventIds), true);
+            });
+
+        if ($invalidScanners->isNotEmpty()) {
+            throw new RuntimeException('Cannot finalize scanner configuration while review-required or incomplete scanners still exist.');
+        }
+    }
+
+    private function deduplicateArrivals(): void
+    {
+        DB::table('event_arrivals')
+            ->select(['ticket_id', 'event_id'])
+            ->groupBy('ticket_id', 'event_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->orderBy('ticket_id')
+            ->orderBy('event_id')
+            ->chunk(100, function (Collection $duplicateGroups): void {
+                foreach ($duplicateGroups as $group) {
+                    $arrivals = DB::table('event_arrivals')
+                        ->where('ticket_id', $group->ticket_id)
+                        ->where('event_id', $group->event_id)
+                        ->orderBy('flagged')
+                        ->orderBy('id')
+                        ->get();
+
+                    $arrivalToKeep = $arrivals->firstWhere('flagged', false) ?? $arrivals->first();
+
+                    if ($arrivalToKeep === null) {
+                        continue;
+                    }
+
+                    $arrivalIdsToDelete = $arrivals
+                        ->pluck('id')
+                        ->reject(fn (int $arrivalId): bool => $arrivalId === $arrivalToKeep->id)
+                        ->all();
+
+                    if ($arrivalIdsToDelete !== []) {
+                        DB::table('event_arrivals')->whereIn('id', $arrivalIdsToDelete)->delete();
+                    }
+                }
+            });
+    }
+};

--- a/e2e/entry-staff-scanner-event-split.spec.ts
+++ b/e2e/entry-staff-scanner-event-split.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+test('organizer configures an entry staff scanner with separate entry and pool events', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByPlaceholder('email@example.com').fill('test@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+
+    await page.goto('/e2e-fixtures.json');
+
+    const fixtures = JSON.parse(await page.locator('body').innerText()) as {
+        entryPoolProjectId: number;
+        entryPoolEntryEventId: number;
+        entryPoolPoolEventId: number;
+    };
+
+    await page.goto(`/admin/projects/${fixtures.entryPoolProjectId}/scanners`);
+    await expect(page.getByRole('button', { name: 'New Scanner' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'New Scanner' }).click();
+    await expect(page.getByPlaceholder('e.g. Eingang Nord')).toBeVisible();
+
+    await page.getByPlaceholder('e.g. Eingang Nord').fill('Browser Config Scanner');
+    await page.evaluate(({ entryEventId, poolEventId }) => {
+        const root = Array.from(document.querySelectorAll('[wire\\:id]')).find((element) => {
+            return element.textContent?.includes('Pool Events') && element.textContent?.includes('New Scanner');
+        }) as HTMLElement | undefined;
+        const componentId = root?.getAttribute('wire:id');
+        const livewire = (window as Window & {
+            Livewire?: { find: (id: string) => { set: (name: string, value: unknown) => void } };
+        }).Livewire;
+
+        if (!componentId || !livewire) {
+            throw new Error('Livewire component not found.');
+        }
+
+        const component = livewire.find(componentId);
+        component.set('form.entryEventId', poolEventId);
+        component.set('form.poolEventIds', [entryEventId, poolEventId]);
+    }, {
+        entryEventId: fixtures.entryPoolEntryEventId,
+        poolEventId: fixtures.entryPoolPoolEventId,
+    });
+    await page.getByLabel('Starts at').fill('2026-04-29T17:00');
+    await page.getByLabel('Ends at').fill('2026-04-29T21:00');
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(page.getByText('Browser Config Scanner')).toBeVisible();
+    await expect(page.getByText('Entry Event: E2E Pool Event')).toBeVisible();
+    await expect(page.getByText('Pool Events: E2E Entry Event, E2E Pool Event').last()).toBeVisible();
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -92,6 +92,8 @@ vendor/bin/sail artisan tinker --execute="
   use App\Enums\GearItemType;
   use App\Enums\ScannerMode;
   use App\Enums\ScannerType;
+  use App\Actions\GenerateTicket;
+  use App\Actions\RefreshTicketJwt;
   use App\Models\Event;
   use App\Models\Organization;
   use App\Models\Project;
@@ -254,7 +256,8 @@ vendor/bin/sail artisan tinker --execute="
 
     ProjectScanner::factory()->active()->create([
       'project_id' => \$project->id,
-      'event_id' => \$event->id,
+      'entry_event_id' => \$event->id,
+      'pool_event_ids' => [\$event->id],
       'name' => 'E2E Volunteer Admin Scanner',
       'type' => ScannerType::VolunteerAdmin,
       'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
@@ -308,7 +311,8 @@ vendor/bin/sail artisan tinker --execute="
 
     ProjectScanner::factory()->active()->create([
       'project_id' => \$pastProject->id,
-      'event_id' => \$pastEvent->id,
+      'entry_event_id' => \$pastEvent->id,
+      'pool_event_ids' => [\$pastEvent->id],
       'name' => 'E2E Volunteer Admin Past Scanner',
       'type' => ScannerType::VolunteerAdmin,
       'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
@@ -317,6 +321,81 @@ vendor/bin/sail artisan tinker --execute="
       'starts_at' => now()->subHour(),
       'ends_at' => now()->addHours(4),
     ]);
+
+    \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-pool-scanner-token')->delete();
+    \App\Models\Event::whereIn('name', [
+      'E2E Entry Event',
+      'E2E Pool Event',
+    ])->delete();
+    \App\Models\Project::where('name', 'E2E Entry Pool Scanner Project')->delete();
+    \App\Models\Volunteer::where('email', 'entry-pool@example.com')->delete();
+
+    \$entryPoolProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Entry Pool Scanner Project',
+    ]);
+
+    \$entryEvent = Event::factory()->for(\$organization)->for(\$entryPoolProject)->published()->create([
+      'name' => 'E2E Entry Event',
+      'slug' => 'e2e-entry-event',
+      'starts_at' => now()->subHours(2),
+      'ends_at' => now()->addHours(8),
+      'attendance_grace_minutes' => 10,
+    ]);
+
+    \$poolEvent = Event::factory()->for(\$organization)->for(\$entryPoolProject)->published()->create([
+      'name' => 'E2E Pool Event',
+      'slug' => 'e2e-pool-event',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(6),
+      'attendance_grace_minutes' => 10,
+    ]);
+
+    \$poolJob = VolunteerJob::factory()->create([
+      'event_id' => \$poolEvent->id,
+      'name' => 'Pool Event Team',
+    ]);
+
+    \$poolShift = Shift::factory()->create([
+      'volunteer_job_id' => \$poolJob->id,
+      'shift_date' => now()->toDateString(),
+      'starts_at' => now()->subMinutes(30),
+      'ends_at' => now()->addHours(2),
+      'display_text' => now()->subMinutes(30)->format('M d, H:i').' - '.now()->addHours(2)->format('H:i'),
+    ]);
+
+    \$poolVolunteer = Volunteer::factory()->verified()->for(\$entryPoolProject)->create([
+      'first_name' => 'Entry',
+      'last_name' => 'Pool',
+      'email' => 'entry-pool@example.com',
+      'phone' => '+491701112233',
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$poolVolunteer->id,
+      'shift_id' => \$poolShift->id,
+    ]);
+
+    \$ticket = app(GenerateTicket::class)->execute(\$poolVolunteer, \$entryEvent);
+    app(RefreshTicketJwt::class)->execute(\$ticket);
+
+    \$entryPoolScanner = ProjectScanner::factory()->active()->create([
+      'project_id' => \$entryPoolProject->id,
+      'entry_event_id' => \$entryEvent->id,
+      'pool_event_ids' => [\$entryEvent->id, \$poolEvent->id],
+      'name' => 'E2E Entry Pool Scanner',
+      'type' => ScannerType::EntryStaff,
+      'modes' => [ScannerMode::Checkin->value],
+      'scanner_token' => 'e2e-entry-pool-scanner-token',
+      'auth_code' => '333333',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
+
+    file_put_contents(base_path('public/e2e-fixtures.json'), json_encode([
+      'entryPoolProjectId' => \$entryPoolProject->id,
+      'entryPoolEntryEventId' => \$entryEvent->id,
+      'entryPoolPoolEventId' => \$poolEvent->id,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   });
 
   echo 'Volunteer admin shift-list fixture created';
@@ -330,3 +409,4 @@ echo "  EntranceStaff:  entrance@example.com / password"
 echo "  Dashboard user: dashboard@example.com / password"
 echo "  VA scanner:     /s/e2e-va-shift-list-token with code 222222"
 echo "  VA all past:    /s/e2e-va-all-past-token with code 444444"
+echo "  Entry/pool:     /s/e2e-entry-pool-scanner-token with code 333333"

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -34,7 +34,7 @@ import {
     type ShiftGroup,
     type ShiftGroupVolunteerRow,
 } from './shift-context';
-import { syncOutbox } from './sync';
+import { ScannerContractVersionError, syncOutbox } from './sync';
 import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGear, VolunteerGearPickup, GuestEntry } from './types';
 
 type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | 'invalid' | 'confirmed';
@@ -60,6 +60,9 @@ interface ScannerAppConfig {
     scannerId: number;
     scannerType: 'entry_staff' | 'volunteer_admin';
     modes: string[];
+    entryEventId: number | null;
+    contractVersion: number;
+    requiresConfigurationReview: boolean;
     scannerToken: string;
     dataUrl: string;
     syncUrl: string;
@@ -92,7 +95,10 @@ export function scannerApp(config: ScannerAppConfig) {
         _gearItems: [] as GearItem[],
         _volunteerGear: {} as Record<number, VolunteerGear[]>,
         _graceMinutes: null as number | null,
+        _contractVersion: config.contractVersion as number | null,
+        _entryEventId: config.entryEventId as number | null,
         _eventIds: [] as number[],
+        _requiresConfigurationReview: config.requiresConfigurationReview,
         _syncUrl: config.syncUrl,
         _dataUrl: config.dataUrl,
         _gearPickupUrl: config.gearPickupUrl,
@@ -182,6 +188,13 @@ export function scannerApp(config: ScannerAppConfig) {
             return config.scannerType === 'entry_staff';
         },
 
+        get canSubmitArrival(): boolean {
+            return this.canConfirmArrival
+                && this._entryEventId !== null
+                && this._contractVersion !== null
+                && !this._requiresConfigurationReview;
+        },
+
         get canPickupGear(): boolean {
             return config.modes.includes('gear_pickup');
         },
@@ -256,10 +269,14 @@ export function scannerApp(config: ScannerAppConfig) {
             this.guestResult = null;
 
             if (options.fromQr) {
-                const alreadyArrived = this._arrivals.some((arrival) => arrival.volunteer_id === volunteer.id);
+                const alreadyArrived = this._entryEventId !== null && this._arrivals.some((arrival) => {
+                    return arrival.volunteer_id === volunteer.id && arrival.event_id === this._entryEventId;
+                });
 
                 if (alreadyArrived) {
-                    const arrival = this._arrivals.find((entry) => entry.volunteer_id === volunteer.id);
+                    const arrival = this._arrivals.find((entry) => {
+                        return entry.volunteer_id === volunteer.id && entry.event_id === this._entryEventId;
+                    });
                     const lastScan = arrival?.scanned_at
                         ? new Date(arrival.scanned_at).toLocaleTimeString()
                         : '';
@@ -384,6 +401,9 @@ export function scannerApp(config: ScannerAppConfig) {
                         this._attendanceRecords = data.attendance_records ?? [];
                         this._gearItems = data.gear_items ?? [];
                         this._volunteerGear = data.volunteer_gear ?? {};
+                        this._contractVersion = data.scanner?.contract_version ?? this._contractVersion;
+                        this._entryEventId = data.scanner?.entry_event_id ?? this._entryEventId;
+                        this._requiresConfigurationReview = data.scanner?.requires_configuration_review ?? false;
                         this._eventIds = (data.events ?? []).map((e: { id: number }) => e.id);
                         this._graceMinutes = data.events?.[0]?.attendance_grace_minutes ?? null;
 
@@ -470,13 +490,22 @@ export function scannerApp(config: ScannerAppConfig) {
                 return;
             }
 
-            const eventId = this._eventIds[0] ?? 0;
+            if (!this.canSubmitArrival || this._entryEventId === null || this._contractVersion === null) {
+                this.state = 'invalid';
+                this.errorMessage = 'Scanner configuration needs review before volunteer check-in can be used.';
+
+                return;
+            }
+
+            const eventId = this._entryEventId;
 
             const entry = {
                 type: 'arrival' as const,
                 ticket_id: this.result.ticketId,
                 volunteer_id: this.result.volunteerId,
                 event_id: eventId,
+                entry_event_id: eventId,
+                contract_version: this._contractVersion,
                 method: 'qr_scan' as const,
                 scanned_at: new Date().toISOString().replace('T', ' ').substring(0, 19),
             };
@@ -698,8 +727,36 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         async _sync() {
-            await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken, this._guestSyncUrl);
-            this.outboxCount = await getOutboxCount(this._scannerId);
+            try {
+                await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken, this._guestSyncUrl);
+                this.outboxCount = await getOutboxCount(this._scannerId);
+            } catch (error) {
+                if (error instanceof ScannerContractVersionError) {
+                    if (this.isOnline) {
+                        await this.reloadScannerData({ preserveUiState: true });
+
+                        try {
+                            await syncOutbox(this._scannerId, this._syncUrl, this._scannerToken, this._guestSyncUrl);
+                            this.outboxCount = await getOutboxCount(this._scannerId);
+
+                            return;
+                        } catch (retryError) {
+                            if (!(retryError instanceof ScannerContractVersionError)) {
+                                throw retryError;
+                            }
+                        }
+                    }
+
+                    this.state = 'invalid';
+                    this.result = null;
+                    this.selectedVolunteer = null;
+                    this.errorMessage = 'Queued arrivals need organizer review before they can be synced.';
+
+                    return;
+                }
+
+                throw error;
+            }
         },
 
         dismiss() {

--- a/resources/js/scanner/sync.ts
+++ b/resources/js/scanner/sync.ts
@@ -1,5 +1,12 @@
 import { getOutboxEntries, deleteOutboxEntries } from './idb-store';
 
+export class ScannerContractVersionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ScannerContractVersionError';
+    }
+}
+
 function getHeaders(scannerToken: string): Record<string, string> {
     return {
         'Content-Type': 'application/json',
@@ -25,14 +32,17 @@ export async function syncOutbox(
     // Sync arrivals
     const arrivals = entries.filter((e) => !e.type || e.type === 'arrival');
     if (arrivals.length > 0) {
+        const contractVersion = getArrivalContractVersion(arrivals);
+
         try {
             const response = await fetch(syncUrl, {
                 method: 'POST',
                 headers,
                 body: JSON.stringify({
+                    contract_version: contractVersion,
                     arrivals: arrivals.map((e) => ({
                         ticket_id: e.ticket_id,
-                        event_id: e.event_id,
+                        event_id: e.entry_event_id ?? e.event_id,
                         method: e.method,
                         scanned_at: e.scanned_at,
                     })),
@@ -69,4 +79,22 @@ export async function syncOutbox(
             // Network error — will retry next sync
         }
     }
+}
+
+function getArrivalContractVersion(entries: Array<{ contract_version?: number; entry_event_id?: number | null }>): number {
+    const contractVersions = new Set<number>();
+
+    for (const entry of entries) {
+        if (typeof entry.contract_version !== 'number' || typeof entry.entry_event_id !== 'number') {
+            throw new ScannerContractVersionError('Queued arrivals require fresh scanner data before they can be synced.');
+        }
+
+        contractVersions.add(entry.contract_version);
+    }
+
+    if (contractVersions.size !== 1) {
+        throw new ScannerContractVersionError('Queued arrivals were created with different scanner contracts.');
+    }
+
+    return [...contractVersions][0];
 }

--- a/resources/js/scanner/types.ts
+++ b/resources/js/scanner/types.ts
@@ -116,6 +116,8 @@ export interface OutboxEntry {
     ticket_id?: number;
     volunteer_id?: number;
     event_id?: number;
+    entry_event_id?: number | null;
+    contract_version?: number;
     method?: 'qr_scan' | 'manual_lookup';
     scanned_at: string;
     shift_signup_id?: number;

--- a/resources/views/livewire/projects/scanner-management.blade.php
+++ b/resources/views/livewire/projects/scanner-management.blade.php
@@ -4,7 +4,7 @@
             <flux:button variant="ghost" icon="arrow-left" :href="route('projects.index')" wire:navigate aria-label="{{ __('Back to projects') }}" />
             <flux:heading size="xl">{{ $project->name }}</flux:heading>
         </div>
-        <flux:button variant="primary" icon="plus" wire:click="$set('showCreateModal', true)">
+        <flux:button variant="primary" icon="plus" wire:click="showCreateScannerModal" :disabled="$this->events->isEmpty()">
             {{ __('New Scanner') }}
         </flux:button>
     </div>
@@ -19,6 +19,12 @@
         <flux:callout variant="danger" class="mb-4">{{ $message }}</flux:callout>
     @enderror
 
+    @if ($this->events->isEmpty())
+        <flux:callout variant="warning" class="mb-4">
+            {{ __('Create at least one event before configuring scanners.') }}
+        </flux:callout>
+    @endif
+
     {{-- Scanner list --}}
     @if ($this->scanners->isEmpty())
         <flux:card>
@@ -32,6 +38,12 @@
                 <flux:card wire:key="scanner-{{ $scanner->id }}">
                     <div class="flex items-start justify-between gap-4">
                         <div class="min-w-0 flex-1">
+                            @php
+                                $poolEventNames = collect($scanner->configuredPoolEventIds())
+                                    ->map(fn ($eventId) => $this->eventNamesById[$eventId] ?? ('#'.$eventId))
+                                    ->implode(', ');
+                            @endphp
+
                             <div class="flex items-center gap-2 mb-1">
                                 <flux:heading size="lg">{{ $scanner->name }}</flux:heading>
                                 @php $status = $scanner->status; @endphp
@@ -48,6 +60,21 @@
                             </flux:text>
                             @if ($scanner->hint_text)
                                 <flux:text size="sm" class="mt-1">{{ $scanner->hint_text }}</flux:text>
+                            @endif
+
+                            <div class="mt-2 space-y-1">
+                                <flux:text size="sm" class="text-zinc-500">
+                                    {{ __('Entry Event: :event', ['event' => $scanner->entryEvent?->name ?? __('Needs review')]) }}
+                                </flux:text>
+                                <flux:text size="sm" class="text-zinc-500">
+                                    {{ __('Pool Events: :events', ['events' => $poolEventNames !== '' ? $poolEventNames : __('Needs review')]) }}
+                                </flux:text>
+                            </div>
+
+                            @if ($scanner->requires_configuration_review)
+                                <flux:callout variant="warning" class="mt-3">
+                                    {{ __('Configuration review required before volunteer check-in can be used.') }}
+                                </flux:callout>
                             @endif
 
                             {{-- Auth code --}}
@@ -163,13 +190,36 @@
             @endif
 
             <flux:field>
-                <flux:label>{{ __('Scope to Event (optional)') }}</flux:label>
-                <flux:select wire:model="form.eventId">
-                    <flux:select.option value="">{{ __('Project-wide') }}</flux:select.option>
+                <flux:label>{{ __('Entry Event') }}</flux:label>
+                <flux:select wire:model.live="form.entryEventId">
                     @foreach ($this->events as $event)
                         <flux:select.option :value="$event->id">{{ $event->name }}</flux:select.option>
                     @endforeach
                 </flux:select>
+                <flux:error name="form.entryEventId" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Pool Events') }}</flux:label>
+
+                @if ($form->type === 'volunteer_admin')
+                    <flux:text size="sm" class="text-zinc-500">
+                        {{ __('Volunteer Admin scanners always use the selected entry event as their only pool event.') }}
+                    </flux:text>
+                @else
+                    <div class="space-y-2">
+                        @foreach ($this->events as $event)
+                            <flux:checkbox
+                                wire:key="pool-event-{{ $event->id }}"
+                                wire:model="form.poolEventIds"
+                                :value="$event->id"
+                                :label="$event->name"
+                            />
+                        @endforeach
+                    </div>
+                @endif
+
+                <flux:error name="form.poolEventIds" />
             </flux:field>
 
             <div class="grid grid-cols-2 gap-4">

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -3,6 +3,9 @@
         scannerId: {{ $scannerId }},
         scannerType: '{{ $scannerType }}',
         modes: @js($modes),
+        entryEventId: @js($eventId),
+        contractVersion: {{ $contractVersion }},
+        requiresConfigurationReview: @js($requiresConfigurationReview),
         scannerToken: '{{ $scannerToken }}',
         dataUrl: '{{ $this->dataUrl }}',
         syncUrl: '{{ $this->syncUrl }}',
@@ -114,7 +117,7 @@
                     <p class="mt-1 text-center text-sm text-white" x-text="state === 'invalid' ? errorMessage : resultMessage"></p>
 
                     {{-- Confirm Arrival button (result state only) --}}
-                    <template x-if="state === 'result' && !guestResult">
+                    <template x-if="state === 'result' && !guestResult && canSubmitArrival">
                         <div class="mt-3 flex justify-center">
                             <button
                                 type="button"
@@ -124,6 +127,12 @@
                                 {{ __('Confirm Arrival') }}
                             </button>
                         </div>
+                    </template>
+
+                    <template x-if="state === 'result' && !guestResult && !canSubmitArrival">
+                        <p class="mt-3 text-center text-sm text-amber-300">
+                            {{ __('Scanner configuration must be reviewed before volunteer check-in can be used.') }}
+                        </p>
                     </template>
 
                     {{-- Next Scan button (terminal states) --}}

--- a/tests/Feature/Actions/CloneProjectTest.php
+++ b/tests/Feature/Actions/CloneProjectTest.php
@@ -106,10 +106,12 @@ it('does not copy volunteers or signups', function () {
     expect($cloned->volunteers)->toHaveCount(0);
 });
 
-it('clones scanners with event_id cleared and new token', function () {
-    $event = Event::factory()->for($this->org)->for($this->project)->create();
+it('clones scanners with remapped event configuration and new token', function () {
+    $event = Event::factory()->for($this->org)->for($this->project)->create(['name' => 'Day 1']);
+    $poolEvent = Event::factory()->for($this->org)->for($this->project)->create(['name' => 'Day 2']);
     $originalScanner = ProjectScanner::factory()->for($this->project)->create([
-        'event_id' => $event->id,
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id, $poolEvent->id],
         'name' => 'Main Scanner',
     ]);
 
@@ -120,7 +122,11 @@ it('clones scanners with event_id cleared and new token', function () {
     expect($clonedScanner)->not->toBeNull()
         ->and($clonedScanner->name)->toBe('Main Scanner')
         ->and($clonedScanner->project_id)->toBe($cloned->id)
-        ->and($clonedScanner->event_id)->toBeNull()
+        ->and($clonedScanner->entry_event_id)->toBe($cloned->events->firstWhere('name', 'Day 1 (Copy)')?->id)
+        ->and($clonedScanner->pool_event_ids)->toBe([
+            $cloned->events->firstWhere('name', 'Day 1 (Copy)')?->id,
+            $cloned->events->firstWhere('name', 'Day 2 (Copy)')?->id,
+        ])
         ->and($clonedScanner->scanner_token)->not->toBe($originalScanner->scanner_token);
 });
 

--- a/tests/Feature/Actions/CreateProjectScannerTest.php
+++ b/tests/Feature/Actions/CreateProjectScannerTest.php
@@ -12,12 +12,15 @@ beforeEach(function () {
 });
 
 it('creates a scanner with correct columns', function () {
+    $event = Event::factory()->for($this->project)->create();
     $action = new CreateProjectScanner;
 
     $result = $action->execute($this->project, [
         'name' => 'Eingang Nord',
         'type' => ScannerType::EntryStaff->value,
         'modes' => [ScannerMode::Checkin->value],
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
@@ -31,12 +34,15 @@ it('creates a scanner with correct columns', function () {
 });
 
 it('stores plaintext 6-digit auth code', function () {
+    $event = Event::factory()->for($this->project)->create();
     $action = new CreateProjectScanner;
 
     $result = $action->execute($this->project, [
         'name' => 'Test Scanner',
         'type' => ScannerType::EntryStaff->value,
         'modes' => [ScannerMode::Checkin->value],
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
@@ -51,12 +57,15 @@ it('stores plaintext 6-digit auth code', function () {
 });
 
 it('generates unique scanner_token of 64 hex chars', function () {
+    $event = Event::factory()->for($this->project)->create();
     $action = new CreateProjectScanner;
 
     $scanner1 = $action->execute($this->project, [
         'name' => 'Scanner 1',
         'type' => ScannerType::EntryStaff->value,
         'modes' => [ScannerMode::Checkin->value],
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
@@ -65,6 +74,8 @@ it('generates unique scanner_token of 64 hex chars', function () {
         'name' => 'Scanner 2',
         'type' => ScannerType::EntryStaff->value,
         'modes' => [ScannerMode::Checkin->value],
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
@@ -75,12 +86,15 @@ it('generates unique scanner_token of 64 hex chars', function () {
 });
 
 it('does not set transient raw_auth_code property', function () {
+    $event = Event::factory()->for($this->project)->create();
     $action = new CreateProjectScanner;
 
     $result = $action->execute($this->project, [
         'name' => 'No Transient Test',
         'type' => ScannerType::EntryStaff->value,
         'modes' => [ScannerMode::Checkin->value],
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
@@ -88,22 +102,25 @@ it('does not set transient raw_auth_code property', function () {
     expect($result->raw_auth_code ?? null)->toBeNull();
 });
 
-it('accepts optional event_id, gear_item_ids, and hint_text', function () {
-    $event = Event::factory()->for($this->project)->create();
+it('stores entry and pool events', function () {
+    $entryEvent = Event::factory()->for($this->project)->create();
+    $poolEvent = Event::factory()->for($this->project)->create();
     $action = new CreateProjectScanner;
 
     $result = $action->execute($this->project, [
         'name' => 'VA Scanner',
         'type' => ScannerType::VolunteerAdmin->value,
         'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
-        'event_id' => $event->id,
+        'entry_event_id' => $entryEvent->id,
+        'pool_event_ids' => [$entryEvent->id, $poolEvent->id],
         'gear_item_ids' => [1, 2, 3],
         'hint_text' => 'Scan volunteer badges here',
         'starts_at' => '2026-07-01 10:00:00',
         'ends_at' => '2026-07-01 18:00:00',
     ]);
 
-    expect($result->event_id)->toBe($event->id)
+    expect($result->entry_event_id)->toBe($entryEvent->id)
+        ->and($result->pool_event_ids)->toBe([$entryEvent->id, $poolEvent->id])
         ->and($result->gear_item_ids)->toBe([1, 2, 3])
         ->and($result->hint_text)->toBe('Scan volunteer badges here')
         ->and($result->type)->toBe(ScannerType::VolunteerAdmin);

--- a/tests/Feature/Actions/RecordArrivalTest.php
+++ b/tests/Feature/Actions/RecordArrivalTest.php
@@ -84,9 +84,10 @@ it('returns flagged duplicate on re-scan', function () {
     );
 
     expect($first->flagged)->toBeFalse()
-        ->and($second->flagged)->toBeTrue()
-        ->and($second->flag_reason)->toContain('Duplicate')
-        ->and(EventArrival::count())->toBe(2);
+        ->and($second->id)->toBe($first->id)
+        ->and($second->duplicate_detected)->toBeTrue()
+        ->and($second->duplicate_message)->toContain('Duplicate')
+        ->and(EventArrival::count())->toBe(1);
 });
 
 it('preserves original scan time on duplicate', function () {
@@ -107,7 +108,7 @@ it('preserves original scan time on duplicate', function () {
     );
 
     expect($first->fresh()->scanned_at->toDateTimeString())->toBe('2025-06-15 10:00:00')
-        ->and($second->scanned_at->toDateTimeString())->toBe('2025-06-15 10:30:00');
+        ->and($second->scanned_at->toDateTimeString())->toBe('2025-06-15 10:00:00');
 
     Carbon::setTestNow();
 });

--- a/tests/Feature/Actions/UpdateProjectScannerTest.php
+++ b/tests/Feature/Actions/UpdateProjectScannerTest.php
@@ -9,8 +9,11 @@ use App\Models\ProjectScanner;
 
 beforeEach(function () {
     $this->project = Project::factory()->create();
+    $this->event = Event::factory()->for($this->project)->create();
     $this->scanner = ProjectScanner::factory()->create([
         'project_id' => $this->project->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'name' => 'Original Name',
         'type' => ScannerType::EntryStaff,
         'modes' => [ScannerMode::Checkin->value],
@@ -56,11 +59,8 @@ it('updates time window', function () {
         ->and($result->ends_at->format('Y-m-d H:i:s'))->toBe('2026-08-01 20:00:00');
 });
 
-it('clears nullable fields when explicitly set to null', function () {
-    $event = Event::factory()->for($this->project)->create();
-
+it('clears nullable metadata fields', function () {
     $this->scanner->update([
-        'event_id' => $event->id,
         'gear_item_ids' => [1, 2],
         'hint_text' => 'Some hint',
     ]);
@@ -68,25 +68,41 @@ it('clears nullable fields when explicitly set to null', function () {
     $action = new UpdateProjectScanner;
 
     $result = $action->execute($this->scanner, [
-        'event_id' => null,
         'gear_item_ids' => null,
         'hint_text' => null,
     ]);
 
-    expect($result->event_id)->toBeNull()
-        ->and($result->gear_item_ids)->toBeNull()
+    expect($result->gear_item_ids)->toBeNull()
         ->and($result->hint_text)->toBeNull();
 });
 
-it('sets event_id when provided', function () {
+it('sets entry_event_id when provided', function () {
     $event = Event::factory()->for($this->project)->create();
     $action = new UpdateProjectScanner;
 
     $result = $action->execute($this->scanner, [
-        'event_id' => $event->id,
+        'entry_event_id' => $event->id,
+        'pool_event_ids' => [$event->id],
     ]);
 
-    expect($result->event_id)->toBe($event->id);
+    expect($result->entry_event_id)->toBe($event->id);
+});
+
+it('updates entry and pool events while clearing the review flag', function () {
+    $entryEvent = Event::factory()->for($this->project)->create();
+    $poolEvent = Event::factory()->for($this->project)->create();
+    $this->scanner->update(['requires_configuration_review' => true]);
+
+    $action = new UpdateProjectScanner;
+
+    $result = $action->execute($this->scanner, [
+        'entry_event_id' => $entryEvent->id,
+        'pool_event_ids' => [$entryEvent->id, $poolEvent->id],
+    ]);
+
+    expect($result->entry_event_id)->toBe($entryEvent->id)
+        ->and($result->pool_event_ids)->toBe([$entryEvent->id, $poolEvent->id])
+        ->and($result->requires_configuration_review)->toBeFalse();
 });
 
 it('persists changes to database', function () {

--- a/tests/Feature/Flows/ScannerIntegrationFlowTest.php
+++ b/tests/Feature/Flows/ScannerIntegrationFlowTest.php
@@ -40,7 +40,8 @@ it('completes full entry staff flow: create scanner, auth, fetch data, sync arri
         ->set('form.name', 'Main Entrance')
         ->set('form.type', ScannerType::EntryStaff->value)
         ->set('form.modes', [ScannerMode::Checkin->value])
-        ->set('form.eventId', $event->id)
+        ->set('form.entryEventId', $event->id)
+        ->set('form.poolEventIds', [$event->id])
         ->set('form.startsAt', '2026-07-01T10:00')
         ->set('form.endsAt', '2026-07-01T18:00')
         ->call('createScanner')
@@ -83,6 +84,7 @@ it('completes full entry staff flow: create scanner, auth, fetch data, sync arri
 
     // Step 5: Sync an arrival
     $syncResponse = $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [
             [
                 'ticket_id' => $ticket->id,
@@ -161,6 +163,7 @@ it('completes full volunteer admin flow: create scanner, auth, fetch data, gear 
     ]);
 
     $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [
             [
                 'ticket_id' => $ticket->id,

--- a/tests/Feature/Http/ScannerAttendanceApiTest.php
+++ b/tests/Feature/Http/ScannerAttendanceApiTest.php
@@ -30,7 +30,8 @@ beforeEach(function () {
     ]);
     $this->scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::VolunteerAdmin,
     ]);
 });

--- a/tests/Feature/Http/ScannerDataControllerEdgeCasesTest.php
+++ b/tests/Feature/Http/ScannerDataControllerEdgeCasesTest.php
@@ -48,6 +48,7 @@ it('returns 403 when scanner ID in sync URL does not match token', function () {
     ]);
 
     $this->postJson(route('scanner-api.sync', $scanner2->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [],
     ], [
         'X-Scanner-Token' => $scanner1->scanner_token,
@@ -127,11 +128,13 @@ it('returns 404 when syncing arrival for ticket from different project', functio
 
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::EntryStaff,
     ]);
 
     $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [
             [
                 'ticket_id' => $otherTicket->id,
@@ -145,14 +148,41 @@ it('returns 404 when syncing arrival for ticket from different project', functio
     ])->assertNotFound();
 });
 
-// --- Data: returns data scoped to scanner's event ---
-
-it('returns only volunteers for scanner event when event_id is set', function () {
-    $event2 = Event::factory()->for($this->project)->create();
-
+it('rejects arrival sync when the contract version is missing', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'arrivals' => [
+            [
+                'ticket_id' => $ticket->id,
+                'event_id' => $this->event->id,
+                'method' => 'qr_scan',
+                'scanned_at' => now()->toISOString(),
+            ],
+        ],
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ])->assertUnprocessable();
+});
+
+// --- Data: returns data scoped to scanner's configured pool ---
+
+it('returns only configured pool events', function () {
+    $event2 = Event::factory()->for($this->project)->create();
+
+    $scanner = ProjectScanner::factory()->active()->forEntryEvent($this->event)->create([
+        'project_id' => $this->project->id,
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -164,14 +194,16 @@ it('returns only volunteers for scanner event when event_id is set', function ()
         ->assertJsonPath('events.0.id', $this->event->id);
 });
 
-// --- Data: project-wide scanner returns all events ---
+// --- Data: multi-event pool returns all configured events ---
 
-it('returns all project events when scanner has no event_id', function () {
-    Event::factory()->count(2)->for($this->project)->create();
+it('returns all configured pool events for a multi-event scanner', function () {
+    $additionalEvents = Event::factory()->count(2)->for($this->project)->create();
+    $poolEventIds = collect([$this->event->id])
+        ->merge($additionalEvents->pluck('id'))
+        ->all();
 
-    $scanner = ProjectScanner::factory()->active()->create([
+    $scanner = ProjectScanner::factory()->active()->withPoolEvents($this->event, $poolEventIds)->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -180,8 +212,7 @@ it('returns all project events when scanner has no event_id', function () {
 
     $response->assertOk();
 
-    $eventCount = Event::where('project_id', $this->project->id)->count();
-    $response->assertJsonCount($eventCount, 'events');
+    $response->assertJsonCount(count($poolEventIds), 'events');
 });
 
 // --- Gear pickup validation ---

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\ScannerType;
 use App\Models\Event;
+use App\Models\EventArrival;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
@@ -25,9 +26,8 @@ afterEach(function () {
 });
 
 it('returns scanner data with valid token', function () {
-    $scanner = ProjectScanner::factory()->active()->create([
+    $scanner = ProjectScanner::factory()->active()->forEntryEvent($this->event)->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
     ]);
 
     $volunteer = Volunteer::factory()->create([
@@ -44,7 +44,7 @@ it('returns scanner data with valid token', function () {
 
     $response->assertOk()
         ->assertJsonStructure([
-            'scanner' => ['id', 'type', 'modes'],
+            'scanner' => ['id', 'type', 'modes', 'entry_event_id', 'pool_event_ids', 'contract_version'],
             'events',
             'volunteers',
             'arrivals',
@@ -52,18 +52,32 @@ it('returns scanner data with valid token', function () {
             'keys',
         ])
         ->assertJsonPath('scanner.id', $scanner->id)
-        ->assertJsonPath('scanner.type', ScannerType::EntryStaff->value);
+        ->assertJsonPath('scanner.type', ScannerType::EntryStaff->value)
+        ->assertJsonPath('scanner.entry_event_id', $this->event->id)
+        ->assertJsonPath('scanner.pool_event_ids.0', $this->event->id)
+        ->assertJsonPath('scanner.contract_version', ProjectScanner::CONTRACT_VERSION);
 });
 
 it('includes phone in volunteer data when phone exists', function () {
-    $scanner = ProjectScanner::factory()->active()->create([
+    $scanner = ProjectScanner::factory()->active()->forEntryEvent($this->event)->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
     ]);
 
-    Volunteer::factory()->create([
+    $volunteer = Volunteer::factory()->create([
         'project_id' => $this->project->id,
         'phone' => '+49123456789',
+    ]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+    EventArrival::create([
+        'ticket_id' => $ticket->id,
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'scanned_by' => null,
+        'scanned_at' => now(),
+        'method' => 'qr_scan',
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -75,14 +89,25 @@ it('includes phone in volunteer data when phone exists', function () {
 });
 
 it('includes null phone when volunteer has no phone', function () {
-    $scanner = ProjectScanner::factory()->active()->create([
+    $scanner = ProjectScanner::factory()->active()->forEntryEvent($this->event)->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
     ]);
 
-    Volunteer::factory()->create([
+    $volunteer = Volunteer::factory()->create([
         'project_id' => $this->project->id,
         'phone' => null,
+    ]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+    EventArrival::create([
+        'ticket_id' => $ticket->id,
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'scanned_by' => null,
+        'scanned_at' => now(),
+        'method' => 'qr_scan',
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -98,7 +123,8 @@ it('includes attendance_states in data response', function () {
 
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -113,7 +139,8 @@ it('includes attendance_states in data response', function () {
 it('returns volunteer shift payload fields required for volunteer admin shift list', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
 
     $volunteer = Volunteer::factory()->create([
@@ -179,7 +206,8 @@ it('returns default states for projects with null attendance_states', function (
 
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
 
     $response = $this->getJson(route('scanner-api.data', $scanner->id), [
@@ -212,7 +240,8 @@ it('returns 401 without token', function () {
 it('syncs arrivals for entry staff scanner', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::EntryStaff,
     ]);
 
@@ -223,6 +252,7 @@ it('syncs arrivals for entry staff scanner', function () {
     ]);
 
     $response = $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [
             [
                 'ticket_id' => $ticket->id,
@@ -242,7 +272,8 @@ it('syncs arrivals for entry staff scanner', function () {
 it('returns 403 when VA scanner tries to sync arrivals', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
 
     $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
@@ -252,6 +283,7 @@ it('returns 403 when VA scanner tries to sync arrivals', function () {
     ]);
 
     $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
         'arrivals' => [
             [
                 'ticket_id' => $ticket->id,
@@ -263,6 +295,39 @@ it('returns 403 when VA scanner tries to sync arrivals', function () {
     ], [
         'X-Scanner-Token' => $scanner->scanner_token,
     ])->assertForbidden();
+});
+
+it('syncs arrivals to the scanner entry event instead of the client payload event', function () {
+    $poolEvent = Event::factory()->for($this->project)->create();
+    $scanner = ProjectScanner::factory()->active()->withPoolEvents($this->event, [$this->event->id, $poolEvent->id])->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
+        'arrivals' => [
+            [
+                'ticket_id' => $ticket->id,
+                'event_id' => $poolEvent->id,
+                'method' => 'qr_scan',
+                'scanned_at' => now()->toISOString(),
+            ],
+        ],
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk();
+
+    expect($response->json('arrivals'))->toHaveCount(1)
+        ->and($response->json('arrivals.0.event_id'))->toBe($this->event->id);
 });
 
 it('records gear pickup for VA scanner', function () {
@@ -302,9 +367,8 @@ it('returns 403 when entry staff scanner tries gear pickup', function () {
 });
 
 it('returns gear_items for volunteer admin scanner', function () {
-    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->forEntryEvent($this->event)->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
     ]);
     $gearItem = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->create([
         'project_id' => $this->project->id,
@@ -324,12 +388,21 @@ it('returns gear_items for volunteer admin scanner', function () {
 it('returns volunteer_gear keyed by volunteer id for VA scanner', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
     $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
     Ticket::factory()->create([
         'project_id' => $this->project->id,
         'volunteer_id' => $volunteer->id,
+    ]);
+    EventArrival::create([
+        'ticket_id' => Ticket::where('volunteer_id', $volunteer->id)->firstOrFail()->id,
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'scanned_by' => null,
+        'scanned_at' => now(),
+        'method' => 'qr_scan',
     ]);
     $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
     $gear = VolunteerGear::factory()->create([
@@ -352,7 +425,8 @@ it('returns volunteer_gear keyed by volunteer id for VA scanner', function () {
 it('returns empty gear data for entry staff scanner', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::EntryStaff,
     ]);
     ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
@@ -369,12 +443,21 @@ it('returns empty gear data for entry staff scanner', function () {
 it('returns volunteer gear with pickup information', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
     $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
-    Ticket::factory()->create([
+    $ticket = Ticket::factory()->create([
         'project_id' => $this->project->id,
         'volunteer_id' => $volunteer->id,
+    ]);
+    EventArrival::create([
+        'ticket_id' => $ticket->id,
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'scanned_by' => null,
+        'scanned_at' => now(),
+        'method' => 'qr_scan',
     ]);
     $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
     $gear = VolunteerGear::factory()->create([
@@ -400,11 +483,21 @@ it('returns volunteer gear with pickup information', function () {
 it('includes quantity_entitled in volunteer gear payload for Typ 2 gear', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
         'project_id' => $this->project->id,
-        'event_id' => null,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
     ]);
 
     $item = ProjectGearItem::factory()->quantity(3)->for($this->project)->create();
     $volunteer = Volunteer::factory()->for($this->project)->create();
+    $ticket = Ticket::factory()->for($this->project)->create(['volunteer_id' => $volunteer->id]);
+    EventArrival::create([
+        'ticket_id' => $ticket->id,
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'scanned_by' => null,
+        'scanned_at' => now(),
+        'method' => 'qr_scan',
+    ]);
     VolunteerGear::factory()->withQuantity(3)->create([
         'project_gear_item_id' => $item->id,
         'volunteer_id' => $volunteer->id,
@@ -422,7 +515,8 @@ it('includes quantity_entitled in volunteer gear payload for Typ 2 gear', functi
 it('includes quantity_per_volunteer in gear items payload', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::VolunteerAdmin,
     ]);
 
@@ -440,7 +534,8 @@ it('includes quantity_per_volunteer in gear items payload', function () {
 it('rejects gear pickup when quantity exceeded via scanner API', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::VolunteerAdmin,
     ]);
 
@@ -467,7 +562,8 @@ it('rejects gear pickup when quantity exceeded via scanner API', function () {
 it('allows gear pickup within quantity limit via scanner API', function () {
     $scanner = ProjectScanner::factory()->active()->create([
         'project_id' => $this->project->id,
-        'event_id' => $this->event->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
         'type' => ScannerType::VolunteerAdmin,
     ]);
 

--- a/tests/Feature/Livewire/ScannerManagementEdgeCasesTest.php
+++ b/tests/Feature/Livewire/ScannerManagementEdgeCasesTest.php
@@ -4,6 +4,7 @@ use App\Enums\ScannerMode;
 use App\Enums\ScannerType;
 use App\Enums\StaffRole;
 use App\Livewire\Projects\ScannerManagement;
+use App\Models\Event;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\ProjectScanner;
@@ -14,6 +15,7 @@ use Livewire\Livewire;
 beforeEach(function () {
     ['user' => $this->organizer, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
     $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->project)->create();
     app()->instance(Organization::class, $this->org);
 });
 

--- a/tests/Feature/Livewire/ScannerManagementTest.php
+++ b/tests/Feature/Livewire/ScannerManagementTest.php
@@ -5,6 +5,7 @@ use App\Enums\ScannerType;
 use App\Enums\StaffRole;
 use App\Jobs\SendScannerLinksJob;
 use App\Livewire\Projects\ScannerManagement;
+use App\Models\Event;
 use App\Models\GuestList;
 use App\Models\Organization;
 use App\Models\Project;
@@ -18,6 +19,7 @@ use Livewire\Livewire;
 beforeEach(function () {
     ['user' => $this->organizer, 'organization' => $this->org] = createUserWithOrganization(StaffRole::Organizer);
     $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->project)->create();
     app()->instance(Organization::class, $this->org);
 });
 

--- a/tests/Feature/Models/ProjectScannerEdgeCasesTest.php
+++ b/tests/Feature/Models/ProjectScannerEdgeCasesTest.php
@@ -87,23 +87,23 @@ it('scopes scheduled scanners correctly', function () {
     Carbon::setTestNow();
 });
 
-// --- Event relationship ---
+// --- Entry event relationship ---
 
-it('belongs to an event when event_id is set', function () {
+it('belongs to an entry event', function () {
     $project = Project::factory()->create();
     $event = Event::factory()->for($project)->create();
-    $scanner = ProjectScanner::factory()->create([
-        'project_id' => $project->id,
-        'event_id' => $event->id,
-    ]);
+    $scanner = ProjectScanner::factory()->forEntryEvent($event)->create();
 
-    expect($scanner->event->id)->toBe($event->id);
+    expect($scanner->entryEvent->id)->toBe($event->id);
 });
 
-it('has null event when event_id is null', function () {
-    $scanner = ProjectScanner::factory()->create(['event_id' => null]);
+it('returns configured pool event ids', function () {
+    $project = Project::factory()->create();
+    $entryEvent = Event::factory()->for($project)->create();
+    $poolEvent = Event::factory()->for($project)->create();
+    $scanner = ProjectScanner::factory()->withPoolEvents($entryEvent, [$entryEvent->id, $poolEvent->id])->create();
 
-    expect($scanner->event)->toBeNull();
+    expect($scanner->configuredPoolEventIds())->toBe([$entryEvent->id, $poolEvent->id]);
 });
 
 // --- Type casting ---

--- a/tests/Feature/Models/ProjectScannerTest.php
+++ b/tests/Feature/Models/ProjectScannerTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\ScannerMode;
 use App\Enums\ScannerType;
+use App\Models\Event;
 use App\Models\Project;
 use App\Models\ProjectScanner;
 use App\Models\ProjectScannerAssignee;
@@ -25,6 +26,14 @@ it('belongs to a project', function () {
     $scanner = ProjectScanner::factory()->for($project)->create();
 
     expect($scanner->project->id)->toBe($project->id);
+});
+
+it('belongs to an entry event', function () {
+    $project = Project::factory()->create();
+    $event = Event::factory()->for($project)->create();
+    $scanner = ProjectScanner::factory()->forEntryEvent($event)->create();
+
+    expect($scanner->entryEvent->id)->toBe($event->id);
 });
 
 it('has many assignees', function () {

--- a/tests/js/scanner/sync.test.ts
+++ b/tests/js/scanner/sync.test.ts
@@ -19,6 +19,8 @@ describe('sync (M11 — scanner token auth)', () => {
             type: 'arrival',
             ticket_id: 10,
             volunteer_id: 1,
+            entry_event_id: 5,
+            contract_version: 1,
             method: 'qr_scan',
             scanned_at: '2026-03-02 10:00:00',
         });
@@ -38,8 +40,10 @@ describe('sync (M11 — scanner token auth)', () => {
         expect(options.headers['X-Scanner-Token']).toBe('test-scanner-token');
 
         const body = JSON.parse(options.body);
+        expect(body.contract_version).toBe(1);
         expect(body.arrivals).toHaveLength(1);
         expect(body.arrivals[0].ticket_id).toBe(10);
+        expect(body.arrivals[0].event_id).toBe(5);
 
         vi.unstubAllGlobals();
     });
@@ -49,6 +53,8 @@ describe('sync (M11 — scanner token auth)', () => {
             type: 'arrival',
             ticket_id: 10,
             volunteer_id: 1,
+            entry_event_id: 5,
+            contract_version: 1,
             method: 'qr_scan',
             scanned_at: '2026-03-02 10:00:00',
         });
@@ -71,6 +77,8 @@ describe('sync (M11 — scanner token auth)', () => {
             type: 'arrival',
             ticket_id: 10,
             volunteer_id: 1,
+            entry_event_id: 5,
+            contract_version: 1,
             method: 'qr_scan',
             scanned_at: '2026-03-02 10:00:00',
         });
@@ -90,6 +98,8 @@ describe('sync (M11 — scanner token auth)', () => {
             type: 'arrival',
             ticket_id: 10,
             volunteer_id: 1,
+            entry_event_id: 5,
+            contract_version: 1,
             method: 'qr_scan',
             scanned_at: '2026-03-02 10:00:00',
         });
@@ -118,5 +128,19 @@ describe('sync (M11 — scanner token auth)', () => {
         expect(mockFetch).not.toHaveBeenCalled();
 
         vi.unstubAllGlobals();
+    });
+
+    it('rejects stale arrival entries that are missing contract metadata', async () => {
+        await addOutboxEntry(1, {
+            type: 'arrival',
+            ticket_id: 10,
+            volunteer_id: 1,
+            method: 'qr_scan',
+            scanned_at: '2026-03-02 10:00:00',
+        });
+
+        await expect(syncOutbox(1, '/api/scanner/1/sync', 'test-token'))
+            .rejects
+            .toThrow('Queued arrivals require fresh scanner data before they can be synced.');
     });
 });


### PR DESCRIPTION
## Summary
- split scanner configuration into `entry_event_id` and `pool_event_ids`, then finalize the schema by removing the legacy `event_id`
- update scanner runtime, Livewire management UI, clone flow, and duplicate arrival handling to use the new event model
- add PHP, JS, and Playwright coverage for the new scanner configuration and scanner flows

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Http/ScannerDataControllerTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Http/ScannerDataControllerEdgeCasesTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Actions/CreateProjectScannerTest.php tests/Feature/Actions/UpdateProjectScannerTest.php tests/Feature/Actions/CloneProjectTest.php tests/Feature/Models/ProjectScannerTest.php tests/Feature/Models/ProjectScannerEdgeCasesTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Livewire/ScannerManagementTest.php tests/Feature/Livewire/ScannerManagementEdgeCasesTest.php tests/Feature/Flows/ScannerIntegrationFlowTest.php tests/Feature/Livewire/ScannerAppTest.php`
- `vendor/bin/sail artisan test --compact --filter=ProjectScanner`
- `vendor/bin/sail artisan test --compact --filter=ScannerApp`
- `vendor/bin/sail npm run test -- scanner`
- `vendor/bin/sail npm exec playwright test e2e/entry-staff-scanner-event-split.spec.ts`
- `vendor/bin/sail npm exec playwright test e2e/va-scanner-shift-list.spec.ts`
- `vendor/bin/sail npm run build`
- `vendor/bin/sail bin pint --dirty --format agent`

Closes #199