### PR TITLE
fix(guest-lists): add browser qr fallback links

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #190 complete — volunteer portal announcements are null-safe and scoped to the volunteer's actual targeting"
-current_milestone: issue-190-portal-announcement-visibility
+current_focus: "Issue #193 complete — guest invitation emails now include per-entry signed browser fallback links with a read-only public guest pass page"
+current_milestone: issue-193-guest-mail-magic-link
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-28T20:41:27+02:00"
+last_updated: "2026-04-30T11:47:11+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -38,6 +38,7 @@ last_updated: "2026-04-28T20:41:27+02:00"
 | m19-non-expiring-magic-links | Non-Expiring Volunteer Magic Links | #185 make volunteer portal/ticket magic links non-expiring | m15, m17 | complete |
 | issue-175-announcement-recipient-resilience | Announcement Recipient Resilience | #175 token-backed verified recipient resolution for announcements | m13, m18, m19 | complete |
 | issue-190-portal-announcement-visibility | Portal Announcement Visibility | #190 null-safe volunteer portal announcements + targeted visibility filtering | m15, issue-175-announcement-recipient-resilience | complete |
+| issue-193-guest-mail-magic-link | Guest Mail Magic-Link Fallback | #193 signed browser fallback page for guest invitation QR codes | m12, m15, m19 | complete |
 
 ## Artifacts
 
@@ -58,6 +59,7 @@ last_updated: "2026-04-28T20:41:27+02:00"
 | `.tall-pipeline/m19-non-expiring-magic-links.md` | plan+implement+test | m19 | Issue #185 plan + implementation tracking for volunteer magic link expiry removal | complete |
 | `.tall-pipeline/issue-175-announcement-recipient-resilience.md` | plan+implement+test | issue-175 | Issue #175 plan + implementation tracking for resilient announcement recipients | complete |
 | `.tall-pipeline/issue-190-portal-announcement-visibility.md` | plan+implement+test | issue-190 | Issue #190 tracking for null-safe volunteer portal announcements and targeted visibility | complete |
+| `.tall-pipeline/issue-193-guest-mail-magic-link.md` | plan+implement+test | issue-193 | Issue #193 tracking for guest invitation magic-link QR fallbacks | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-193-guest-mail-magic-link.md
+++ b/.tall-pipeline/issue-193-guest-mail-magic-link.md
@@ -1,0 +1,44 @@
+# Milestone: issue-193-guest-mail-magic-link — Guest Mail Magic-Link Fallback
+
+**GitHub Issue:** [#193](https://github.com/reneweiser/voluntify/issues/193)
+**Features:** #193
+**Dependencies:** m12-guest-lists, m15-volunteer-portal-enhancements, m19-non-expiring-magic-links
+**Branch:** fix/193-guest-mail-magic-link
+
+## Plan
+- **Status:** complete
+- **Gate summary:** replace mail-client-only dependence on inline SVG with a per-entry signed browser fallback page, while keeping the existing SVG mail rendering for clients that support it.
+
+### Scope
+- Add a signed public guest pass route and read-only Blade page for a single `GuestEntry`
+- Add `GuestEntry::guestPassUrl()` with scanner-based expiry and a defensive fallback TTL
+- Update guest invitation mails to include a per-entry browser fallback link under the existing QR block
+- Add guest-friendly invalid or expired-link handling plus no-store and noindex protections
+- Add regression coverage for helper URL generation, public route behavior, and multi-entry mail rendering
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] AC-1: Write failing tests for `GuestEntry::guestPassUrl()` signed URL generation and expiry branches
+  - [x] AC-2: Write failing HTTP tests for the signed guest pass route, invalid or expired-link handling, and response hardening
+  - [x] AC-3: Write failing mail tests for per-entry fallback links in grouped guest invitation emails
+  - [x] AC-4: Add the signed route, controller, model helper, and guest pass Blade view
+  - [x] AC-5: Update exception rendering for guest-friendly invalid or expired signed links
+  - [x] AC-6: Eager load required guest relations in the mail job and update the mail template with per-entry browser links
+  - [x] Verify: run focused Sail tests, Pint, and affected regression coverage
+- **Gate summary:** signed guest pass fallback links now render per entry in guest invitation emails, open a read-only browser QR page, and return a guest-friendly 403 for invalid or expired links without exposing cacheable or indexable content.
+
+## Test
+- **Status:** complete
+- **Gate summary:** RED confirmed on missing `guestPassUrl()`, missing `guest.pass.show`, and absent mail fallback links. GREEN verified with focused Sail coverage for `GuestEntryTest`, `GuestInvitationMailTest`, `GuestPassControllerTest`, `SendGuestInvitationsJobTest`, `GuestListLifecycleTest`, `VolunteerTicketTest`, and `EmailVerificationTest`, plus `vendor/bin/sail bin pint --dirty --format agent`.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Jobs | `ConfirmGuestListJob`, `SendGuestInvitationsJob` |
+| Models | `GuestEntry`, `GuestGroup`, `GuestList`, `ProjectScanner`, `Ticket`, `MagicLinkToken` |
+| Public UI | `layouts/public.blade.php`, `Public\VolunteerTicket`, volunteer public-route patterns |
+| Mail | `GuestInvitationMail`, `resources/views/mail/guest-invitation.blade.php` |
+| Tests | `GuestInvitationMailTest`, `GuestListLifecycleTest`, `SendGuestInvitationsJobTest`, `TicketTest`, `EmailVerificationTest` |

