### PR TITLE
Phase 1: Reliability & Lifecycle Hygiene

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #193 complete — guest invitation emails now include per-entry signed browser fallback links with a read-only public guest pass page"
-current_milestone: issue-193-guest-mail-magic-link
+current_focus: "Issue #196 complete — volunteer-admin scanner no longer shows the arrival duplicate state after QR volunteer selection"
+current_milestone: issue-196-scanner-arrival-duplicate-status
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T11:47:11+02:00"
+last_updated: "2026-04-30T13:55:23+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -39,6 +39,7 @@ last_updated: "2026-04-30T11:47:11+02:00"
 | issue-175-announcement-recipient-resilience | Announcement Recipient Resilience | #175 token-backed verified recipient resolution for announcements | m13, m18, m19 | complete |
 | issue-190-portal-announcement-visibility | Portal Announcement Visibility | #190 null-safe volunteer portal announcements + targeted visibility filtering | m15, issue-175-announcement-recipient-resilience | complete |
 | issue-193-guest-mail-magic-link | Guest Mail Magic-Link Fallback | #193 signed browser fallback page for guest invitation QR codes | m12, m15, m19 | complete |
+| issue-196-scanner-arrival-duplicate-status | Scanner Arrival Duplicate Status | #196 volunteer-admin scanners should skip arrival duplicate status while entry-staff behavior stays unchanged | m11, m16 | complete |
 
 ## Artifacts
 
@@ -60,6 +61,7 @@ last_updated: "2026-04-30T11:47:11+02:00"
 | `.tall-pipeline/issue-175-announcement-recipient-resilience.md` | plan+implement+test | issue-175 | Issue #175 plan + implementation tracking for resilient announcement recipients | complete |
 | `.tall-pipeline/issue-190-portal-announcement-visibility.md` | plan+implement+test | issue-190 | Issue #190 tracking for null-safe volunteer portal announcements and targeted visibility | complete |
 | `.tall-pipeline/issue-193-guest-mail-magic-link.md` | plan+implement+test | issue-193 | Issue #193 tracking for guest invitation magic-link QR fallbacks | complete |
