### PR TITLE
feat(scanner): add entry staff volunteer lookup

### DIFF
--- a/e2e/entry-staff-volunteer-lookup.spec.ts
+++ b/e2e/entry-staff-volunteer-lookup.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    viewport: { width: 430, height: 720 },
+});
+
+test('entry staff scanner supports volunteer manual lookup, confirm, duplicate badge, and cached reload', async ({ page }) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+
+    await page.goto('/s/e2e-entry-manual-lookup-token');
+
+    await page.getByLabel('Enter 6-digit code').fill('555555');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-entry-manual-lookup-token\/scan$/);
+    await expect(page.getByRole('tab', { name: 'Scanner' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Volunteers' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Gastliste' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Volunteers' }).click();
+
+    const volunteersTab = page.locator('#tabpanel-volunteers');
+    const searchInput = page.getByPlaceholder('Search volunteers...');
+    const volunteerRow = volunteersTab.getByRole('button').filter({ hasText: 'Past Lookup' });
+
+    await searchInput.fill('P');
+    await expect(volunteersTab.getByText('Mindestens 2 Zeichen eingeben.')).toBeVisible();
+
+    await searchInput.fill('Past');
+    await expect(volunteerRow).toBeVisible();
+    await expect(volunteerRow).toContainText('past-manual-lookup@example.com');
+
+    await volunteerRow.click();
+
+    await expect(volunteersTab.getByText('Past Lookup').first()).toBeVisible();
+    await expect(volunteersTab).toContainText('past-manual-lookup@example.com');
+    await expect(volunteersTab).toContainText('+491701234999');
+    await expect(volunteersTab.getByRole('button', { name: 'Confirm Arrival' })).toBeVisible();
+
+    await volunteersTab.getByRole('button', { name: 'Confirm Arrival' }).click();
+
+    await expect(volunteersTab.getByText('Already checked in.')).toBeVisible();
+    await expect(volunteerRow.getByText('Bereits eingecheckt')).toBeVisible();
+
+    await page.locator('[x-data]').evaluate(async (element) => {
+        const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+        if (!component) {
+            throw new Error('Scanner Alpine component not found.');
+        }
+
+        component.isOnline = false;
+        await component.reloadScannerData({ preserveUiState: true });
+    });
+
+    await expect(volunteersTab.getByText('Offline - showing cached volunteer data.')).toBeVisible();
+    await expect(searchInput).toHaveValue('Past');
+    await expect(volunteersTab.getByText('Already checked in.')).toBeVisible();
+    await expect(volunteerRow).toBeVisible();
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -322,9 +322,9 @@ vendor/bin/sail artisan tinker --execute="
       'ends_at' => now()->addHours(4),
     ]);
 
-    \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-pool-scanner-token')->delete();
-    \App\Models\Event::whereIn('name', [
-      'E2E Entry Event',
+  \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-pool-scanner-token')->delete();
+  \App\Models\Event::whereIn('name', [
+    'E2E Entry Event',
       'E2E Pool Event',
     ])->delete();
     \App\Models\Project::where('name', 'E2E Entry Pool Scanner Project')->delete();
@@ -396,6 +396,77 @@ vendor/bin/sail artisan tinker --execute="
       'entryPoolEntryEventId' => \$entryEvent->id,
       'entryPoolPoolEventId' => \$poolEvent->id,
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-manual-lookup-token')->delete();
+    \App\Models\Event::whereIn('name', [
+      'E2E Entry Manual Event',
+      'E2E Entry Manual Past Event',
+    ])->delete();
+    \App\Models\Project::where('name', 'E2E Entry Manual Lookup Project')->delete();
+    \App\Models\Volunteer::where('email', 'past-manual-lookup@example.com')->delete();
+
+    \$manualLookupProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Entry Manual Lookup Project',
+    ]);
+
+    \$manualEntryEvent = Event::factory()->for(\$organization)->for(\$manualLookupProject)->published()->create([
+      'name' => 'E2E Entry Manual Event',
+      'slug' => 'e2e-entry-manual-event',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(6),
+      'attendance_grace_minutes' => 10,
+    ]);
+
+    \$manualPastEvent = Event::factory()->for(\$organization)->for(\$manualLookupProject)->published()->create([
+      'name' => 'E2E Entry Manual Past Event',
+      'slug' => 'e2e-entry-manual-past-event',
+      'starts_at' => now()->subDays(30),
+      'ends_at' => now()->subDays(30)->addHours(6),
+      'attendance_grace_minutes' => 10,
+    ]);
+
+    \$manualPastJob = VolunteerJob::factory()->create([
+      'event_id' => \$manualPastEvent->id,
+      'name' => 'Past Event Team',
+    ]);
+
+    \$manualPastShift = Shift::factory()->create([
+      'volunteer_job_id' => \$manualPastJob->id,
+      'shift_date' => now()->subDays(30)->toDateString(),
+      'starts_at' => now()->subDays(30)->setTime(10, 0),
+      'ends_at' => now()->subDays(30)->setTime(14, 0),
+      'display_text' => now()->subDays(30)->setTime(10, 0)->format('M d, H:i').' - '.now()->subDays(30)->setTime(14, 0)->format('H:i'),
+    ]);
+
+    \$manualVolunteer = Volunteer::factory()->verified()->for(\$manualLookupProject)->create([
+      'first_name' => 'Past',
+      'last_name' => 'Lookup',
+      'email' => 'past-manual-lookup@example.com',
+      'phone' => '+491701234999',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$manualLookupProject->id,
+      'volunteer_id' => \$manualVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$manualVolunteer->id,
+      'shift_id' => \$manualPastShift->id,
+    ]);
+
+    ProjectScanner::factory()->active()->create([
+      'project_id' => \$manualLookupProject->id,
+      'entry_event_id' => \$manualEntryEvent->id,
+      'pool_event_ids' => [\$manualEntryEvent->id, \$manualPastEvent->id],
+      'name' => 'E2E Entry Manual Lookup Scanner',
+      'type' => ScannerType::EntryStaff,
+      'modes' => [ScannerMode::Checkin->value],
+      'scanner_token' => 'e2e-entry-manual-lookup-token',
+      'auth_code' => '555555',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
   });
 
   echo 'Volunteer admin shift-list fixture created';
@@ -410,3 +481,4 @@ echo "  Dashboard user: dashboard@example.com / password"
 echo "  VA scanner:     /s/e2e-va-shift-list-token with code 222222"
 echo "  VA all past:    /s/e2e-va-all-past-token with code 444444"
 echo "  Entry/pool:     /s/e2e-entry-pool-scanner-token with code 333333"
+echo "  Entry lookup:   /s/e2e-entry-manual-lookup-token with code 555555"

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -40,6 +40,8 @@ import type { Volunteer, ArrivalRecord, AttendanceRecord, GearItem, VolunteerGea
 type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | 'invalid' | 'confirmed';
 type ScannerTab = 'scanner' | 'volunteers' | 'guests' | 'shifts';
 type ScannerDataSource = 'network' | 'cache' | 'unavailable';
+type VolunteerSelectionSource = 'qr' | 'manual' | 'shift' | null;
+type VolunteerDetailState = 'ready' | 'checked_in' | 'configuration_review' | 'missing_ticket' | null;
 
 interface SelectedShiftContext {
     volunteerId: number;
@@ -112,9 +114,11 @@ export function scannerApp(config: ScannerAppConfig) {
         _video: null as HTMLVideoElement | null,
         _canvas: null as HTMLCanvasElement | null,
         activeTab: 'scanner' as ScannerTab,
+        volunteerSearchQuery: '' as string,
         guestSearchQuery: '' as string,
         shiftSearchQuery: '' as string,
         guestResult: null as GuestEntry | null,
+        selectedVolunteerSource: null as VolunteerSelectionSource,
 
         get filteredGuestGroups(): { label: string; guestCount: number; entries: GuestEntry[] }[] {
             const groups = new Map<number, { label: string; guestCount: number; entries: GuestEntry[] }>();
@@ -139,6 +143,58 @@ export function scannerApp(config: ScannerAppConfig) {
             }
 
             return Array.from(groups.values());
+        },
+
+        get shouldShowVolunteerSearchHint(): boolean {
+            const query = this.volunteerSearchQuery.trim();
+
+            return query.length > 0 && query.length < 2;
+        },
+
+        get filteredVolunteers(): Volunteer[] {
+            if (this.scannerType !== 'entry_staff') {
+                return [];
+            }
+
+            const query = this.volunteerSearchQuery.trim().toLowerCase();
+            if (query.length < 2) {
+                return [];
+            }
+
+            return this._volunteers
+                .filter((volunteer) => {
+                    return volunteer.first_name.toLowerCase().includes(query)
+                        || volunteer.last_name.toLowerCase().includes(query)
+                        || volunteer.email.toLowerCase().includes(query);
+                })
+                .sort((left, right) => {
+                    const leftHasArrival = this.hasArrivalForEntryEvent(left.id) ? 1 : 0;
+                    const rightHasArrival = this.hasArrivalForEntryEvent(right.id) ? 1 : 0;
+
+                    return leftHasArrival - rightHasArrival
+                        || left.name.localeCompare(right.name)
+                        || left.id - right.id;
+                });
+        },
+
+        get volunteerDetailState(): VolunteerDetailState {
+            if (this.selectedVolunteerSource !== 'manual' || !this.selectedVolunteer) {
+                return null;
+            }
+
+            if (!this.result) {
+                return 'missing_ticket';
+            }
+
+            if (this.hasArrivalForEntryEvent(this.selectedVolunteer.id)) {
+                return 'checked_in';
+            }
+
+            if (!this.canSubmitArrival) {
+                return 'configuration_review';
+            }
+
+            return 'ready';
         },
 
         get hasShiftListTab(): boolean {
@@ -265,13 +321,16 @@ export function scannerApp(config: ScannerAppConfig) {
         selectVolunteer(volunteer: Volunteer, options: { fromQr?: boolean; shiftContext?: SelectedShiftContext | null } = {}) {
             this.selectedVolunteer = volunteer;
             this.selectedShiftContext = options.shiftContext ?? null;
-            this.result = this.buildVolunteerResult(volunteer);
+            this.selectedVolunteerSource = options.fromQr
+                ? 'qr'
+                : options.shiftContext
+                    ? 'shift'
+                    : null;
+            this.result = volunteer.ticket ? this.buildVolunteerResult(volunteer) : null;
             this.guestResult = null;
 
             if (options.fromQr) {
-                const alreadyArrived = this._entryEventId !== null && this._arrivals.some((arrival) => {
-                    return arrival.volunteer_id === volunteer.id && arrival.event_id === this._entryEventId;
-                });
+                const alreadyArrived = this.hasArrivalForEntryEvent(volunteer.id);
 
                 if (alreadyArrived) {
                     const arrival = this._arrivals.find((entry) => {
@@ -300,6 +359,12 @@ export function scannerApp(config: ScannerAppConfig) {
             this.errorMessage = '';
         },
 
+        selectVolunteerFromSearch(volunteer: Volunteer) {
+            this.selectVolunteer(volunteer);
+            this.selectedVolunteerSource = 'manual';
+            this.guestResult = null;
+        },
+
         selectVolunteerFromShift(row: ShiftGroupVolunteerRow) {
             const volunteer = this._volunteers.find((entry) => entry.id === row.volunteerId);
             if (!volunteer) {
@@ -315,7 +380,25 @@ export function scannerApp(config: ScannerAppConfig) {
                     shiftId: row.shiftId,
                 },
             });
+            this.selectedVolunteerSource = 'shift';
             this.activeTab = 'scanner';
+        },
+
+        hasArrivalForEntryEvent(volunteerId: number): boolean {
+            return this._entryEventId !== null && this._arrivals.some((arrival) => {
+                return arrival.volunteer_id === volunteerId && arrival.event_id === this._entryEventId;
+            });
+        },
+
+        clearVolunteerSelection() {
+            this.selectedVolunteer = null;
+            this.selectedShiftContext = null;
+            this.selectedVolunteerSource = null;
+            this.result = null;
+            this.guestResult = null;
+            this.resultMessage = '';
+            this.errorMessage = '';
+            this.state = 'scanning';
         },
 
         async setActiveTab(tab: ScannerTab) {
@@ -335,9 +418,11 @@ export function scannerApp(config: ScannerAppConfig) {
 
             const preservedState = options.preserveUiState ? {
                 activeTab: this.activeTab,
+                volunteerSearchQuery: this.volunteerSearchQuery,
                 shiftSearchQuery: this.shiftSearchQuery,
                 selectedVolunteerId: this.selectedVolunteer?.id ?? null,
                 selectedShiftContext: this.selectedShiftContext,
+                selectedVolunteerSource: this.selectedVolunteerSource,
             } : null;
 
             await this._loadScannerData();
@@ -349,6 +434,7 @@ export function scannerApp(config: ScannerAppConfig) {
             this.activeTab = preservedState.activeTab === 'shifts' && !this.hasShiftListTab
                 ? 'scanner'
                 : preservedState.activeTab;
+            this.volunteerSearchQuery = preservedState.volunteerSearchQuery;
             this.shiftSearchQuery = preservedState.shiftSearchQuery;
 
             if (!preservedState.selectedVolunteerId) {
@@ -359,6 +445,7 @@ export function scannerApp(config: ScannerAppConfig) {
             if (!volunteer) {
                 this.selectedVolunteer = null;
                 this.selectedShiftContext = null;
+                this.selectedVolunteerSource = null;
                 this.result = null;
                 this.shiftListNotice = 'Selected volunteer is no longer available in the latest scanner data.';
                 return;
@@ -380,6 +467,7 @@ export function scannerApp(config: ScannerAppConfig) {
             this.selectVolunteer(volunteer, {
                 shiftContext: shiftContext ?? null,
             });
+            this.selectedVolunteerSource = preservedState.selectedVolunteerSource;
         },
 
         async _loadScannerData() {
@@ -437,7 +525,7 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         async _onQrDetected(jwtToken: string) {
-            if (this._processing || this.state !== 'scanning') {
+            if (this._processing || this.state !== 'scanning' || this.activeTab !== 'scanner') {
                 return;
             }
             this._processing = true;
@@ -490,14 +578,26 @@ export function scannerApp(config: ScannerAppConfig) {
                 return;
             }
 
+            if (this.hasArrivalForEntryEvent(this.result.volunteerId)) {
+                if (this.selectedVolunteerSource === 'qr') {
+                    this.state = 'duplicate';
+                    this.resultMessage = 'Already checked in.';
+                }
+
+                return;
+            }
+
             if (!this.canSubmitArrival || this._entryEventId === null || this._contractVersion === null) {
-                this.state = 'invalid';
-                this.errorMessage = 'Scanner configuration needs review before volunteer check-in can be used.';
+                if (this.selectedVolunteerSource === 'qr') {
+                    this.state = 'invalid';
+                    this.errorMessage = 'Scanner configuration needs review before volunteer check-in can be used.';
+                }
 
                 return;
             }
 
             const eventId = this._entryEventId;
+            const method = this.selectedVolunteerSource === 'manual' ? 'manual_lookup' as const : 'qr_scan' as const;
 
             const entry = {
                 type: 'arrival' as const,
@@ -506,7 +606,7 @@ export function scannerApp(config: ScannerAppConfig) {
                 event_id: eventId,
                 entry_event_id: eventId,
                 contract_version: this._contractVersion,
-                method: 'qr_scan' as const,
+                method,
                 scanned_at: new Date().toISOString().replace('T', ' ').substring(0, 19),
             };
 
@@ -527,8 +627,10 @@ export function scannerApp(config: ScannerAppConfig) {
             await addOutboxEntry(this._scannerId, entry);
             this.outboxCount = await getOutboxCount(this._scannerId);
 
-            this.state = 'confirmed';
-            this.resultMessage = `${this.result.name} checked in successfully.`;
+            if (this.selectedVolunteerSource === 'qr') {
+                this.state = 'confirmed';
+                this.resultMessage = `${this.result.name} checked in successfully.`;
+            }
 
             // Try to sync immediately if online
             if (this.isOnline) {
@@ -765,6 +867,7 @@ export function scannerApp(config: ScannerAppConfig) {
             this.guestResult = null;
             this.selectedVolunteer = null;
             this.selectedShiftContext = null;
+            this.selectedVolunteerSource = null;
             this.resultMessage = '';
             this.errorMessage = '';
             this._resetInactivityTimer();
@@ -774,6 +877,7 @@ export function scannerApp(config: ScannerAppConfig) {
             const alreadyCheckedIn = entry.checked_in_at !== null;
             this.selectedVolunteer = null;
             this.selectedShiftContext = null;
+            this.selectedVolunteerSource = null;
             this.result = null;
             this.guestResult = entry;
 

--- a/resources/js/scanner/idb-store.ts
+++ b/resources/js/scanner/idb-store.ts
@@ -97,7 +97,12 @@ export async function getVolunteers(scannerId: number): Promise<Volunteer[]> {
 export async function searchVolunteers(scannerId: number, query: string): Promise<Volunteer[]> {
     const volunteers = await getVolunteers(scannerId);
     const lowerQuery = query.toLowerCase();
-    return volunteers.filter((v) => v.name.toLowerCase().includes(lowerQuery));
+
+    return volunteers.filter((volunteer) => {
+        return volunteer.first_name.toLowerCase().includes(lowerQuery)
+            || volunteer.last_name.toLowerCase().includes(lowerQuery)
+            || volunteer.email.toLowerCase().includes(lowerQuery);
+    });
 }
 
 export async function storeKeys(scannerId: number, keys: ScannerKeys): Promise<void> {

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -190,9 +190,106 @@
                 </div>
             </div>
 
-            {{-- Volunteers tab (placeholder) --}}
-            <div id="tabpanel-volunteers" role="tabpanel" aria-labelledby="tab-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col items-center justify-center">
-                <p class="text-sm text-zinc-400">{{ __('Use QR scanner or manual lookup for volunteer check-in.') }}</p>
+            {{-- Volunteers tab --}}
+            <div id="tabpanel-volunteers" role="tabpanel" aria-labelledby="tab-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col space-y-4">
+                <div class="space-y-3 px-1">
+                    <input
+                        type="text"
+                        x-model.debounce.300ms="volunteerSearchQuery"
+                        placeholder="{{ __('Search volunteers...') }}"
+                        aria-label="{{ __('Search volunteers') }}"
+                        class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-base text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+
+                    <template x-if="scannerDataSource === 'cache'">
+                        <div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                            Offline - showing cached volunteer data.
+                        </div>
+                    </template>
+                </div>
+
+                <template x-if="selectedVolunteer && selectedVolunteerSource === 'manual'">
+                    <div class="px-1" x-cloak>
+                        <div
+                            class="rounded-xl p-4"
+                            :class="{
+                                'bg-emerald-500/10 border border-emerald-500/30': volunteerDetailState === 'ready',
+                                'bg-amber-500/10 border border-amber-500/30': volunteerDetailState === 'checked_in' || volunteerDetailState === 'configuration_review',
+                                'bg-zinc-800 border border-zinc-700': volunteerDetailState === 'missing_ticket'
+                            }"
+                        >
+                            <p class="text-center text-lg font-semibold text-white" x-text="selectedVolunteer?.name"></p>
+                            <p class="mt-1 text-center text-sm text-zinc-400" x-text="selectedVolunteer?.email"></p>
+                            <p class="mt-1 text-center text-xs text-zinc-400" x-show="selectedVolunteer?.phone" x-text="selectedVolunteer?.phone"></p>
+                            <p class="mt-1 text-center text-xs text-zinc-400" x-show="selectedVolunteer && !selectedVolunteer?.phone">{{ __('No phone number') }}</p>
+
+                            <p class="mt-3 text-center text-sm text-white" x-show="volunteerDetailState === 'ready'">Ready to check in.</p>
+                            <p class="mt-3 text-center text-sm text-white" x-show="volunteerDetailState === 'checked_in'">Already checked in.</p>
+                            <p class="mt-3 text-center text-sm text-amber-300" x-show="volunteerDetailState === 'configuration_review'">
+                                {{ __('Scanner configuration must be reviewed before volunteer check-in can be used.') }}
+                            </p>
+                            <p class="mt-3 text-center text-sm text-zinc-300" x-show="volunteerDetailState === 'missing_ticket'">
+                                {{ __('This volunteer cannot be checked in because no project ticket is available.') }}
+                            </p>
+
+                            <template x-if="volunteerDetailState === 'ready'">
+                                <div class="mt-3 flex justify-center">
+                                    <button
+                                        type="button"
+                                        class="min-h-12 w-full rounded-lg bg-emerald-600 px-4 py-3 text-base font-medium text-white hover:bg-emerald-500 active:bg-emerald-700"
+                                        @click="confirmArrival()"
+                                    >
+                                        {{ __('Confirm Arrival') }}
+                                    </button>
+                                </div>
+                            </template>
+
+                            <div class="mt-3 flex justify-center">
+                                <button
+                                    type="button"
+                                    class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                                    @click="clearVolunteerSelection()"
+                                >
+                                    {{ __('Close Details') }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                <div class="space-y-3 overflow-y-auto px-1">
+                    <template x-if="scannerDataSource === 'unavailable'">
+                        <p class="py-8 text-center text-sm text-zinc-500">Volunteer data is unavailable right now.</p>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && shouldShowVolunteerSearchHint">
+                        <p class="py-8 text-center text-sm text-zinc-500">Mindestens 2 Zeichen eingeben.</p>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && !shouldShowVolunteerSearchHint && volunteerSearchQuery.trim().length >= 2 && filteredVolunteers.length === 0">
+                        <p class="py-8 text-center text-sm text-zinc-500">No matching volunteers found.</p>
+                    </template>
+
+                    <template x-for="volunteer in filteredVolunteers" :key="volunteer.id">
+                        <button
+                            type="button"
+                            class="flex min-h-12 w-full items-center justify-between rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-3 text-left transition hover:bg-zinc-900"
+                            :class="selectedVolunteerSource === 'manual' && selectedVolunteer?.id === volunteer.id ? 'ring-1 ring-emerald-500/60' : ''"
+                            @click="selectVolunteerFromSearch(volunteer)"
+                        >
+                            <div class="min-w-0 flex-1">
+                                <p class="text-sm font-medium text-white" x-text="volunteer.name"></p>
+                                <p class="text-xs text-zinc-400" x-text="volunteer.email"></p>
+                                <p class="text-xs text-zinc-500" x-show="volunteer.phone" x-text="volunteer.phone"></p>
+                            </div>
+                            <div class="ml-3 shrink-0">
+                                <template x-if="hasArrivalForEntryEvent(volunteer.id)">
+                                    <span class="rounded-full bg-amber-500/20 px-3 py-1 text-xs text-amber-300">Bereits eingecheckt</span>
+                                </template>
+                            </div>
+                        </button>
+                    </template>
+                </div>
             </div>
 
             {{-- Gastliste tab --}}

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -201,6 +201,58 @@ it('returns volunteer shift payload fields required for volunteer admin shift li
         ->assertJsonPath('volunteers.0.shift_signups.0.attendance_record.status', 'on_time');
 });
 
+it('includes volunteers from past pooled events in entry staff scanner data', function () {
+    $pastEvent = Event::factory()->for($this->project)->create([
+        'starts_at' => Carbon::parse('2026-06-01 09:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 18:00:00'),
+    ]);
+
+    $scanner = ProjectScanner::factory()->active()->withPoolEvents($this->event, [$this->event->id, $pastEvent->id])->create([
+        'project_id' => $this->project->id,
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $volunteer = Volunteer::factory()->create([
+        'project_id' => $this->project->id,
+        'first_name' => 'Past',
+        'last_name' => 'Volunteer',
+        'email' => 'past-volunteer@example.com',
+    ]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $pastEvent->id,
+        'name' => 'Archive Crew',
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 14:00:00'),
+        'display_text' => 'Jun 01, 10:00 - 14:00',
+    ]);
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk();
+
+    $volunteerPayload = collect($response->json('volunteers'))->firstWhere('id', $volunteer->id);
+
+    expect($volunteerPayload)->not->toBeNull()
+        ->and($volunteerPayload['ticket']['id'])->toBe($ticket->id)
+        ->and($volunteerPayload['shift_signups'][0]['id'])->toBe($signup->id)
+        ->and($volunteerPayload['shift_signups'][0]['shift']['id'])->toBe($shift->id);
+});
+
 it('returns default states for projects with null attendance_states', function () {
     $this->project->update(['attendance_states' => null]);
 
@@ -267,6 +319,44 @@ it('syncs arrivals for entry staff scanner', function () {
 
     $response->assertOk()
         ->assertJsonStructure(['arrivals']);
+});
+
+it('syncs manual lookup arrivals for entry staff scanner', function () {
+    $scanner = ProjectScanner::factory()->active()->create([
+        'project_id' => $this->project->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
+        'type' => ScannerType::EntryStaff,
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
+        'arrivals' => [
+            [
+                'ticket_id' => $ticket->id,
+                'event_id' => $this->event->id,
+                'method' => 'manual_lookup',
+                'scanned_at' => now()->toISOString(),
+            ],
+        ],
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('arrivals.0.method', 'manual_lookup');
+
+    $arrival = EventArrival::query()->where('ticket_id', $ticket->id)->first();
+
+    expect($arrival)->not->toBeNull()
+        ->and($arrival->event_id)->toBe($this->event->id)
+        ->and($arrival->method->value)->toBe('manual_lookup');
 });
 
 it('returns 403 when VA scanner tries to sync arrivals', function () {

--- a/tests/Feature/Livewire/ScannerAppTest.php
+++ b/tests/Feature/Livewire/ScannerAppTest.php
@@ -63,6 +63,21 @@ it('loads entry staff scanner properties correctly', function () {
         ->assertSee('Scan tickets here');
 });
 
+it('renders manual volunteer lookup UI for entry staff scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->create([
+        'type' => ScannerType::EntryStaff,
+    ]);
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSee('Volunteers')
+        ->assertSee('Search volunteers...')
+        ->assertSeeHtml('volunteerSearchQuery')
+        ->assertSeeHtml('selectVolunteerFromSearch(volunteer)')
+        ->assertSee('Bereits eingecheckt')
+        ->assertSee('Close Details');
+});
+
 it('loads volunteer admin scanner properties correctly', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
     session(['scanner_id' => $scanner->id]);
@@ -70,6 +85,16 @@ it('loads volunteer admin scanner properties correctly', function () {
     Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
         ->assertSet('scannerType', ScannerType::VolunteerAdmin->value)
         ->assertSet('modes', [ScannerMode::Checkin->value, ScannerMode::GearPickup->value]);
+});
+
+it('does not render entry staff volunteer lookup UI for volunteer admin scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertDontSee('Search volunteers...')
+        ->assertDontSeeHtml('selectVolunteerFromSearch(volunteer)')
+        ->assertDontSee('Close Details');
 });
 
 it('renders scanner and shift-list tabs for volunteer admin scanners with checkin mode', function () {

--- a/tests/js/scanner/alpine-scanner.test.ts
+++ b/tests/js/scanner/alpine-scanner.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Volunteer } from '@/scanner/types';
+
+const cameraMocks = vi.hoisted(() => ({
+    startCamera: vi.fn(),
+    stopCamera: vi.fn(),
+}));
+
+const idbStoreMocks = vi.hoisted(() => ({
+    openScannerDb: vi.fn(),
+    storeVolunteers: vi.fn(),
+    storeKeys: vi.fn(),
+    storeAttendanceRecords: vi.fn(),
+    storeGuestEntries: vi.fn(),
+    getKeys: vi.fn(),
+    getVolunteers: vi.fn(),
+    getGuestEntries: vi.fn(),
+    getAttendanceRecords: vi.fn(),
+    addOutboxEntry: vi.fn(),
+    getOutboxCount: vi.fn(),
+}));
+
+const syncMocks = vi.hoisted(() => {
+    class ScannerContractVersionError extends Error {}
+
+    return {
+        ScannerContractVersionError,
+        syncOutbox: vi.fn(),
+    };
+});
+
+vi.mock('@/scanner/camera', () => cameraMocks);
+vi.mock('@/scanner/idb-store', () => idbStoreMocks);
+vi.mock('@/scanner/jwt-validator', () => ({
+    validateJwt: vi.fn(),
+}));
+vi.mock('@/scanner/sync', () => syncMocks);
+
+import { scannerApp } from '@/scanner/alpine-scanner';
+
+function makeVolunteer(overrides: Partial<Volunteer> = {}): Volunteer {
+    const id = overrides.id ?? 1;
+
+    return {
+        id,
+        first_name: 'Alice',
+        last_name: 'Johnson',
+        name: 'Alice Johnson',
+        email: 'alice@example.com',
+        phone: '+49123456789',
+        ticket: { id: id + 100, jwt_token: 'token', volunteer_id: id, project_id: 1 },
+        shift_signups: [],
+        ...overrides,
+    };
+}
+
+function createApp() {
+    return scannerApp({
+        scannerId: 7,
+        scannerType: 'entry_staff',
+        modes: ['checkin'],
+        entryEventId: 5,
+        contractVersion: 1,
+        requiresConfigurationReview: false,
+        scannerToken: 'scanner-token',
+        dataUrl: '/scanner/data',
+        syncUrl: '/scanner/sync',
+        gearPickupUrl: '/scanner/gear',
+        guestSyncUrl: '/scanner/guests',
+        guestGearPickupUrl: '/scanner/guests/gear',
+    });
+}
+
+describe('alpine-scanner manual volunteer lookup', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        idbStoreMocks.getOutboxCount.mockResolvedValue(1);
+        Object.defineProperty(window.navigator, 'onLine', {
+            configurable: true,
+            value: true,
+        });
+    });
+
+    it('filters volunteers by query and keeps checked-in volunteers last', () => {
+        const app = createApp();
+        const uncheckedVolunteer = makeVolunteer();
+        const checkedInVolunteer = makeVolunteer({
+            id: 2,
+            first_name: 'Bob',
+            last_name: 'Example',
+            name: 'Bob Example',
+            email: 'bob@example.com',
+        });
+
+        app._volunteers = [checkedInVolunteer, uncheckedVolunteer];
+        app._arrivals = [{
+            id: 1,
+            ticket_id: checkedInVolunteer.ticket.id,
+            volunteer_id: checkedInVolunteer.id,
+            event_id: 5,
+            scanned_by: null,
+            scanned_at: '2026-03-02 10:00:00',
+            method: 'qr_scan',
+            flagged: false,
+            flag_reason: null,
+        }];
+
+        app.volunteerSearchQuery = 'a';
+        expect(app.filteredVolunteers).toEqual([]);
+
+        app.volunteerSearchQuery = 'EXAMPLE.COM';
+        expect(app.filteredVolunteers.map((volunteer) => volunteer.id)).toEqual([
+            uncheckedVolunteer.id,
+            checkedInVolunteer.id,
+        ]);
+    });
+
+    it('selects a volunteer from manual search without leaving the volunteers tab', () => {
+        const app = createApp();
+        const volunteer = makeVolunteer();
+
+        app.activeTab = 'volunteers';
+        app.selectVolunteerFromSearch(volunteer);
+
+        expect(app.activeTab).toBe('volunteers');
+        expect(app.selectedVolunteer?.id).toBe(volunteer.id);
+        expect(app.selectedVolunteerSource).toBe('manual');
+        expect(app.state).toBe('scanning');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+
+    it('queues manual arrivals with the manual lookup method', async () => {
+        const app = createApp();
+        const volunteer = makeVolunteer();
+
+        app.isOnline = false;
+        app.selectVolunteerFromSearch(volunteer);
+
+        await app.confirmArrival();
+
+        expect(idbStoreMocks.addOutboxEntry).toHaveBeenCalledWith(7, expect.objectContaining({
+            volunteer_id: volunteer.id,
+            ticket_id: volunteer.ticket.id,
+            event_id: 5,
+            entry_event_id: 5,
+            contract_version: 1,
+            method: 'manual_lookup',
+        }));
+        expect(app._arrivals).toContainEqual(expect.objectContaining({
+            volunteer_id: volunteer.id,
+            event_id: 5,
+            method: 'manual_lookup',
+        }));
+        expect(app.hasArrivalForEntryEvent(volunteer.id)).toBe(true);
+        expect(app.state).toBe('scanning');
+    });
+
+    it('does not queue a duplicate manual arrival for an already checked-in volunteer', async () => {
+        const app = createApp();
+        const volunteer = makeVolunteer();
+
+        app._arrivals = [{
+            id: 1,
+            ticket_id: volunteer.ticket.id,
+            volunteer_id: volunteer.id,
+            event_id: 5,
+            scanned_by: null,
+            scanned_at: '2026-03-02 10:00:00',
+            method: 'manual_lookup',
+            flagged: false,
+            flag_reason: null,
+        }];
+        app.selectVolunteerFromSearch(volunteer);
+
+        await app.confirmArrival();
+
+        expect(app.volunteerDetailState).toBe('checked_in');
+        expect(idbStoreMocks.addOutboxEntry).not.toHaveBeenCalled();
+        expect(app._arrivals).toHaveLength(1);
+    });
+
+    it('preserves manual lookup state when scanner data reloads', async () => {
+        const app = createApp();
+        const volunteer = makeVolunteer();
+
+        app._volunteers = [volunteer];
+        app.activeTab = 'volunteers';
+        app.volunteerSearchQuery = 'ali';
+        app.selectVolunteerFromSearch(volunteer);
+        app._loadScannerData = vi.fn(async function (this: typeof app) {
+            this._volunteers = [volunteer];
+            this._guestEntries = [];
+            this._attendanceRecords = [];
+            this.outboxCount = 1;
+        });
+
+        await app.reloadScannerData({ preserveUiState: true });
+
+        expect(app.activeTab).toBe('volunteers');
+        expect(app.volunteerSearchQuery).toBe('ali');
+        expect(app.selectedVolunteer?.id).toBe(volunteer.id);
+        expect(app.selectedVolunteerSource).toBe('manual');
+    });
+});

--- a/tests/js/scanner/idb-store.test.ts
+++ b/tests/js/scanner/idb-store.test.ts
@@ -63,15 +63,31 @@ describe('idb-store (DB_VERSION 3 — scannerId keys)', () => {
         expect(scanner2[0].name).toBe('Bob Smith');
     });
 
-    it('searches volunteers by name substring', async () => {
+    it('searches volunteers by first and last name substrings', async () => {
         await storeVolunteers(1, [
             makeVolunteer(),
             makeVolunteer({ id: 2, first_name: 'Bob', last_name: 'Smith', name: 'Bob Smith', email: 'bob@example.com' }),
         ]);
 
-        const result = await searchVolunteers(1, 'ali');
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe('Alice Johnson');
+        await expect(searchVolunteers(1, 'ali')).resolves.toMatchObject([
+            expect.objectContaining({ name: 'Alice Johnson' }),
+        ]);
+
+        await expect(searchVolunteers(1, 'SMI')).resolves.toMatchObject([
+            expect.objectContaining({ name: 'Bob Smith' }),
+        ]);
+    });
+
+    it('searches volunteers by email substring', async () => {
+        await storeVolunteers(1, [
+            makeVolunteer(),
+            makeVolunteer({ id: 2, first_name: 'Bob', last_name: 'Smith', name: 'Bob Smith', email: 'bob@example.com' }),
+        ]);
+
+        const result = await searchVolunteers(1, 'EXAMPLE.COM');
+
+        expect(result).toHaveLength(2);
+        expect(result.map((volunteer) => volunteer.name)).toEqual(['Alice Johnson', 'Bob Smith']);
     });
 
     it('adds and retrieves outbox entries by scannerId', async () => {


### PR DESCRIPTION
## Summary
- add manual volunteer search to the Entry Staff scanner with a 2-character threshold, checked-in badges, and an in-tab detail panel
- reuse the existing arrival outbox and sync flow for manual check-ins while preserving offline cached lookup behavior
- cover the new flow with Livewire, HTTP, Vitest, and Playwright scanner tests

## Testing
- vendor/bin/sail artisan test --compact --filter=ScannerApp
- vendor/bin/sail artisan test --compact --filter=ScannerDataController
- vendor/bin/sail npm run test -- scanner
- bash e2e/setup.sh
- vendor/bin/sail npm run test:e2e -- e2e/entry-staff-volunteer-lookup.spec.ts e2e/entry-staff-scanner-event-split.spec.ts e2e/va-scanner-shift-list.spec.ts

Closes #195