--- a/app/Http/Controllers/GuestPassController.php
+++ b/app/Http/Controllers/GuestPassController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\GuestEntry;
+use Illuminate\Http\Response;
+
+class GuestPassController extends Controller
+{
+    public function __invoke(GuestEntry $entry): Response
+    {
+        $entry->loadMissing(['group.guestList.project', 'group.guestList.scanner']);
+
+        abort_if(blank($entry->qr_token), 404);
+        abort_if(! $entry->group->guestList->isConfirmed(), 404);
+
+        return response()->view('public.guest-pass', [
+            'entry' => $entry,
+            'message' => null,
+            'title' => $entry->displayLabel().' - Guest Pass',
+        ], 200, [
+            'Cache-Control' => 'no-store, private',
+            'X-Robots-Tag' => 'noindex, nofollow, noarchive',
+        ]);
+    }
+}

--- a/app/Jobs/SendGuestInvitationsJob.php
+++ b/app/Jobs/SendGuestInvitationsJob.php
@@ -27,6 +27,7 @@ class SendGuestInvitationsJob implements ShouldQueue
     public function handle(): void
     {
         $entries = $this->guestList->entries()
+            ->with(['group.guestList.project', 'group.guestList.scanner'])
             ->where('email', $this->email)
             ->whereNotNull('qr_token')
             ->get();

--- a/app/Models/GuestEntry.php
+++ b/app/Models/GuestEntry.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\URL;
 
 class GuestEntry extends Model
 {
@@ -71,5 +72,15 @@ class GuestEntry extends Model
     public function qrCodeSvg(): string
     {
         return app(QrCodeGenerator::class)->generate($this->qr_token);
+    }
+
+    public function guestPassUrl(): string
+    {
+        $this->loadMissing('group.guestList.scanner');
+
+        $expiresAt = $this->group->guestList->scanner?->ends_at?->copy()->addHours(12)
+            ?? now()->addDays(7);
+
+        return URL::temporarySignedRoute('guest.pass.show', $expiresAt, ['entry' => $this->id]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,8 @@ use App\Http\Middleware\ScannerAuthMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
 use Sentry\Laravel\Integration;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -31,4 +33,19 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         Integration::handles($exceptions);
+
+        $exceptions->render(function (InvalidSignatureException $exception, Request $request) {
+            if (! $request->routeIs('guest.pass.show')) {
+                return null;
+            }
+
+            return response()->view('public.guest-pass', [
+                'entry' => null,
+                'message' => 'This guest pass link is invalid or has expired.',
+                'title' => 'Guest Pass Unavailable',
+            ], 403, [
+                'Cache-Control' => 'no-store, private',
+                'X-Robots-Tag' => 'noindex, nofollow, noarchive',
+            ]);
+        });
     })->create();

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -37,7 +37,8 @@
 
         {{-- Main content --}}
         <main id="main-content" style="position: relative; z-index: 1; max-width: 896px; margin: 0 auto; padding: 5rem 1.5rem 3rem;">
-            {{ $slot }}
+            {{ $slot ?? '' }}
+            @yield('content')
         </main>
 
         {{-- Footer (matches landing page) --}}

--- a/resources/views/mail/guest-invitation.blade.php
+++ b/resources/views/mail/guest-invitation.blade.php
@@ -13,6 +13,10 @@ Name: {{ $entry->name }}
 
 {!! $entry->qrCodeSvg() !!}
 
+If the QR code is not visible in your email app, open this pass in your browser.
+
+<a href="{{ $entry->guestPassUrl() }}">{{ $entry->guestPassUrl() }}</a>
+
 @endforeach
 
 Please present your QR code at the entrance.

--- a/resources/views/public/guest-pass.blade.php
+++ b/resources/views/public/guest-pass.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.public')
+
+@section('meta')
+    <meta name="robots" content="noindex,nofollow,noarchive">
+@endsection
+
+@section('content')
+    <div class="mx-auto max-w-2xl pt-10">
+        @if ($entry)
+            @php($guestList = $entry->group->guestList)
+
+            <div class="mb-8">
+                <p class="text-sm uppercase tracking-[0.2em] text-zinc-500">{{ __('Guest Pass') }}</p>
+                <h1 class="font-bebas text-4xl tracking-[0.04em] text-white">{{ $guestList->project->name }}</h1>
+                <p class="mt-3 text-zinc-400">{{ $guestList->name }}</p>
+            </div>
+
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-black/20">
+                <div class="mb-6">
+                    <p class="text-sm uppercase tracking-[0.2em] text-zinc-500">{{ __('Pass Holder') }}</p>
+                    <h2 class="font-bebas text-3xl tracking-[0.04em] text-white">{{ $entry->displayLabel() }}</h2>
+
+                    @if ($entry->name)
+                        <p class="mt-2 text-zinc-300">{{ $entry->name }}</p>
+                    @endif
+                </div>
+
+                <div class="flex justify-center rounded-2xl bg-white p-5">
+                    <div class="size-full max-w-80 text-black">
+                        {!! $entry->qrCodeSvg() !!}
+                    </div>
+                </div>
+
+                <p class="mt-6 text-sm text-zinc-300">{{ __('Please present this QR code at the entrance.') }}</p>
+            </div>
+        @else
+            <div class="rounded-2xl border border-amber-400/20 bg-white/5 p-6 shadow-2xl shadow-black/20">
+                <p class="text-sm uppercase tracking-[0.2em] text-amber-300">{{ __('Guest Pass Unavailable') }}</p>
+                <h1 class="mt-3 font-bebas text-4xl tracking-[0.04em] text-white">{{ __('Link unavailable') }}</h1>
+                <p class="mt-4 text-zinc-300">{{ $message }}</p>
+                <p class="mt-3 text-sm text-zinc-400">{{ __('Please contact the event organizer if you need a new guest pass email.') }}</p>
+            </div>
+        @endif
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\GuestPassController;
 use App\Http\Controllers\VolunteerExportController;
 use App\Livewire\ActivityFeed;
 use App\Livewire\Auth\ChangePassword;
@@ -59,6 +60,7 @@ if (app()->environment('local')) {
 Route::livewire('p/{publicToken}', ProjectWebsite::class)->name('projects.public');
 Route::livewire('events/{publicToken}', EventSignup::class)->name('events.public')->middleware('throttle:60,1');
 Route::livewire('events/{publicToken}/jobs/{jobId}/cheat-sheet', JobCheatSheet::class)->name('events.jobs.cheat-sheet');
+Route::get('guest-pass/{entry}', GuestPassController::class)->middleware('signed')->name('guest.pass.show');
 Route::livewire('my-ticket/{magicToken}', VolunteerTicket::class)->name('volunteer.ticket');
 Route::livewire('my-portal/{magicToken}', VolunteerPortal::class)->name('volunteer.portal');
 Route::livewire('verify-email/{token}', EmailVerificationPage::class)->name('volunteer.verify-email');

--- a/tests/Feature/Http/GuestPassControllerTest.php
+++ b/tests/Feature/Http/GuestPassControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function () {
+    $this->project = Project::factory()->create(['name' => 'Summer Festival']);
+    $this->scanner = ProjectScanner::factory()->for($this->project)->create([
+        'ends_at' => now()->addHours(4),
+    ]);
+    $this->guestList = GuestList::factory()
+        ->for($this->project)
+        ->for($this->scanner, 'scanner')
+        ->confirmed()
+        ->create([
+            'name' => 'Artist Guest List',
+        ]);
+    $this->group = GuestGroup::factory()->for($this->guestList)->create([
+        'label' => 'DJ Soundwave',
+        'guest_count' => 1,
+    ]);
+});
+
+it('renders the guest pass for a valid signed link', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'name' => 'DJ Soundwave',
+    ]);
+
+    $this->get($entry->guestPassUrl())
+        ->assertOk()
+        ->assertSee('Summer Festival')
+        ->assertSee('Artist Guest List')
+        ->assertSee('DJ Soundwave 1/1')
+        ->assertSee('<svg', escape: false)
+        ->assertHeader('Cache-Control', 'no-store, private')
+        ->assertHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+});
+
+it('shows a guest-friendly message for an invalid signature', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+
+    $this->get($entry->guestPassUrl().'&tampered=1')
+        ->assertForbidden()
+        ->assertSee('This guest pass link is invalid or has expired.');
+});
+
+it('shows a guest-friendly message for an expired signature', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create();
+    $url = URL::temporarySignedRoute('guest.pass.show', now()->subMinute(), ['entry' => $entry->id]);
+
+    $this->get($url)
+        ->assertForbidden()
+        ->assertSee('This guest pass link is invalid or has expired.');
+});
+
+it('returns 404 when the guest entry has no qr token', function () {
+    $entry = GuestEntry::factory()->for($this->group, 'group')->create([
+        'qr_token' => null,
+    ]);
+    $url = URL::temporarySignedRoute('guest.pass.show', now()->addMinutes(5), ['entry' => $entry->id]);
+
+    $this->get($url)->assertNotFound();
+});
+
+it('returns 404 when the guest list is still a draft', function () {
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create();
+    $draftGuestList = GuestList::factory()
+        ->for($project)
+        ->for($scanner, 'scanner')
+        ->create();
+    $group = GuestGroup::factory()->for($draftGuestList)->create([
+        'guest_count' => 1,
+    ]);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create();
+    $url = URL::temporarySignedRoute('guest.pass.show', now()->addMinutes(5), ['entry' => $entry->id]);
+
+    $this->get($url)->assertNotFound();
+});