+| `.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md` | plan+implement+test | issue-196 | Issue #196 tracking for volunteer-admin scanner duplicate-status regression | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md
+++ b/.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md
@@ -1,0 +1,36 @@
+# Milestone: issue-196-scanner-arrival-duplicate-status — Scanner Arrival Duplicate Status
+
+**GitHub Issue:** [#196](https://github.com/reneweiser/voluntify/issues/196)
+**Features:** #196
+**Dependencies:** m11-scanner, m16-bugfixes
+**Branch:** current workspace
+
+## Plan
+- **Status:** complete
+- **Gate summary:** keep the `entry_staff` arrival duplicate flow unchanged while preventing `volunteer_admin` QR scans from showing the irrelevant duplicate arrival state.
+
+### Scope
+- Update `resources/js/scanner/alpine-scanner.ts` so QR-selected volunteers on `volunteer_admin` scanners stop after loading the volunteer result
+- Preserve the existing `entry_staff` duplicate and ready-to-check-in messaging exactly
+- Add focused Vitest regression coverage for both scanner types and both arrival states
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: add failing QR-selection tests for `volunteer_admin` and `entry_staff` arrival states
+  - [x] GREEN: return early for `volunteer_admin` before the arrival duplicate branch
+  - [x] REFACTOR: keep the change isolated to the existing QR selection flow with no behavior changes outside scanner type branching
+  - [x] Verify: run focused Sail Vitest coverage and a production Vite build
+- **Gate summary:** `volunteer_admin` now always lands on `state = 'result'` with an empty `resultMessage` after QR volunteer selection, while `entry_staff` still shows the existing duplicate and ready messages.
+
+## Test
+- **Status:** complete
+- **Gate summary:** RED confirmed with 2 failing Vitest assertions before the fix. GREEN verified with `vendor/bin/sail npm run test -- --run tests/js/scanner/alpine-scanner.test.ts` and `vendor/bin/sail npm run build`.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Scanner TS | `resources/js/scanner/alpine-scanner.ts` QR volunteer selection flow |
+| Tests | `tests/js/scanner/alpine-scanner.test.ts` |

--- a/app/Console/Commands/PurgePendingDeletionsCommand.php
+++ b/app/Console/Commands/PurgePendingDeletionsCommand.php
@@ -12,11 +12,11 @@ class PurgePendingDeletionsCommand extends Command
 {
     protected $signature = 'app:purge-pending-deletions';
 
-    protected $description = 'Permanently delete projects and events that have been pending deletion for 30+ days';
+    protected $description = 'Permanently delete projects and events that have been pending deletion for more than 7 days';
 
     public function handle(): void
     {
-        $cutoff = now()->subDays(30);
+        $cutoff = now()->subDays(7);
 
         $events = Event::where('deletion_requested_at', '<', $cutoff)->get();
         $eventAction = app(PermanentlyDeleteEvent::class);

--- a/app/Livewire/Events/EmailTemplateEditor.php
+++ b/app/Livewire/Events/EmailTemplateEditor.php
@@ -173,6 +173,7 @@ class EmailTemplateEditor extends Component
             EmailTemplateType::PreShiftReminder24h,
             EmailTemplateType::PreShiftReminder4h => array_merge($common, [
                 'job_name' => 'Aufbau-Team',
+                'relativer_tag' => $type === EmailTemplateType::PreShiftReminder24h ? 'morgen' : 'heute',
                 'shift_date' => $sa->format('d.m.Y'),
                 'shift_time' => $sa->format('H:i').' — '.$ea->format('H:i'),
                 'event_location' => $this->event->location ? "**Ort:** {$this->event->location}" : '',

--- a/app/Livewire/ScannerAuth.php
+++ b/app/Livewire/ScannerAuth.php
@@ -36,11 +36,10 @@ class ScannerAuth extends Component
     {
         $scanner = ProjectScanner::with('project')->where('scanner_token', $scannerToken)->firstOrFail();
 
-        $tz = $scanner->project->timezone ?? 'UTC';
         $this->scannerToken = $scannerToken;
         $this->scannerName = $scanner->name;
-        $this->startsAt = $scanner->starts_at->setTimezone($tz)->format('H:i');
-        $this->endsAt = $scanner->ends_at->setTimezone($tz)->format('H:i');
+        $this->startsAt = $scanner->starts_at->setTimezone($this->projectTimezone($scanner))->format('H:i');
+        $this->endsAt = $scanner->ends_at->setTimezone($this->projectTimezone($scanner))->format('H:i');
 
         if ($scanner->isExpired()) {
             $this->errorMessage = 'Das Scanner-Fenster ist abgelaufen.';
@@ -50,7 +49,7 @@ class ScannerAuth extends Component
         }
 
         if ($scanner->isScheduled()) {
-            $this->errorMessage = 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$scanner->starts_at->format('H:i').'.';
+            $this->errorMessage = 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$this->formattedStartTime($scanner).'.';
             $this->formDisabled = true;
 
             return;
@@ -86,7 +85,7 @@ class ScannerAuth extends Component
             if ($scanner->isExpired() || $scanner->isScheduled()) {
                 $this->errorMessage = $scanner->isExpired()
                     ? 'Das Scanner-Fenster ist abgelaufen.'
-                    : 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$scanner->starts_at->format('H:i').'.';
+                    : 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$this->formattedStartTime($scanner).'.';
                 $this->formDisabled = true;
 
                 return;
@@ -111,7 +110,7 @@ class ScannerAuth extends Component
 
             match ($result) {
                 AuthenticationResult::Expired => $this->errorMessage = 'Das Scanner-Fenster ist abgelaufen.',
-                AuthenticationResult::NotYetActive => $this->errorMessage = 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$scanner->starts_at->format('H:i').'.',
+                AuthenticationResult::NotYetActive => $this->errorMessage = 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um '.$this->formattedStartTime($scanner).'.',
                 AuthenticationResult::InvalidCode => $this->errorMessage = 'Ungültiger Code. Bitte versuche es erneut.',
                 default => null,
             };
@@ -137,5 +136,15 @@ class ScannerAuth extends Component
         ]);
 
         $this->redirect(route('scanner.app', $this->scannerToken));
+    }
+
+    private function projectTimezone(ProjectScanner $scanner): string
+    {
+        return $scanner->project->timezone ?: 'UTC';
+    }
+
+    private function formattedStartTime(ProjectScanner $scanner): string
+    {
+        return $scanner->starts_at->setTimezone($this->projectTimezone($scanner))->format('H:i');
     }
 }

--- a/app/Notifications/PreShiftReminder.php
+++ b/app/Notifications/PreShiftReminder.php
@@ -37,6 +37,8 @@ class PreShiftReminder extends Notification implements ShouldQueue
     {
         $this->shift->loadMissing('volunteerJob');
         $job = $this->shift->volunteerJob;
+        $timezone = $this->event->project->timezone ?? 'UTC';
+        $shiftStartsAt = $this->shift->starts_at?->copy()->setTimezone($timezone);
 
         $cheatSheetUrl = $job->instructions
             ? route('events.jobs.cheat-sheet', ['publicToken' => $this->event->public_token, 'jobId' => $job->id])
@@ -53,9 +55,10 @@ class PreShiftReminder extends Notification implements ShouldQueue
                 // Legacy placeholders (backwards compatibility)
                 'volunteer_name' => $notifiable->full_name,
                 'event_name' => $this->event->name,
+                'relativer_tag' => $this->relativeDayLabel($timezone),
                 'job_name' => $job->name,
-                'shift_date' => $this->shift->shift_date->setTimezone($this->event->project->timezone ?? 'UTC')->format('d.m.Y'),
-                'shift_time' => $this->shift->displayTimeRange($this->event->project->timezone ?? 'UTC'),
+                'shift_date' => ($shiftStartsAt ?? $this->shift->shift_date->copy()->setTimezone($timezone))->format('d.m.Y'),
+                'shift_time' => $this->shift->displayTimeRange($timezone),
                 'event_location' => $this->event->location ? "**Ort:** {$this->event->location}" : '',
                 'cheat_sheet_url' => $cheatSheetUrl ? "[Aufgaben-Infos anzeigen]({$cheatSheetUrl})" : '',
                 'portal_link' => '', // Will be set when portal URL is available
@@ -76,5 +79,26 @@ class PreShiftReminder extends Notification implements ShouldQueue
         }
 
         return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
+    }
+
+    private function relativeDayLabel(string $timezone): string
+    {
+        $shiftStartsAt = $this->shift->starts_at?->copy()->setTimezone($timezone);
+
+        if ($shiftStartsAt === null) {
+            return 'am '.$this->shift->shift_date->copy()->setTimezone($timezone)->format('d.m.Y');
+        }
+
+        $today = now()->setTimezone($timezone);
+
+        if ($shiftStartsAt->isSameDay($today)) {
+            return 'heute';
+        }
+
+        if ($shiftStartsAt->isSameDay($today->copy()->addDay())) {
+            return 'morgen';
+        }
+
+        return 'am '.$shiftStartsAt->format('d.m.Y');
     }
 }

--- a/app/Services/EmailTemplateRenderer.php
+++ b/app/Services/EmailTemplateRenderer.php
@@ -19,12 +19,12 @@ class EmailTemplateRenderer
             'body' => "Hallo {{vorname}}!\n\nDu bist für **{{event_name}}** angemeldet.\n\n**Deine Schichten:**\n{{shifts_summary}}\n{{event_location}}\n\nDu erhältst dein Ticket mit QR-Code über einen separaten Link.\n\nVielen Dank für deine Unterstützung!",
         ],
         'pre_shift_reminder_24h' => [
-            'subject' => 'Erinnerung: Deine Schicht bei {{event_name}} ist morgen',
-            'body' => "Hallo {{vorname}}!\n\nDies ist eine Erinnerung, dass deine Schicht bei **{{event_name}}** morgen stattfindet.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis morgen!",
+            'subject' => 'Erinnerung: Deine Schicht bei {{event_name}} ist {{relativer_tag}}',
+            'body' => "Hallo {{vorname}}!\n\nDies ist eine Erinnerung, dass deine Schicht bei **{{event_name}}** {{relativer_tag}} stattfindet.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis bald!",
         ],
         'pre_shift_reminder_4h' => [
             'subject' => 'Erinnerung: Deine Schicht bei {{event_name}} beginnt bald',
-            'body' => "Hallo {{vorname}}!\n\nDeine Schicht bei **{{event_name}}** beginnt in wenigen Stunden.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis gleich!",
+            'body' => "Hallo {{vorname}}!\n\nDeine Schicht bei **{{event_name}}** beginnt {{relativer_tag}} in wenigen Stunden.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis gleich!",
         ],
         'email_verification' => [
             'subject' => 'Bestätige deine E-Mail für {{event_name}}',
@@ -123,6 +123,7 @@ class EmailTemplateRenderer
                 'nachname',
                 'volunteer_name', // Legacy
                 'event_name',
+                'relativer_tag',
                 'job_name',
                 'shift_date',
                 'shift_time',

--- a/e2e/pending-deletion-retention.spec.ts
+++ b/e2e/pending-deletion-retention.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type Fixtures = {
+    deletionProjectId: number;
+    deletionEventId: number;
+    pendingDeletionProjectId: number;
+    pendingDeletionEventId: number;
+    pendingDeletionProjectDate: string;
+    pendingDeletionEventDate: string;
+};
+
+async function login(page: Page): Promise<void> {
+    await page.goto('/login');
+    await page.getByPlaceholder('email@example.com').fill('test@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+}
+
+async function loadFixtures(page: Page): Promise<Fixtures> {
+    await page.goto('/e2e-fixtures.json');
+
+    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
+}
+
+test('event deletion UI uses the 7-day retention copy', async ({ page }) => {
+    const fixtures = await loadFixtures(page);
+
+    await login(page);
+    await page.goto(`/admin/events/${fixtures.deletionEventId}`);
+
+    await page.getByRole('button', { name: 'Löschen' }).click();
+    await expect(page.getByText('Dieses Event wird in 7 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.')).toBeVisible();
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+
+    await page.goto(`/admin/events/${fixtures.pendingDeletionEventId}`);
+    await expect(page.getByText(`Dieses Event ist zur Löschung vorgemerkt und wird am ${fixtures.pendingDeletionEventDate} endgültig gelöscht.`)).toBeVisible();
+});
+
+test('project deletion UI uses the 7-day retention copy', async ({ page }) => {
+    const fixtures = await loadFixtures(page);
+
+    await login(page);
+    await page.goto(`/admin/projects/${fixtures.deletionProjectId}`);
+
+    await page.getByRole('button', { name: 'Löschen' }).click();
+    await expect(page.getByText('Das Projekt wird in 7 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.')).toBeVisible();
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+
+    await page.goto(`/admin/projects/${fixtures.pendingDeletionProjectId}`);
+    await expect(page.getByText(`Dieses Projekt ist zur Löschung vorgemerkt und wird am ${fixtures.pendingDeletionProjectDate} endgültig gelöscht.`)).toBeVisible();
+});

--- a/e2e/pre-shift-reminder-relative-day.spec.ts
+++ b/e2e/pre-shift-reminder-relative-day.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+type MailpitAddress = {
+    Address: string;
+};
+
+type MailpitMessage = {
+    Subject?: string;
+    Snippet?: string;
+    To?: MailpitAddress[];
+};
+
+type MailpitInbox = {
+    messages?: MailpitMessage[];
+};
+
+const mailpitBaseUrl = 'http://mailpit:8025';
+
+test('24-hour pre-shift reminders use today and tomorrow wording', async ({ request }) => {
+    await expect.poll(async () => {
+        const response = await request.get(`${mailpitBaseUrl}/api/v1/messages`);
+        const inbox = await response.json() as MailpitInbox;
+
+        return inbox.messages?.length ?? 0;
+    }).toBeGreaterThanOrEqual(2);
+
+    const response = await request.get(`${mailpitBaseUrl}/api/v1/messages`);
+    const inbox = await response.json() as MailpitInbox;
+
+    const todayReminder = inbox.messages?.find((message) => {
+        return message.To?.some((recipient) => recipient.Address === 'reminder-today@example.com');
+    });
+
+    const tomorrowReminder = inbox.messages?.find((message) => {
+        return message.To?.some((recipient) => recipient.Address === 'reminder-tomorrow@example.com');
+    });
+
+    expect(todayReminder?.Subject).toContain('ist heute');
+    expect(todayReminder?.Snippet).toContain('heute stattfindet');
+
+    expect(tomorrowReminder?.Subject).toContain('ist morgen');
+    expect(tomorrowReminder?.Snippet).toContain('morgen stattfindet');
+});

--- a/e2e/scanner-auth-timezone.spec.ts
+++ b/e2e/scanner-auth-timezone.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type Fixtures = {
+    scannerAuthBerlinToken: string;
+    scannerAuthBerlinStartLabel: string;
+    scannerAuthUtcToken: string;
+    scannerAuthUtcStartLabel: string;
+};
+
+async function loadFixtures(page: Page): Promise<Fixtures> {
+    await page.goto('/e2e-fixtures.json');
+
+    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
+}
+
+test('scheduled scanner auth shows the project timezone start time', async ({ page }) => {
+    const fixtures = await loadFixtures(page);
+
+    await page.goto(`/s/${fixtures.scannerAuthBerlinToken}`);
+
+    await expect(page.getByText(`Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um ${fixtures.scannerAuthBerlinStartLabel}.`)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'E2E Berlin Scheduled Scanner' })).toBeVisible();
+});
+
+test('scheduled scanner auth falls back to UTC when the project timezone is empty', async ({ page }) => {
+    const fixtures = await loadFixtures(page);
+
+    await page.goto(`/s/${fixtures.scannerAuthUtcToken}`);
+
+    await expect(page.getByText(`Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um ${fixtures.scannerAuthUtcStartLabel}.`)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'E2E UTC Scheduled Scanner' })).toBeVisible();
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -89,7 +89,10 @@ curl -s -X DELETE http://localhost:8025/api/v1/messages
 # 7. Create deterministic Volunteer Admin scanner fixture for shift-list E2E
 echo "Creating volunteer-admin shift-list E2E fixture..."
 vendor/bin/sail artisan tinker --execute="
+  use App\Actions\SendPreShiftReminders;
+  use App\Enums\ArrivalMethod;
   use App\Enums\GearItemType;
+  use App\Enums\ReminderWindow;
   use App\Enums\ScannerMode;
   use App\Enums\ScannerType;
   use App\Actions\GenerateTicket;
@@ -187,9 +190,20 @@ vendor/bin/sail artisan tinker --execute="
       'phone' => '+491701234567',
     ]);
 