--- a/tests/Feature/Mail/GuestInvitationMailTest.php
+++ b/tests/Feature/Mail/GuestInvitationMailTest.php
@@ -51,6 +51,25 @@ it('renders markdown with project name and entry labels', function () {
         ->assertSeeInHtml('present your QR code');
 });
 
+it('renders a browser fallback link for each guest entry', function () {
+    $entry1 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'name' => 'DJ Soundwave',
+        'email' => 'dj@example.com',
+    ]);
+    $entry2 = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
+        'number' => 2,
+        'email' => 'dj@example.com',
+    ]);
+
+    $mail = new GuestInvitationMail($this->guestList, new Collection([$entry1, $entry2]));
+
+    $mail->assertSeeInHtml('If the QR code is not visible in your email app, open this pass in your browser.')
+        ->assertSeeInHtml(e($entry1->guestPassUrl()), escape: false)
+        ->assertSeeInHtml(e($entry2->guestPassUrl()), escape: false)
+        ->assertSeeInHtml('<svg', escape: false);
+});
+
 it('renders entry name when present', function () {
     $entry = GuestEntry::factory()->for($this->group, 'group')->withQrToken()->create([
         'number' => 1,

--- a/tests/Feature/Models/GuestEntryTest.php
+++ b/tests/Feature/Models/GuestEntryTest.php
@@ -3,7 +3,15 @@
 use App\Models\GuestEntry;
 use App\Models\GuestEntryGear;
 use App\Models\GuestGroup;
+use App\Models\GuestList;
+use App\Models\Project;
+use App\Models\ProjectScanner;
 use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\URL;
+
+use function Pest\Laravel\travelTo;
 
 it('creates a guest entry with correct attributes', function () {
     $group = GuestGroup::factory()->create(['label' => 'DJ Soundwave', 'guest_count' => 3]);
@@ -74,4 +82,52 @@ it('nullifies checked_in_by when user is deleted', function () {
     $user->delete();
 
     expect($entry->fresh()->checked_in_by)->toBeNull();
+});
+
+it('generates a signed guest pass URL using scanner end time plus buffer', function () {
+    travelTo(Carbon::parse('2026-04-30 12:00:00'));
+
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create([
+        'ends_at' => Carbon::parse('2026-05-02 01:00:00'),
+    ]);
+    $guestList = GuestList::factory()
+        ->for($project)
+        ->for($scanner, 'scanner')
+        ->confirmed()
+        ->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1, 'label' => 'Artist']);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1]);
+
+    $url = $entry->guestPassUrl();
+
+    parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
+
+    expect(URL::hasValidSignature(Request::create($url)))->toBeTrue()
+        ->and($query['expires'] ?? null)->toBe((string) $scanner->ends_at->addHours(12)->timestamp)
+        ->and($url)->toContain('/guest-pass/'.$entry->id);
+});
+
+it('falls back to a seven-day guest pass expiry when scanner end time is unavailable', function () {
+    travelTo(Carbon::parse('2026-04-30 12:00:00'));
+
+    $project = Project::factory()->create();
+    $scanner = ProjectScanner::factory()->for($project)->create();
+    $guestList = GuestList::factory()
+        ->for($project)
+        ->for($scanner, 'scanner')
+        ->confirmed()
+        ->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1, 'label' => 'Artist']);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1]);
+
+    $entry->load('group.guestList.scanner');
+    $entry->group->guestList->scanner->forceFill(['ends_at' => null]);
+
+    $url = $entry->guestPassUrl();
+
+    parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
+
+    expect(URL::hasValidSignature(Request::create($url)))->toBeTrue()
+        ->and($query['expires'] ?? null)->toBe((string) now()->addDays(7)->timestamp);
 });


### PR DESCRIPTION
## Summary
- add per-entry signed guest pass links to guest invitation emails so recipients can open each QR code in the browser when mail clients strip inline SVGs
- render a read-only public guest pass page with no-store and noindex protections plus a guest-friendly invalid or expired-link response
- cover the new helper, mail, and HTTP flows with focused tests and keep the surrounding guest and public-link regressions green

Closes #193

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Models/GuestEntryTest.php tests/Feature/Mail/GuestInvitationMailTest.php tests/Feature/Http/GuestPassControllerTest.php tests/Feature/Jobs/SendGuestInvitationsJobTest.php tests/Feature/GuestListLifecycleTest.php tests/Feature/Public/VolunteerTicketTest.php tests/Feature/Auth/EmailVerificationTest.php`
- `vendor/bin/sail bin pint --dirty --format agent`
- `bash e2e/setup.sh`
- `vendor/bin/sail npm run test:e2e`