-    Ticket::factory()->create([
+    \$lisaTicket = Ticket::factory()->create([
       'project_id' => \$project->id,
       'volunteer_id' => \$lisa->id,
+    ]);
+
+    app(RefreshTicketJwt::class)->execute(\$lisaTicket);
+
+    \App\Models\EventArrival::factory()->create([
+      'ticket_id' => \$lisaTicket->id,
+      'volunteer_id' => \$lisa->id,
+      'event_id' => \$event->id,
+      'scanned_by' => null,
+      'scanned_at' => now()->setTime(10, 0),
+      'method' => ArrivalMethod::QrScan,
     ]);
 
     ShiftSignup::factory()->create([
@@ -391,12 +405,6 @@ vendor/bin/sail artisan tinker --execute="
       'ends_at' => now()->addHours(4),
     ]);
 
-    file_put_contents(base_path('public/e2e-fixtures.json'), json_encode([
-      'entryPoolProjectId' => \$entryPoolProject->id,
-      'entryPoolEntryEventId' => \$entryEvent->id,
-      'entryPoolPoolEventId' => \$poolEvent->id,
-    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-
     \App\Models\ProjectScanner::where('scanner_token', 'e2e-entry-manual-lookup-token')->delete();
     \App\Models\Event::whereIn('name', [
       'E2E Entry Manual Event',
@@ -467,6 +475,202 @@ vendor/bin/sail artisan tinker --execute="
       'starts_at' => now()->subHour(),
       'ends_at' => now()->addHours(4),
     ]);
+
+    \App\Models\ProjectScanner::whereIn('scanner_token', [
+      'e2e-berlin-scheduled-token',
+      'e2e-utc-scheduled-token',
+    ])->delete();
+    \App\Models\Event::whereIn('name', [
+      'E2E Berlin Scheduled Event',
+      'E2E UTC Scheduled Event',
+    ])->delete();
+    \App\Models\Project::whereIn('name', [
+      'E2E Berlin Scheduled Scanner Project',
+      'E2E UTC Scheduled Scanner Project',
+    ])->delete();
+
+    \$berlinProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Berlin Scheduled Scanner Project',
+      'timezone' => 'Europe/Berlin',
+    ]);
+
+    \$berlinEvent = Event::factory()->for(\$organization)->for(\$berlinProject)->published()->create([
+      'name' => 'E2E Berlin Scheduled Event',
+      'slug' => 'e2e-berlin-scheduled-event',
+      'starts_at' => now()->addDay(),
+      'ends_at' => now()->addDay()->addHours(4),
+    ]);
+
+    \$berlinScannerStart = now('Europe/Berlin')->addDay()->setTime(16, 0)->utc();
+    \$berlinScannerEnd = now('Europe/Berlin')->addDay()->setTime(20, 0)->utc();
+
+    ProjectScanner::factory()->create([
+      'project_id' => \$berlinProject->id,
+      'entry_event_id' => \$berlinEvent->id,
+      'pool_event_ids' => [\$berlinEvent->id],
+      'name' => 'E2E Berlin Scheduled Scanner',
+      'type' => ScannerType::EntryStaff,
+      'modes' => [ScannerMode::Checkin->value],
+      'scanner_token' => 'e2e-berlin-scheduled-token',
+      'auth_code' => '666666',
+      'starts_at' => \$berlinScannerStart,
+      'ends_at' => \$berlinScannerEnd,
+    ]);
+
+    \$utcProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E UTC Scheduled Scanner Project',
+      'timezone' => '',
+    ]);
+
+    \$utcEvent = Event::factory()->for(\$organization)->for(\$utcProject)->published()->create([
+      'name' => 'E2E UTC Scheduled Event',
+      'slug' => 'e2e-utc-scheduled-event',
+      'starts_at' => now()->addDay(),
+      'ends_at' => now()->addDay()->addHours(4),
+    ]);
+
+    \$utcScannerStart = now()->addDay()->setTime(14, 0);
+    \$utcScannerEnd = now()->addDay()->setTime(18, 0);
+
+    ProjectScanner::factory()->create([
+      'project_id' => \$utcProject->id,
+      'entry_event_id' => \$utcEvent->id,
+      'pool_event_ids' => [\$utcEvent->id],
+      'name' => 'E2E UTC Scheduled Scanner',
+      'type' => ScannerType::EntryStaff,
+      'modes' => [ScannerMode::Checkin->value],
+      'scanner_token' => 'e2e-utc-scheduled-token',
+      'auth_code' => '777777',
+      'starts_at' => \$utcScannerStart,
+      'ends_at' => \$utcScannerEnd,
+    ]);
+
+    \App\Models\Event::whereIn('name', [
+      'E2E Pending Deletion Event',
+      'E2E Deletion Modal Event',
+    ])->delete();
+    \App\Models\Project::whereIn('name', [
+      'E2E Pending Deletion Project',
+      'E2E Deletion Modal Project',
+    ])->delete();
+
+    \$pendingDeletionProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Pending Deletion Project',
+      'deletion_requested_at' => now()->subDays(2),
+    ]);
+
+    \$pendingDeletionEvent = Event::factory()->for(\$organization)->for(\$pendingDeletionProject)->archived()->create([
+      'name' => 'E2E Pending Deletion Event',
+      'slug' => 'e2e-pending-deletion-event',
+      'deletion_requested_at' => now()->subDays(2),
+    ]);
+
+    \$deletionModalProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Deletion Modal Project',
+    ]);
+
+    \$deletionModalEvent = Event::factory()->for(\$organization)->for(\$deletionModalProject)->archived()->create([
+      'name' => 'E2E Deletion Modal Event',
+      'slug' => 'e2e-deletion-modal-event',
+    ]);
+
+    \$fixedReminderNow = \Carbon\Carbon::parse('2026-07-01 07:00:00', 'UTC');
+    \Carbon\Carbon::setTestNow(\$fixedReminderNow);
+
+    \App\Models\Event::where('name', 'E2E Reminder Event')->delete();
+    \App\Models\Project::where('name', 'E2E Reminder Project')->delete();
+    \App\Models\Volunteer::whereIn('email', [
+      'reminder-today@example.com',
+      'reminder-tomorrow@example.com',
+    ])->delete();
+
+    \$reminderProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Reminder Project',
+      'timezone' => 'Europe/Berlin',
+    ]);
+
+    \$reminderEvent = Event::factory()->for(\$organization)->for(\$reminderProject)->published()->create([
+      'name' => 'E2E Reminder Event',
+      'slug' => 'e2e-reminder-event',
+      'starts_at' => \Carbon\Carbon::parse('2026-07-01 09:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-07-02 00:00:00', 'UTC'),
+    ]);
+
+    \$reminderTodayJob = VolunteerJob::factory()->create([
+      'event_id' => \$reminderEvent->id,
+      'name' => 'Today Reminder Job',
+    ]);
+
+    \$reminderTomorrowJob = VolunteerJob::factory()->create([
+      'event_id' => \$reminderEvent->id,
+      'name' => 'Tomorrow Reminder Job',
+    ]);
+
+    \$todayReminderShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reminderTodayJob->id,
+      'shift_date' => '2026-07-01',
+      'starts_at' => \Carbon\Carbon::parse('2026-07-01 15:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-07-01 17:00:00', 'UTC'),
+      'display_text' => 'Jul 01, 17:00 - 19:00',
+    ]);
+
+    \$tomorrowReminderShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reminderTomorrowJob->id,
+      'shift_date' => '2026-07-02',
+      'starts_at' => \Carbon\Carbon::parse('2026-07-01 22:30:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-07-02 00:30:00', 'UTC'),
+      'display_text' => 'Jul 02, 00:30 - 02:30',
+    ]);
+
+    \$todayReminderVolunteer = Volunteer::factory()->verified()->for(\$reminderProject)->create([
+      'first_name' => 'Heute',
+      'last_name' => 'Erinnerung',
+      'email' => 'reminder-today@example.com',
+      'phone' => '+491700000100',
+    ]);
+
+    \$tomorrowReminderVolunteer = Volunteer::factory()->verified()->for(\$reminderProject)->create([
+      'first_name' => 'Morgen',
+      'last_name' => 'Erinnerung',
+      'email' => 'reminder-tomorrow@example.com',
+      'phone' => '+491700000200',
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$todayReminderVolunteer->id,
+      'shift_id' => \$todayReminderShift->id,
+      'notification_24h_sent' => false,
+      'notification_4h_sent' => false,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$tomorrowReminderVolunteer->id,
+      'shift_id' => \$tomorrowReminderShift->id,
+      'notification_24h_sent' => false,
+      'notification_4h_sent' => false,
+    ]);
+
+    app(SendPreShiftReminders::class)->execute(ReminderWindow::TwentyFourHour);
+
+    \Carbon\Carbon::setTestNow();
+
+    file_put_contents(base_path('public/e2e-fixtures.json'), json_encode([
+      'entryPoolProjectId' => \$entryPoolProject->id,
+      'entryPoolEntryEventId' => \$entryEvent->id,
+      'entryPoolPoolEventId' => \$poolEvent->id,
+      'scannerAuthBerlinToken' => 'e2e-berlin-scheduled-token',
+      'scannerAuthBerlinStartLabel' => \$berlinScannerStart->copy()->setTimezone('Europe/Berlin')->format('H:i'),
+      'scannerAuthUtcToken' => 'e2e-utc-scheduled-token',
+      'scannerAuthUtcStartLabel' => \$utcScannerStart->format('H:i'),
+      'deletionProjectId' => \$deletionModalProject->id,
+      'deletionEventId' => \$deletionModalEvent->id,
+      'pendingDeletionProjectId' => \$pendingDeletionProject->id,
+      'pendingDeletionEventId' => \$pendingDeletionEvent->id,
+      'pendingDeletionProjectDate' => \$pendingDeletionProject->deletion_requested_at->copy()->addDays(7)->format('d.m.Y'),
+      'pendingDeletionEventDate' => \$pendingDeletionEvent->deletion_requested_at->copy()->addDays(7)->format('d.m.Y'),
+      'reminderTodayEmail' => 'reminder-today@example.com',
+      'reminderTomorrowEmail' => 'reminder-tomorrow@example.com',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   });
 
   echo 'Volunteer admin shift-list fixture created';

--- a/e2e/va-scanner-arrival-status.spec.ts
+++ b/e2e/va-scanner-arrival-status.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    viewport: { width: 430, height: 720 },
+});
+
+test('volunteer admin scanner skips the entry arrival duplicate status after QR scan', async ({ page }) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+
+    await page.goto('/s/e2e-va-shift-list-token');
+
+    await page.getByLabel('Enter 6-digit code').fill('222222');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-va-shift-list-token\/scan$/);
+
+    await expect.poll(async () => {
+        return page.locator('[x-data]').evaluate((element) => {
+            const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+            return component?._volunteers.find((entry: { email: string }) => entry.email === 'lisa-shifts@example.com')?.ticket?.jwt_token ?? '';
+        });
+    }).toBeTruthy();
+
+    const qrToken = await page.locator('[x-data]').evaluate((element) => {
+        const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+        return component?._volunteers.find((entry: { email: string }) => entry.email === 'lisa-shifts@example.com')?.ticket?.jwt_token ?? '';
+    });
+
+    const scannerState = await page.locator('[x-data]').evaluate(async (element, token) => {
+        const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+        if (!component) {
+            throw new Error('Scanner Alpine component not found.');
+        }
+
+        await component._onQrDetected(token);
+
+        return {
+            state: component.state,
+            resultMessage: component.resultMessage,
+        };
+    }, qrToken);
+
+    expect(scannerState).toEqual({
+        state: 'result',
+        resultMessage: '',
+    });
+
+    const scannerTab = page.locator('#tabpanel-va-scanner');
+
+    await expect(scannerTab.getByText('Lisa Mueller').first()).toBeVisible();
+    await expect(scannerTab.getByText('lisa-shifts@example.com')).toBeVisible();
+    await expect(scannerTab.getByRole('heading', { name: 'Shifts' })).toBeVisible();
+    await expect(scannerTab.getByRole('heading', { name: 'Gear' })).toBeVisible();
+    await expect(scannerTab.locator('[role="alert"]')).not.toBeVisible();
+    await expect(scannerTab.getByText(/Already checked in at/i)).toHaveCount(0);
+});

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -330,6 +330,14 @@ export function scannerApp(config: ScannerAppConfig) {
             this.guestResult = null;
 
             if (options.fromQr) {
+                if (this.scannerType === 'volunteer_admin') {
+                    this.state = 'result';
+                    this.resultMessage = '';
+                    this.errorMessage = '';
+
+                    return;
+                }
+
                 const alreadyArrived = this.hasArrivalForEntryEvent(volunteer.id);
 
                 if (alreadyArrived) {

--- a/resources/views/livewire/events/event-show.blade.php
+++ b/resources/views/livewire/events/event-show.blade.php
@@ -303,7 +303,7 @@
     <flux:modal wire:model="showDeleteModal" focusable class="max-w-lg">
         <div class="space-y-4">
             <flux:heading size="lg">{{ __('Event löschen') }}</flux:heading>
-            <flux:text>{{ __('Dieses Event wird in 30 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.') }}</flux:text>
+            <flux:text>{{ __('Dieses Event wird in 7 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.') }}</flux:text>
             <flux:input type="password" wire:model="deletePassword" :label="__('Passwort bestätigen')" :placeholder="__('Dein aktuelles Passwort')" />
             @error('deletePassword')
                 <flux:text class="text-red-500 text-sm">{{ $message }}</flux:text>

--- a/resources/views/livewire/events/event-show.blade.php
+++ b/resources/views/livewire/events/event-show.blade.php
@@ -120,7 +120,7 @@
     {{-- Pending deletion warning --}}
     @if ($event->isPendingDeletion())
         <flux:callout variant="warning" class="mb-4">
-            {{ __('Dieses Event ist zur Löschung vorgemerkt und wird am :date endgültig gelöscht.', ['date' => $event->deletion_requested_at->addDays(30)->format('d.m.Y')]) }}
+            {{ __('Dieses Event ist zur Löschung vorgemerkt und wird am :date endgültig gelöscht.', ['date' => $event->deletion_requested_at->addDays(7)->format('d.m.Y')]) }}
         </flux:callout>
     @endif
 

--- a/resources/views/livewire/events/project-show.blade.php
+++ b/resources/views/livewire/events/project-show.blade.php
@@ -33,7 +33,7 @@
     {{-- Pending deletion warning --}}
     @if ($project->isPendingDeletion())
         <flux:callout variant="warning" class="mb-6">
-            {{ __('Dieses Projekt ist zur Löschung vorgemerkt und wird am :date endgültig gelöscht.', ['date' => $project->deletion_requested_at->addDays(30)->format('d.m.Y')]) }}
+            {{ __('Dieses Projekt ist zur Löschung vorgemerkt und wird am :date endgültig gelöscht.', ['date' => $project->deletion_requested_at->addDays(7)->format('d.m.Y')]) }}
         </flux:callout>
     @endif
 

--- a/resources/views/livewire/events/project-show.blade.php
+++ b/resources/views/livewire/events/project-show.blade.php
@@ -326,7 +326,7 @@
     <flux:modal wire:model="showDeleteModal" focusable class="max-w-lg">
         <div class="space-y-4">
             <flux:heading size="lg">{{ __('Projekt löschen') }}</flux:heading>
-            <flux:text>{{ __('Das Projekt wird in 30 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.') }}</flux:text>
+            <flux:text>{{ __('Das Projekt wird in 7 Tagen endgültig gelöscht. Du kannst es in dieser Zeit jederzeit wiederherstellen.') }}</flux:text>
             <flux:input type="password" wire:model="deletePassword" :label="__('Passwort bestätigen')" :placeholder="__('Dein aktuelles Passwort')" />
             @error('deletePassword')
                 <flux:text class="text-red-500 text-sm">{{ $message }}</flux:text>

--- a/tests/Feature/Commands/PurgePendingDeletionsTest.php
+++ b/tests/Feature/Commands/PurgePendingDeletionsTest.php
@@ -12,10 +12,10 @@ use App\Models\ShiftSignup;
 use App\Models\Volunteer;
 use App\Models\VolunteerJob;
 
-it('purges projects pending deletion for 30+ days', function () {
+it('purges projects pending deletion for more than 7 days', function () {
     $org = Organization::factory()->create();
     $project = Project::factory()->for($org)->create([
-        'deletion_requested_at' => now()->subDays(31),
+        'deletion_requested_at' => now()->subDays(8),
     ]);
 
     $this->artisan('app:purge-pending-deletions')
@@ -24,10 +24,10 @@ it('purges projects pending deletion for 30+ days', function () {
     expect(Project::find($project->id))->toBeNull();
 });
 
-it('does not purge projects pending deletion for less than 30 days', function () {
+it('does not purge projects pending deletion within 7 days', function () {
     $org = Organization::factory()->create();
     $project = Project::factory()->for($org)->create([
-        'deletion_requested_at' => now()->subDays(15),
+        'deletion_requested_at' => now()->subDays(3),
     ]);
 
     $this->artisan('app:purge-pending-deletions')
@@ -36,11 +36,11 @@ it('does not purge projects pending deletion for less than 30 days', function ()
     expect(Project::find($project->id))->not->toBeNull();
 });
 
-it('purges events pending deletion for 30+ days', function () {
+it('purges events pending deletion for more than 7 days', function () {
     $org = Organization::factory()->create();
     $project = Project::factory()->for($org)->create();
     $event = Event::factory()->for($org)->for($project)->create([
-        'deletion_requested_at' => now()->subDays(31),
+        'deletion_requested_at' => now()->subDays(8),
     ]);
 
     $this->artisan('app:purge-pending-deletions')
@@ -49,11 +49,11 @@ it('purges events pending deletion for 30+ days', function () {
     expect(Event::find($event->id))->toBeNull();
 });
 
-it('does not purge events pending deletion for less than 30 days', function () {
+it('does not purge events pending deletion within 7 days', function () {
     $org = Organization::factory()->create();
     $project = Project::factory()->for($org)->create();
     $event = Event::factory()->for($org)->for($project)->create([
-        'deletion_requested_at' => now()->subDays(10),
+        'deletion_requested_at' => now()->subDays(3),
     ]);
 
     $this->artisan('app:purge-pending-deletions')
@@ -68,10 +68,22 @@ it('reports no work when nothing to purge', function () {
         ->expectsOutputToContain('No pending deletions to purge.');
 });
 
+it('does not purge projects at exactly 7 days', function () {
+    $org = Organization::factory()->create();
+    $project = Project::factory()->for($org)->create([
+        'deletion_requested_at' => now()->subDays(7),
+    ]);
+
+    $this->artisan('app:purge-pending-deletions')
+        ->assertSuccessful();
+
+    expect(Project::find($project->id))->not->toBeNull();
+});
+
 it('cascades deletion of all child records when purging a project', function () {
     $org = Organization::factory()->create();
     $project = Project::factory()->for($org)->create([
-        'deletion_requested_at' => now()->subDays(31),
+        'deletion_requested_at' => now()->subDays(8),
     ]);
 
     $event = Event::factory()->for($org)->for($project)->create();
@@ -97,18 +109,4 @@ it('cascades deletion of all child records when purging a project', function () 
         ->and(ProjectScanner::find($scanner->id))->toBeNull()
         ->and(HintText::find($hintText->id))->toBeNull()
         ->and(Announcement::find($announcement->id))->toBeNull();
-});
-
-it('does not purge project at exactly 30 days (strict greater-than boundary)', function () {
-    $org = Organization::factory()->create();
-    $project = Project::factory()->for($org)->create([
-        'deletion_requested_at' => now()->subDays(30),
-    ]);
-
-    $this->artisan('app:purge-pending-deletions')
-        ->assertSuccessful();
-
-    // The command uses strict < comparison: subDays(30) means exactly 30 days,
-    // which is NOT less than the cutoff of subDays(30). Purge requires >30 days.
-    expect(Project::find($project->id))->not->toBeNull();
 });

--- a/tests/Feature/Events/EmailTemplateEditorTest.php
+++ b/tests/Feature/Events/EmailTemplateEditorTest.php
@@ -151,6 +151,17 @@ it('shows correct available placeholders for new types [#55]', function () {
         ->and($placeholders)->toContain('portal_link');
 });
 
+it('shows relativer_tag in pre-shift reminder placeholders', function (EmailTemplateType $type) {
+    $component = Livewire::actingAs($this->user)
+        ->test(EmailTemplateEditor::class, ['eventId' => $this->event->id])
+        ->set('selectedType', $type->value);
+
+    expect($component->instance()->availablePlaceholders())->toContain('relativer_tag');
+})->with([
+    EmailTemplateType::PreShiftReminder24h,
+    EmailTemplateType::PreShiftReminder4h,
+]);
+
 it('preview renders with German sample data for new types [#55]', function () {
     Livewire::actingAs($this->user)
         ->test(EmailTemplateEditor::class, ['eventId' => $this->event->id])

--- a/tests/Feature/Livewire/Events/EventShowTest.php
+++ b/tests/Feature/Livewire/Events/EventShowTest.php
@@ -95,3 +95,11 @@ it('confirms republish without organizer note', function () {
         return $job->organizerNote === null;
     });
 });
+
+it('shows the 7-day event deletion banner', function () {
+    $this->event->update(['deletion_requested_at' => now()->subDays(2)]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(EventShow::class, ['eventId' => $this->event->id])
+        ->assertSee($this->event->deletion_requested_at->copy()->addDays(7)->format('d.m.Y'));
+});

--- a/tests/Feature/Livewire/ProjectShowTest.php
+++ b/tests/Feature/Livewire/ProjectShowTest.php
@@ -68,6 +68,14 @@ it('restores a pending-deletion project', function () {
     expect($this->project->refresh()->isPendingDeletion())->toBeFalse();
 });
 
+it('shows the 7-day project deletion banner', function () {
+    $this->project->update(['deletion_requested_at' => now()->subDays(2)]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ProjectShow::class, ['projectId' => $this->project->id])
+        ->assertSee($this->project->deletion_requested_at->copy()->addDays(7)->format('d.m.Y'));
+});
+
 it('shows public link', function () {
     Livewire::actingAs($this->organizer)
         ->test(ProjectShow::class, ['projectId' => $this->project->id])

--- a/tests/Feature/Livewire/ScannerAuthEdgeCasesTest.php
+++ b/tests/Feature/Livewire/ScannerAuthEdgeCasesTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\ScannerAuth;
+use App\Models\Project;
 use App\Models\ProjectScanner;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Hash;
@@ -137,15 +138,31 @@ it('shows not-yet-active message and disables form for scheduled scanner', funct
         ->assertSee('noch nicht aktiv');
 });
 
-it('shows not-yet-active message with start time', function () {
-    $scanner = ProjectScanner::factory()->create([
-        'starts_at' => Carbon::parse('2026-07-01 14:30:00'),
-        'ends_at' => Carbon::parse('2026-07-01 18:00:00'),
+it('formats the scheduled mount message in the project timezone', function () {
+    $scanner = ProjectScanner::factory()->for(
+        Project::factory()->create(['timezone' => 'Europe/Berlin'])
+    )->create([
+        'starts_at' => Carbon::parse('2026-07-01 12:30:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-07-01 16:00:00', 'UTC'),
     ]);
 
     Livewire::test(ScannerAuth::class, ['scannerToken' => $scanner->scanner_token])
         ->assertSet('formDisabled', true)
-        ->assertSee('14:30');
+        ->assertSet('errorMessage', 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um 14:30.')
+        ->assertDontSee('12:30');
+});
+
+it('falls back to UTC for the scheduled mount message when the project has no timezone', function () {
+    $scanner = ProjectScanner::factory()->for(
+        Project::factory()->create(['timezone' => ''])
+    )->create([
+        'starts_at' => Carbon::parse('2026-07-01 12:30:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-07-01 16:00:00', 'UTC'),
+    ]);
+
+    Livewire::test(ScannerAuth::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSet('formDisabled', true)
+        ->assertSet('errorMessage', 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um 12:30.');
 });
 
 it('shows distinct error when scanner expires during auth attempt', function () {
@@ -221,6 +238,50 @@ it('shows timing message instead of rate limit message when scanner is not activ
 
     expect($component->get('errorMessage'))->toContain('abgelaufen');
     expect($component->get('errorMessage'))->not->toContain('Zu viele Versuche');
+});
+
+it('formats the scheduled rate-limit message in the project timezone', function () {
+    $scanner = ProjectScanner::factory()->for(
+        Project::factory()->create(['timezone' => 'Europe/Berlin'])
+    )->create([
+        'auth_code' => '123456',
+        'starts_at' => Carbon::parse('2026-07-01 12:30:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-07-01 16:00:00', 'UTC'),
+    ]);
+
+    $component = Livewire::test(ScannerAuth::class, ['scannerToken' => $scanner->scanner_token]);
+    $sessionKey = 'scanner_auth:'.$scanner->scanner_token.':'.session()->getId();
+
+    for ($i = 0; $i < 5; $i++) {
+        RateLimiter::hit($sessionKey, 1800);
+    }
+
+    $component
+        ->set('authCode', '123456')
+        ->call('authenticate')
+        ->assertSet('formDisabled', true)
+        ->assertSet('errorMessage', 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um 14:30.');
+});
+
+it('formats the authenticate not-yet-active message in the project timezone', function () {
+    $scanner = ProjectScanner::factory()->for(
+        Project::factory()->create(['timezone' => 'Europe/Berlin'])
+    )->create([
+        'auth_code' => '123456',
+        'starts_at' => Carbon::parse('2026-07-01 11:30:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-07-01 16:00:00', 'UTC'),
+    ]);
+
+    $component = Livewire::test(ScannerAuth::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSet('formDisabled', false);
+
+    Carbon::setTestNow('2026-07-01 11:00:00');
+
+    $component
+        ->set('authCode', '123456')
+        ->call('authenticate')
+        ->assertSet('formDisabled', true)
+        ->assertSet('errorMessage', 'Scanner ist noch nicht aktiv. Das Zeitfenster beginnt um 13:30.');
 });
 
 // --- Validation ---

--- a/tests/Feature/Notifications/PreShiftReminderTest.php
+++ b/tests/Feature/Notifications/PreShiftReminderTest.php
@@ -9,6 +9,7 @@ use App\Models\Volunteer;
 use App\Models\VolunteerJob;
 use App\Notifications\PreShiftReminder;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Carbon;
 
 beforeEach(function () {
     $this->org = Organization::factory()->create();
@@ -16,30 +17,95 @@ beforeEach(function () {
         'name' => 'Summer Fest',
         'location' => 'Central Park',
     ]);
+    $this->event->project->update(['timezone' => 'UTC']);
+    $this->event->load('project');
     $this->job = VolunteerJob::factory()->for($this->event)->create(['name' => 'Stage Crew']);
     $this->shift = Shift::factory()->for($this->job, 'volunteerJob')->create();
     $this->volunteer = Volunteer::factory()->create(['first_name' => 'Alice', 'last_name' => 'Test']);
 });
 
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
 it('renders 24h reminder with default template', function () {
+    Carbon::setTestNow(Carbon::parse('2026-04-29 09:00:00', 'UTC'));
+    $this->shift->update([
+        'starts_at' => Carbon::parse('2026-04-30 14:00:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-04-30 16:00:00', 'UTC'),
+    ]);
+
     $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
     $mail = $notification->toMail($this->volunteer);
 
-    // #81 - Updated to expect German subject ("morgen" instead of "tomorrow")
     expect($mail->subject)->toContain('Summer Fest')
         ->and($mail->subject)->toContain('morgen')
+        ->and(implode(' ', $mail->introLines))->toContain('morgen stattfindet')
         ->and(implode(' ', $mail->introLines))->toContain('Stage Crew')
         ->and(implode(' ', $mail->introLines))->toContain('Central Park');
 });
 
 it('renders 4h reminder with default template', function () {
+    Carbon::setTestNow(Carbon::parse('2026-04-29 09:00:00', 'UTC'));
+    $this->shift->update([
+        'starts_at' => Carbon::parse('2026-04-29 13:00:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-04-29 15:00:00', 'UTC'),
+    ]);
+
     $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder4h);
     $mail = $notification->toMail($this->volunteer);
 
-    // #81 - Updated to expect German subject ("bald" instead of "soon")
     expect($mail->subject)->toContain('Summer Fest')
         ->and($mail->subject)->toContain('bald')
+        ->and(implode(' ', $mail->introLines))->toContain('beginnt heute in wenigen Stunden')
         ->and(implode(' ', $mail->introLines))->toContain('Stage Crew');
+});
+
+it('renders 24h reminder with heute when the shift is today', function () {
+    Carbon::setTestNow(Carbon::parse('2026-04-29 09:00:00', 'UTC'));
+    $this->shift->update([
+        'starts_at' => Carbon::parse('2026-04-29 14:00:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-04-29 16:00:00', 'UTC'),
+    ]);
+
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $mail = $notification->toMail($this->volunteer);
+
+    expect($mail->subject)->toContain('ist heute')
+        ->and(implode(' ', $mail->introLines))->toContain('heute stattfindet')
+        ->and(implode(' ', $mail->introLines))->toContain('Bis bald!');
+});
+
+it('renders 24h reminder fallback with formatted date outside today and tomorrow', function () {
+    Carbon::setTestNow(Carbon::parse('2026-04-29 09:00:00', 'UTC'));
+    $this->shift->update([
+        'starts_at' => Carbon::parse('2026-05-02 14:00:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-05-02 16:00:00', 'UTC'),
+    ]);
+
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $mail = $notification->toMail($this->volunteer);
+
+    expect($mail->subject)->toContain('ist am 02.05.2026')
+        ->and(implode(' ', $mail->introLines))->toContain('am 02.05.2026 stattfindet');
+});
+
+it('uses the project timezone to determine the relative day around midnight', function () {
+    $this->event->project->update(['timezone' => 'Europe/Berlin']);
+    $this->event->load('project');
+
+    Carbon::setTestNow(Carbon::parse('2026-04-29 21:30:00', 'UTC'));
+    $this->shift->update([
+        'starts_at' => Carbon::parse('2026-04-29 22:30:00', 'UTC'),
+        'ends_at' => Carbon::parse('2026-04-30 00:30:00', 'UTC'),
+    ]);
+
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $mail = $notification->toMail($this->volunteer);
+
+    expect($mail->subject)->toContain('morgen')
+        ->and(implode(' ', $mail->introLines))->toContain('morgen stattfindet')
+        ->and(implode(' ', $mail->introLines))->toContain('30.04.2026 00:30');
 });
 
 it('uses custom template when set', function () {

--- a/tests/Feature/Services/EmailTemplateRendererTest.php
+++ b/tests/Feature/Services/EmailTemplateRendererTest.php
@@ -134,8 +134,10 @@ it('has German default for pre-shift reminder 24h [#81]', function () {
     $defaults = $this->renderer->getDefaults(EmailTemplateType::PreShiftReminder24h);
 
     expect($defaults['subject'])->toContain('Erinnerung')
-        ->and($defaults['subject'])->toContain('morgen')
-        ->and($defaults['body'])->toContain('Hallo {{vorname}}');
+        ->and($defaults['subject'])->toContain('{{relativer_tag}}')
+        ->and($defaults['body'])->toContain('Hallo {{vorname}}')
+        ->and($defaults['body'])->toContain('{{relativer_tag}} stattfindet')
+        ->and($defaults['body'])->toContain('Bis bald!');
 });
 
 it('has German default for pre-shift reminder 4h [#81]', function () {
@@ -143,7 +145,8 @@ it('has German default for pre-shift reminder 4h [#81]', function () {
 
     expect($defaults['subject'])->toContain('Erinnerung')
         ->and($defaults['subject'])->toContain('bald')
-        ->and($defaults['body'])->toContain('Hallo {{vorname}}');
+        ->and($defaults['body'])->toContain('Hallo {{vorname}}')
+        ->and($defaults['body'])->toContain('{{relativer_tag}} in wenigen Stunden');
 });
 
 it('has German default for email verification [#81]', function () {
@@ -298,6 +301,15 @@ it('returns placeholders for event updated [#81]', function () {
         ->and($placeholders)->toContain('organizer_note')
         ->and($placeholders)->toContain('portal_link');
 });
+
+it('returns relativer_tag for pre-shift reminder placeholders', function (EmailTemplateType $type) {
+    $placeholders = $this->renderer->availablePlaceholders($type);
+
+    expect($placeholders)->toContain('relativer_tag');
+})->with([
+    EmailTemplateType::PreShiftReminder24h,
+    EmailTemplateType::PreShiftReminder4h,
+]);
 
 // ============================================================================
 // #104 Cancellation Confirmation

--- a/tests/js/scanner/alpine-scanner.test.ts
+++ b/tests/js/scanner/alpine-scanner.test.ts
@@ -54,10 +54,10 @@ function makeVolunteer(overrides: Partial<Volunteer> = {}): Volunteer {
     };
 }
 
-function createApp() {
+function createApp(scannerType: 'entry_staff' | 'volunteer_admin' = 'entry_staff') {
     return scannerApp({
         scannerId: 7,
-        scannerType: 'entry_staff',
+        scannerType,
         modes: ['checkin'],
         entryEventId: 5,
         contractVersion: 1,
@@ -200,5 +200,79 @@ describe('alpine-scanner manual volunteer lookup', () => {
         expect(app.volunteerSearchQuery).toBe('ali');
         expect(app.selectedVolunteer?.id).toBe(volunteer.id);
         expect(app.selectedVolunteerSource).toBe('manual');
+    });
+});
+
+describe('alpine-scanner QR volunteer selection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows a volunteer-admin result for an already-arrived volunteer', () => {
+        const app = createApp('volunteer_admin');
+        const volunteer = makeVolunteer();
+
+        app._arrivals = [{
+            id: 1,
+            ticket_id: volunteer.ticket.id,
+            volunteer_id: volunteer.id,
+            event_id: 5,
+            scanned_by: null,
+            scanned_at: '2026-03-02 10:00:00',
+            method: 'qr_scan',
+            flagged: false,
+            flag_reason: null,
+        }];
+
+        app.selectVolunteer(volunteer, { fromQr: true });
+
+        expect(app.state).toBe('result');
+        expect(app.resultMessage).toBe('');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+
+    it('shows a volunteer-admin result for a not-yet-arrived volunteer', () => {
+        const app = createApp('volunteer_admin');
+        const volunteer = makeVolunteer();
+
+        app.selectVolunteer(volunteer, { fromQr: true });
+
+        expect(app.state).toBe('result');
+        expect(app.resultMessage).toBe('');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+
+    it('keeps the entry-staff duplicate state for an already-arrived volunteer', () => {
+        const app = createApp('entry_staff');
+        const volunteer = makeVolunteer();
+
+        app._arrivals = [{
+            id: 1,
+            ticket_id: volunteer.ticket.id,
+            volunteer_id: volunteer.id,
+            event_id: 5,
+            scanned_by: null,
+            scanned_at: '2026-03-02 10:00:00',
+            method: 'qr_scan',
+            flagged: false,
+            flag_reason: null,
+        }];
+
+        app.selectVolunteer(volunteer, { fromQr: true });
+
+        expect(app.state).toBe('duplicate');
+        expect(app.resultMessage).toBe('Already checked in at 10:00:00 AM.');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+
+    it('keeps the entry-staff ready message for a not-yet-arrived volunteer', () => {
+        const app = createApp('entry_staff');
+        const volunteer = makeVolunteer();
+
+        app.selectVolunteer(volunteer, { fromQr: true });
+
+        expect(app.state).toBe('result');
+        expect(app.resultMessage).toBe('Ready to check in.');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
     });
 });


### PR DESCRIPTION
## Summary
- correct pre-shift reminder relative day wording so reminders use `heute`, `morgen`, or a formatted date in the project timezone for issue #194
- show scanner activation times in the project timezone across scheduled and rate-limited auth flows for issue #192
- keep volunteer-admin scanners on the direct result state after QR selection while preserving entry-staff duplicate handling for issue #196
- reduce pending deletion retention from 30 days to 7 days and align both deletion banners and confirmation copy for issue #204
- add targeted Playwright regression coverage for all four phase 1 fixes

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Notifications/PreShiftReminderTest.php tests/Feature/Services/EmailTemplateRendererTest.php tests/Feature/Events/EmailTemplateEditorTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Livewire/ScannerAuthEdgeCasesTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Commands/PurgePendingDeletionsTest.php tests/Feature/Livewire/ProjectShowTest.php tests/Feature/Livewire/Events/EventShowTest.php`
- `bash e2e/setup.sh`
- `vendor/bin/sail npm run test:e2e -- e2e/pre-shift-reminder-relative-day.spec.ts e2e/scanner-auth-timezone.spec.ts e2e/va-scanner-arrival-status.spec.ts e2e/pending-deletion-retention.spec.ts`

Fixes #194
Fixes #192
Fixes #196
Resolves #204