### PR TITLE
feat(signup): complete phase 2 availability controls

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #206 complete — fully booked jobs are hidden from public shift selection unless a returning volunteer already holds a shift in the job"
-current_milestone: issue-206-hide-fully-booked-jobs
+current_focus: "Issue #207 complete — empty-state notification opt-in, double opt-in subscriber flow, unsubscribe links, and queued event-availability notifications are implemented for public signup"
+current_milestone: issue-207-signup-empty-state-notifications
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T16:18:00+02:00"
+last_updated: "2026-04-30T20:18:00+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -43,6 +43,7 @@ last_updated: "2026-04-30T16:18:00+02:00"
 | issue-168-shifts-jobs-active-state | Jobs & Shifts Active State | #168 active/inactive controls for jobs and shifts with public signup filtering | m10-signup | complete |
 | issue-203-priority-shift-gate | Priority Shift Gate | #203 event-level priority gating for public signup with organizer override and progress UI | m10-signup, issue-168-shifts-jobs-active-state | complete |
 | issue-206-hide-fully-booked-jobs | Hide Fully Booked Jobs | #206 hide fully booked public-signup jobs while keeping partial/full returning-volunteer context | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate | complete |
+| issue-207-signup-empty-state-notifications | Signup Empty-State Notifications | #207 empty-state opt-in, double opt-in verification, unsubscribe flow, and queued availability notices for public signup | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs | complete |
 
 ## Artifacts
 
@@ -68,6 +69,7 @@ last_updated: "2026-04-30T16:18:00+02:00"
 | `.tall-pipeline/issue-168-shifts-jobs-active-state.md` | plan+implement+test | issue-168 | Issue #168 tracking for active/inactive jobs and shifts plus signup filtering | complete |
 | `.tall-pipeline/issue-203-priority-shift-gate.md` | plan+implement+test | issue-203 | Issue #203 tracking for event-level priority shift gating, organizer override, and signup UI progress | complete |
 | `.tall-pipeline/issue-206-hide-fully-booked-jobs.md` | plan+implement+test | issue-206 | Issue #206 tracking for hiding fully booked jobs from public signup while preserving returning-volunteer visibility | complete |
+| `.tall-pipeline/issue-207-signup-empty-state-notifications.md` | plan+implement+test | issue-207 | Issue #207 tracking for empty-state notification opt-in, verification, unsubscribe, and queued event availability notifications | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #196 complete — volunteer-admin scanner no longer shows the arrival duplicate state after QR volunteer selection"
-current_milestone: issue-196-scanner-arrival-duplicate-status
+current_focus: "Issue #168 complete — inactive jobs and shifts are hidden from public signup while remaining manageable in admin"
+current_milestone: issue-168-shifts-jobs-active-state
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T13:55:23+02:00"
+last_updated: "2026-04-30T14:05:00+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -40,6 +40,7 @@ last_updated: "2026-04-30T13:55:23+02:00"
 | issue-190-portal-announcement-visibility | Portal Announcement Visibility | #190 null-safe volunteer portal announcements + targeted visibility filtering | m15, issue-175-announcement-recipient-resilience | complete |
 | issue-193-guest-mail-magic-link | Guest Mail Magic-Link Fallback | #193 signed browser fallback page for guest invitation QR codes | m12, m15, m19 | complete |
 | issue-196-scanner-arrival-duplicate-status | Scanner Arrival Duplicate Status | #196 volunteer-admin scanners should skip arrival duplicate status while entry-staff behavior stays unchanged | m11, m16 | complete |
+| issue-168-shifts-jobs-active-state | Jobs & Shifts Active State | #168 active/inactive controls for jobs and shifts with public signup filtering | m10-signup | complete |
 
 ## Artifacts
 
@@ -62,6 +63,7 @@ last_updated: "2026-04-30T13:55:23+02:00"
 | `.tall-pipeline/issue-190-portal-announcement-visibility.md` | plan+implement+test | issue-190 | Issue #190 tracking for null-safe volunteer portal announcements and targeted visibility | complete |
 | `.tall-pipeline/issue-193-guest-mail-magic-link.md` | plan+implement+test | issue-193 | Issue #193 tracking for guest invitation magic-link QR fallbacks | complete |
 | `.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md` | plan+implement+test | issue-196 | Issue #196 tracking for volunteer-admin scanner duplicate-status regression | complete |
+| `.tall-pipeline/issue-168-shifts-jobs-active-state.md` | plan+implement+test | issue-168 | Issue #168 tracking for active/inactive jobs and shifts plus signup filtering | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #203 complete — event-level priority gating now locks regular signup until priority shifts hit the configured threshold, with organizer overrides and UI progress"
-current_milestone: issue-203-priority-shift-gate
+current_focus: "Issue #206 complete — fully booked jobs are hidden from public shift selection unless a returning volunteer already holds a shift in the job"
+current_milestone: issue-206-hide-fully-booked-jobs
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T15:05:00+02:00"
+last_updated: "2026-04-30T16:18:00+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -42,6 +42,7 @@ last_updated: "2026-04-30T15:05:00+02:00"
 | issue-196-scanner-arrival-duplicate-status | Scanner Arrival Duplicate Status | #196 volunteer-admin scanners should skip arrival duplicate status while entry-staff behavior stays unchanged | m11, m16 | complete |
 | issue-168-shifts-jobs-active-state | Jobs & Shifts Active State | #168 active/inactive controls for jobs and shifts with public signup filtering | m10-signup | complete |
 | issue-203-priority-shift-gate | Priority Shift Gate | #203 event-level priority gating for public signup with organizer override and progress UI | m10-signup, issue-168-shifts-jobs-active-state | complete |
+| issue-206-hide-fully-booked-jobs | Hide Fully Booked Jobs | #206 hide fully booked public-signup jobs while keeping partial/full returning-volunteer context | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate | complete |
 
 ## Artifacts
 
@@ -66,6 +67,7 @@ last_updated: "2026-04-30T15:05:00+02:00"
 | `.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md` | plan+implement+test | issue-196 | Issue #196 tracking for volunteer-admin scanner duplicate-status regression | complete |
 | `.tall-pipeline/issue-168-shifts-jobs-active-state.md` | plan+implement+test | issue-168 | Issue #168 tracking for active/inactive jobs and shifts plus signup filtering | complete |
 | `.tall-pipeline/issue-203-priority-shift-gate.md` | plan+implement+test | issue-203 | Issue #203 tracking for event-level priority shift gating, organizer override, and signup UI progress | complete |
+| `.tall-pipeline/issue-206-hide-fully-booked-jobs.md` | plan+implement+test | issue-206 | Issue #206 tracking for hiding fully booked jobs from public signup while preserving returning-volunteer visibility | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #168 complete — inactive jobs and shifts are hidden from public signup while remaining manageable in admin"
-current_milestone: issue-168-shifts-jobs-active-state
+current_focus: "Issue #203 complete — event-level priority gating now locks regular signup until priority shifts hit the configured threshold, with organizer overrides and UI progress"
+current_milestone: issue-203-priority-shift-gate
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T14:05:00+02:00"
+last_updated: "2026-04-30T15:05:00+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -41,6 +41,7 @@ last_updated: "2026-04-30T14:05:00+02:00"
 | issue-193-guest-mail-magic-link | Guest Mail Magic-Link Fallback | #193 signed browser fallback page for guest invitation QR codes | m12, m15, m19 | complete |
 | issue-196-scanner-arrival-duplicate-status | Scanner Arrival Duplicate Status | #196 volunteer-admin scanners should skip arrival duplicate status while entry-staff behavior stays unchanged | m11, m16 | complete |
 | issue-168-shifts-jobs-active-state | Jobs & Shifts Active State | #168 active/inactive controls for jobs and shifts with public signup filtering | m10-signup | complete |
+| issue-203-priority-shift-gate | Priority Shift Gate | #203 event-level priority gating for public signup with organizer override and progress UI | m10-signup, issue-168-shifts-jobs-active-state | complete |
 
 ## Artifacts
 
@@ -64,6 +65,7 @@ last_updated: "2026-04-30T14:05:00+02:00"
 | `.tall-pipeline/issue-193-guest-mail-magic-link.md` | plan+implement+test | issue-193 | Issue #193 tracking for guest invitation magic-link QR fallbacks | complete |
 | `.tall-pipeline/issue-196-scanner-arrival-duplicate-status.md` | plan+implement+test | issue-196 | Issue #196 tracking for volunteer-admin scanner duplicate-status regression | complete |
 | `.tall-pipeline/issue-168-shifts-jobs-active-state.md` | plan+implement+test | issue-168 | Issue #168 tracking for active/inactive jobs and shifts plus signup filtering | complete |
+| `.tall-pipeline/issue-203-priority-shift-gate.md` | plan+implement+test | issue-203 | Issue #203 tracking for event-level priority shift gating, organizer override, and signup UI progress | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-168-shifts-jobs-active-state.md
+++ b/.tall-pipeline/issue-168-shifts-jobs-active-state.md
@@ -1,0 +1,40 @@
+# Milestone: issue-168-shifts-jobs-active-state — Jobs & Shifts Active State
+
+**GitHub Issue:** [#168](https://github.com/reneweiser/voluntify/issues/168)
+**Features:** #168
+**Dependencies:** m10-signup
+**Branch:** current workspace
+
+## Plan
+- **Status:** complete
+- **Gate summary:** add an active flag to volunteer jobs and shifts, keep inactive records visible in admin, and filter them out of public signup without touching existing signups.
+
+### Scope
+- Add `is_active` persistence for `volunteer_jobs` and `shifts`
+- Show inactive state plus reactivation controls in `JobsAndShiftsManager`
+- Filter inactive jobs/shifts from public signup queries and reject inactive IDs in reservation/signup actions
+- Cover the behavior with focused action, Livewire, and public signup tests
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: extend action, admin, and public signup tests for inactive jobs/shifts
+  - [x] GREEN: add `is_active` schema/model support and filter inactive records from signup
+  - [x] GREEN: add admin inactive badges plus activate/deactivate controls for jobs and shifts
+  - [x] REFACTOR: keep existing signup and admin flows intact for active records and existing signups
+  - [x] Verify: run focused Sail Pest coverage and Pint
+- **Gate summary:** inactive jobs and shifts now stay manageable in admin, can be reactivated, and are both hidden and rejected in the public signup flow.
+
+## Test
+- **Status:** complete
+- **Gate summary:** focused Pest coverage passed for the updated actions, public signup flow, and jobs/shifts manager, plus dirty Pint formatting.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Schema | `volunteer_jobs.is_active`, `shifts.is_active` |
+| Models | `VolunteerJob::scopeActive()`, `Shift::scopeActive()` |
+| Admin UI | `JobsAndShiftsManager` activate/deactivate controls and inactive badges |
+| Public signup | `EventSignup`, `ReserveShifts`, `SignUpVolunteerForShifts` active-only filtering |

--- a/.tall-pipeline/issue-203-priority-shift-gate.md
+++ b/.tall-pipeline/issue-203-priority-shift-gate.md
@@ -1,0 +1,42 @@
+# Milestone: issue-203-priority-shift-gate — Priority Shift Gate
+
+**GitHub Issue:** [#203](https://github.com/reneweiser/voluntify/issues/203)
+**Features:** #203
+**Dependencies:** m10-signup, issue-168-shifts-jobs-active-state
+**Branch:** current workspace
+
+## Plan
+- **Status:** complete
+- **Gate summary:** add event-level priority gate persistence and latch logic, wire it into volunteer signup and cancellation flows, and expose the controls/status in organizer admin plus public signup UI.
+
+### Scope
+- Add `events.priority_unlock_threshold_percent`, `events.priority_gate_unlocked_at`, and `shifts.is_priority`
+- Evaluate the one-way unlock latch from event settings, shift edits, signups, and cancellations
+- Block public reservation/signup attempts on regular shifts while the gate is closed, while keeping organizer manual enrollment exempt
+- Show locked teaser states plus progress on the public signup page and expose organizer controls/status in jobs/shifts, event settings, and event overview
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: extend model, action, cancellation, public signup, event settings, event overview, and manual enrollment tests for priority gating
+  - [x] GREEN: add schema/model support for event thresholds, unlock timestamp, and per-shift priority flags
+  - [x] GREEN: enforce the gate in reservation and signup actions while bypassing it for organizer manual enrollment
+  - [x] GREEN: add organizer admin controls and public signup banner/progress with locked teaser shifts
+  - [x] REFACTOR: keep the latch one-way and reuse the shared event evaluation logic from all relevant mutations
+  - [x] Verify: run focused Sail Pest coverage and Pint
+- **Gate summary:** volunteers now see and respect the priority gate before regular shifts unlock, organizers can configure and inspect it in admin, and manual organizer enrollment still bypasses the gate while contributing to the unlock threshold.
+
+## Test
+- **Status:** complete
+- **Gate summary:** focused Pest coverage passed for the new event gate model logic, signup and cancellation actions, public signup UI, organizer admin screens, and adjacent shift/event action regressions, plus dirty Pint formatting.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Schema | `events.priority_unlock_threshold_percent`, `events.priority_gate_unlocked_at`, `shifts.is_priority` |
+| Models | `Event::isPriorityGateOpen()`, `Event::priorityFillRate()`, `Event::priorityFilledSpots()`, `Event::priorityCapacityTotal()`, `Event::evaluatePriorityGate()`, `Shift::scopePriority()`, `Shift::scopeNonPriority()` |
+| Actions | `ReserveShifts` and `SignUpVolunteerForShifts` gate regular public selections; `ManualEnrollment` bypasses with `bypassPriorityGate`; `CancelShiftSignup`, `CreateShift`, `UpdateShift`, and `UpdateEvent` all re-evaluate the latch |
+| Admin UI | `EventSettings` threshold control, `JobsAndShiftsManager` priority toggle, `EventShow` priority gate status card |
+| Public signup | `EventSignup` priority gate banner/progress plus locked regular-shift teaser state |

--- a/.tall-pipeline/issue-206-hide-fully-booked-jobs.md
+++ b/.tall-pipeline/issue-206-hide-fully-booked-jobs.md
@@ -1,0 +1,35 @@
+# Milestone: issue-206-hide-fully-booked-jobs — Hide Fully Booked Jobs
+
+**GitHub Issue:** [#206](https://github.com/reneweiser/voluntify/issues/206)
+**Features:** #206
+**Dependencies:** issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate
+**Branch:** current workspace
+
+## Plan
+- **Status:** complete
+- **Gate summary:** filter fully booked jobs out of the public signup job list while keeping partially available jobs intact and preserving visibility for returning volunteers who already hold a shift in an otherwise full job.
+
+### Scope
+- Filter `EventSignup::jobs()` so jobs disappear only when every active shift is full and none of those shifts belongs to the returning volunteer.
+- Keep existing per-shift rendering unchanged so full shifts still show within partially available jobs.
+- Cover new volunteer, returning volunteer, and all-jobs-full cases with focused public signup tests.
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: add public signup coverage for hidden full jobs, partially full jobs, returning-volunteer visibility, and all-jobs-full empty collections
+  - [x] GREEN: filter fully booked jobs in `EventSignup::jobs()` while preserving jobs containing an existing volunteer signup
+  - [x] REFACTOR: reuse the existing shift fullness helpers and leave the Blade rendering unchanged
+  - [x] Verify: run focused Sail Pest coverage and Pint
+- **Gate summary:** the public signup now omits jobs that offer no selectable shifts, but still shows partially available jobs and keeps returning volunteers' existing fully booked jobs visible.
+
+## Test
+- **Status:** complete
+- **Gate summary:** focused public signup Pest coverage passed for hiding fully booked jobs, preserving partially available jobs, keeping returning-volunteer visibility, and returning an empty collection when every job is fully booked, plus dirty Pint formatting.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Public signup | `EventSignup::jobs()` now filters fully booked jobs unless one of the job's shifts is in `existingShiftIds` |

--- a/.tall-pipeline/issue-207-signup-empty-state-notifications.md
+++ b/.tall-pipeline/issue-207-signup-empty-state-notifications.md
@@ -1,0 +1,41 @@
+# Milestone: issue-207-signup-empty-state-notifications — Signup Empty-State Notifications
+
+**GitHub Issue:** [#207](https://github.com/reneweiser/voluntify/issues/207)
+**Features:** #207
+**Dependencies:** issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs
+**Branch:** current workspace
+
+## Plan
+- **Status:** complete
+- **Gate summary:** add an event-scoped notification subscription flow to the public signup empty state, verify subscribers via double opt-in, provide unsubscribe links, and queue one availability-notification batch when an event transitions from no public shifts to available shifts.
+
+### Scope
+- Show a Flux-based empty-state card in `WizardState::SelectingShifts` whenever `EventSignup` has no public jobs to render.
+- Persist event-specific subscribers with verification tokens, verification expiry, unsubscribe tokens, and per-subscriber notification timestamps.
+- Verify subscribers through public routes, send queued availability notifications with unsubscribe links, and debounce organizer-side trigger points via the existing shift/job actions.
+- Cover subscription UI, verification/unsubscribe routes, queued notification delivery, and action-triggered scheduling behavior with focused Pest coverage.
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: add focused Pest coverage for the empty-state opt-in flow, verification/unsubscribe routes, queued notifications, and action-triggered scheduling
+  - [x] GREEN: add `event_notification_subscribers`, the public signup empty-state form, double opt-in actions/routes, unsubscribe flow, and queued event-availability notifications
+  - [x] REFACTOR: move public-signup availability filtering into `Event::publicSignupJobs()` so public signup and notification triggers share one source of truth
+  - [x] Verify: run focused Sail Pest coverage and Pint
+- **Gate summary:** the public signup now shows an email opt-in empty state when no shifts are available, stores event-specific subscribers with double opt-in verification, sends unsubscribe-enabled availability notifications, and only queues one delayed notification batch when an event becomes publicly available again.
+
+## Test
+- **Status:** complete
+- **Gate summary:** focused public signup, controller, notification, job, and action Pest coverage passed for the new empty-state subscription flow, per-event delivery, unsubscribe handling, and queue scheduling behavior; Pint also passed on dirty PHP files.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Models | `EventNotificationSubscriber` with `event_id`, `email`, verification token hash/expiry, unsubscribe token hash, `verified_at`, and `last_notified_at` |
+| Actions | `SubscribeToEventNotifications`, `CompleteEventNotificationSubscription`, `ScheduleEventSubscriberNotification` |
+| Jobs | `NotifyEventSubscribers` delayed/unique per event |
+| Notifications | `EventNotificationSubscriptionVerification`, `EventNewShiftsAvailable` |
+| Routes | `events.notifications.verify`, `events.notifications.unsubscribe` |
+| Public signup | `EventSignup` empty-state opt-in plus shared `Event::publicSignupJobs()` availability filtering |

--- a/app/Actions/CancelShiftSignup.php
+++ b/app/Actions/CancelShiftSignup.php
@@ -28,6 +28,7 @@ class CancelShiftSignup
 
         $signup->cancelled_at = now();
         $signup->save();
+        $event->refresh()->evaluatePriorityGate();
 
         SignupCancelled::dispatch($signup, $signup->volunteer);
     }

--- a/app/Actions/CompleteEventNotificationSubscription.php
+++ b/app/Actions/CompleteEventNotificationSubscription.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions;
+
+use App\Exceptions\ExpiredVerificationException;
+use App\Models\EventNotificationSubscriber;
+use App\ValueObjects\HashedToken;
+
+class CompleteEventNotificationSubscription
+{
+    public function execute(string $plainToken): EventNotificationSubscriber
+    {
+        $subscriber = EventNotificationSubscriber::query()
+            ->where('verification_token_hash', HashedToken::fromPlaintext($plainToken)->hash)
+            ->firstOrFail();
+
+        if ($subscriber->isVerified()) {
+            return $subscriber;
+        }
+
+        if ($subscriber->verification_expires_at?->isPast()) {
+            throw new ExpiredVerificationException('This verification link has expired.');
+        }
+
+        $subscriber->update([
+            'verified_at' => now(),
+        ]);
+
+        return $subscriber->fresh();
+    }
+}

--- a/app/Actions/CreateShift.php
+++ b/app/Actions/CreateShift.php
@@ -17,6 +17,7 @@ class CreateShift
         ?CarbonInterface $endsAt,
         int $capacity,
         bool $isActive,
+        bool $isPriority = false,
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
@@ -26,8 +27,11 @@ class CreateShift
             'ends_at' => $endsAt,
             'capacity' => $capacity,
             'is_active' => $isActive,
+            'is_priority' => $isPriority,
             'display_text' => $displayText,
         ]);
+
+        $shift->volunteerJob->event->refresh()->evaluatePriorityGate();
 
         if ($causer) {
             ShiftCreated::dispatch($shift, $causer);

--- a/app/Actions/CreateShift.php
+++ b/app/Actions/CreateShift.php
@@ -16,6 +16,7 @@ class CreateShift
         ?CarbonInterface $startsAt,
         ?CarbonInterface $endsAt,
         int $capacity,
+        bool $isActive,
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
@@ -24,6 +25,7 @@ class CreateShift
             'starts_at' => $startsAt,
             'ends_at' => $endsAt,
             'capacity' => $capacity,
+            'is_active' => $isActive,
             'display_text' => $displayText,
         ]);
 

--- a/app/Actions/CreateShift.php
+++ b/app/Actions/CreateShift.php
@@ -21,6 +21,8 @@ class CreateShift
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
+        $hadAvailability = $job->event->publicSignupJobs()->isNotEmpty();
+
         $shift = $job->shifts()->create([
             'shift_date' => $shiftDate,
             'starts_at' => $startsAt,
@@ -32,6 +34,7 @@ class CreateShift
         ]);
 
         $shift->volunteerJob->event->refresh()->evaluatePriorityGate();
+        app(ScheduleEventSubscriberNotification::class)->execute($shift->volunteerJob->event->fresh(), $hadAvailability);
 
         if ($causer) {
             ShiftCreated::dispatch($shift, $causer);

--- a/app/Actions/CreateVolunteerJob.php
+++ b/app/Actions/CreateVolunteerJob.php
@@ -14,12 +14,14 @@ class CreateVolunteerJob
         string $name,
         ?string $description,
         ?string $instructions,
+        bool $isActive,
         User $causer,
     ): VolunteerJob {
         $job = $event->volunteerJobs()->create([
             'name' => $name,
             'description' => $description,
             'instructions' => $instructions,
+            'is_active' => $isActive,
         ]);
 
         JobCreated::dispatch($job, $causer);

--- a/app/Actions/ReserveShifts.php
+++ b/app/Actions/ReserveShifts.php
@@ -29,15 +29,21 @@ class ReserveShifts
      */
     public function execute(array $shiftIds, string $sessionId, Event $event): ReservationResult
     {
+        $event = $event->fresh();
         $eventJobIds = $event->volunteerJobs()->active()->pluck('id');
-        $validShiftIds = Shift::whereIn('volunteer_job_id', $eventJobIds)
+        $selectedShifts = Shift::whereIn('volunteer_job_id', $eventJobIds)
             ->active()
             ->whereIn('id', $shiftIds)
-            ->pluck('id')
-            ->all();
+            ->get(['id', 'is_priority']);
+
+        $validShiftIds = $selectedShifts->pluck('id')->all();
 
         if (count($validShiftIds) !== count($shiftIds)) {
             throw new DomainException('One or more shifts do not belong to this event.');
+        }
+
+        if (! $event->isPriorityGateOpen() && $selectedShifts->contains(fn (Shift $shift) => ! $shift->is_priority)) {
+            throw new DomainException($event->priorityGateMessage());
         }
 
         sort($validShiftIds);

--- a/app/Actions/ReserveShifts.php
+++ b/app/Actions/ReserveShifts.php
@@ -29,8 +29,9 @@ class ReserveShifts
      */
     public function execute(array $shiftIds, string $sessionId, Event $event): ReservationResult
     {
-        $eventJobIds = $event->volunteerJobs()->pluck('id');
+        $eventJobIds = $event->volunteerJobs()->active()->pluck('id');
         $validShiftIds = Shift::whereIn('volunteer_job_id', $eventJobIds)
+            ->active()
             ->whereIn('id', $shiftIds)
             ->pluck('id')
             ->all();

--- a/app/Actions/ScheduleEventSubscriberNotification.php
+++ b/app/Actions/ScheduleEventSubscriberNotification.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions;
+
+use App\Jobs\NotifyEventSubscribers;
+use App\Models\Event;
+
+class ScheduleEventSubscriberNotification
+{
+    public function execute(Event $event, bool $hadAvailability): void
+    {
+        if ($hadAvailability || $event->fresh()->publicSignupJobs()->isEmpty()) {
+            return;
+        }
+
+        NotifyEventSubscribers::dispatch($event->id)->delay(now()->addSeconds(60));
+    }
+}

--- a/app/Actions/SignUpVolunteerForShifts.php
+++ b/app/Actions/SignUpVolunteerForShifts.php
@@ -29,8 +29,9 @@ class SignUpVolunteerForShifts
         bool $sendNotification = true,
         ?string $sessionId = null,
     ): ShiftSignupResult {
-        $eventJobIds = $event->volunteerJobs()->pluck('id');
+        $eventJobIds = $event->volunteerJobs()->active()->pluck('id');
         $validShiftIds = Shift::whereIn('volunteer_job_id', $eventJobIds)
+            ->active()
             ->whereIn('id', $shiftIds)
             ->pluck('id')
             ->all();

--- a/app/Actions/SignUpVolunteerForShifts.php
+++ b/app/Actions/SignUpVolunteerForShifts.php
@@ -28,16 +28,23 @@ class SignUpVolunteerForShifts
         array $shiftIds,
         bool $sendNotification = true,
         ?string $sessionId = null,
+        bool $bypassPriorityGate = false,
     ): ShiftSignupResult {
+        $event = $event->fresh();
         $eventJobIds = $event->volunteerJobs()->active()->pluck('id');
-        $validShiftIds = Shift::whereIn('volunteer_job_id', $eventJobIds)
+        $selectedShifts = Shift::whereIn('volunteer_job_id', $eventJobIds)
             ->active()
             ->whereIn('id', $shiftIds)
-            ->pluck('id')
-            ->all();
+            ->get(['id', 'is_priority']);
+
+        $validShiftIds = $selectedShifts->pluck('id')->all();
 
         if (count($validShiftIds) !== count($shiftIds)) {
             throw new DomainException('One or more shifts do not belong to this event.');
+        }
+
+        if (! $bypassPriorityGate && ! $event->isPriorityGateOpen() && $selectedShifts->contains(fn (Shift $shift) => ! $shift->is_priority)) {
+            throw new DomainException($event->priorityGateMessage());
         }
 
         $sortedShiftIds = $shiftIds;
@@ -156,6 +163,8 @@ class SignUpVolunteerForShifts
             skippedDuplicate: $result['skippedDuplicate'],
             skippedOverlap: $result['skippedOverlap'],
         );
+
+        $event->fresh()->evaluatePriorityGate();
 
         if ($sendNotification && $batchResult->hasNewSignups()) {
             $shiftIds = collect($result['newSignups'])

--- a/app/Actions/SubscribeToEventNotifications.php
+++ b/app/Actions/SubscribeToEventNotifications.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Event;
+use App\Models\EventNotificationSubscriber;
+use App\Notifications\EventNotificationSubscriptionVerification;
+use App\ValueObjects\HashedToken;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+
+class SubscribeToEventNotifications
+{
+    public function execute(Event $event, string $email): EventNotificationSubscriber
+    {
+        $normalizedEmail = Str::lower(trim($email));
+
+        $subscriber = EventNotificationSubscriber::firstOrNew([
+            'event_id' => $event->id,
+            'email' => $normalizedEmail,
+        ]);
+
+        if ($subscriber->isVerified()) {
+            return $subscriber;
+        }
+
+        $plainToken = Str::random(64);
+
+        $subscriber->fill([
+            'verification_token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+            'verification_expires_at' => now()->addDays(7),
+        ]);
+
+        $subscriber->save();
+
+        Notification::route('mail', $subscriber->email)->notify(
+            new EventNotificationSubscriptionVerification(
+                $event,
+                route('events.notifications.verify', $plainToken),
+            ),
+        );
+
+        return $subscriber->fresh();
+    }
+}

--- a/app/Actions/UpdateEvent.php
+++ b/app/Actions/UpdateEvent.php
@@ -26,6 +26,7 @@ class UpdateEvent
         ?int $attendanceGraceMinutes = null,
         ?EventVisibility $visibility = null,
         ?string $notificationEmail = null,
+        ?int $priorityUnlockThresholdPercent = null,
         ?User $causer = null,
     ): Event {
         if ($event->status === EventStatus::Archived) {
@@ -44,6 +45,7 @@ class UpdateEvent
             'attendance_grace_minutes' => $attendanceGraceMinutes,
             'visibility' => $visibility ?? $event->visibility,
             'notification_email' => $notificationEmail,
+            'priority_unlock_threshold_percent' => $priorityUnlockThresholdPercent,
         ];
 
         if ($titleImage) {
@@ -60,6 +62,7 @@ class UpdateEvent
             ->all();
 
         $event->update($updateData);
+        $event->refresh()->evaluatePriorityGate();
 
         if ($changed && $causer) {
             EventUpdatedActivity::dispatch($event->refresh(), $causer, $changed);

--- a/app/Actions/UpdateShift.php
+++ b/app/Actions/UpdateShift.php
@@ -17,6 +17,7 @@ class UpdateShift
         ?CarbonInterface $endsAt,
         int $capacity,
         bool $isActive,
+        bool $isPriority = false,
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
@@ -30,6 +31,7 @@ class UpdateShift
             'ends_at' => $endsAt,
             'capacity' => $capacity,
             'is_active' => $isActive,
+            'is_priority' => $isPriority,
             'display_text' => $displayText,
         ];
 
@@ -39,6 +41,7 @@ class UpdateShift
             ->all();
 
         $shift->update($updateData);
+        $shift->volunteerJob->event->refresh()->evaluatePriorityGate();
 
         if ($changed && $causer) {
             ShiftUpdated::dispatch($shift->refresh(), $causer, $changed);

--- a/app/Actions/UpdateShift.php
+++ b/app/Actions/UpdateShift.php
@@ -21,6 +21,9 @@ class UpdateShift
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
+        $event = $shift->volunteerJob->event;
+        $hadAvailability = $event->publicSignupJobs()->isNotEmpty();
+
         if ($capacity < $shift->activeSignups()->count()) {
             throw new DomainException('Cannot reduce capacity below current number of signups.');
         }
@@ -42,6 +45,7 @@ class UpdateShift
 
         $shift->update($updateData);
         $shift->volunteerJob->event->refresh()->evaluatePriorityGate();
+        app(ScheduleEventSubscriberNotification::class)->execute($shift->volunteerJob->event->fresh(), $hadAvailability);
 
         if ($changed && $causer) {
             ShiftUpdated::dispatch($shift->refresh(), $causer, $changed);

--- a/app/Actions/UpdateShift.php
+++ b/app/Actions/UpdateShift.php
@@ -16,6 +16,7 @@ class UpdateShift
         ?CarbonInterface $startsAt,
         ?CarbonInterface $endsAt,
         int $capacity,
+        bool $isActive,
         ?string $displayText = null,
         ?User $causer = null,
     ): Shift {
@@ -28,6 +29,7 @@ class UpdateShift
             'starts_at' => $startsAt,
             'ends_at' => $endsAt,
             'capacity' => $capacity,
+            'is_active' => $isActive,
             'display_text' => $displayText,
         ];
 

--- a/app/Actions/UpdateVolunteerJob.php
+++ b/app/Actions/UpdateVolunteerJob.php
@@ -13,12 +13,14 @@ class UpdateVolunteerJob
         string $name,
         ?string $description,
         ?string $instructions,
+        bool $isActive,
         User $causer,
     ): VolunteerJob {
         $updateData = [
             'name' => $name,
             'description' => $description,
             'instructions' => $instructions,
+            'is_active' => $isActive,
         ];
 
         $changed = collect($updateData)

--- a/app/Actions/UpdateVolunteerJob.php
+++ b/app/Actions/UpdateVolunteerJob.php
@@ -16,6 +16,9 @@ class UpdateVolunteerJob
         bool $isActive,
         User $causer,
     ): VolunteerJob {
+        $event = $job->event;
+        $hadAvailability = $event->publicSignupJobs()->isNotEmpty();
+
         $updateData = [
             'name' => $name,
             'description' => $description,
@@ -29,6 +32,7 @@ class UpdateVolunteerJob
             ->all();
 
         $job->update($updateData);
+        app(ScheduleEventSubscriberNotification::class)->execute($job->event->fresh(), $hadAvailability);
 
         if ($changed) {
             JobUpdated::dispatch($job->refresh(), $causer, $changed);

--- a/app/Http/Controllers/EventNotificationSubscriberController.php
+++ b/app/Http/Controllers/EventNotificationSubscriberController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\CompleteEventNotificationSubscription;
+use App\Exceptions\ExpiredVerificationException;
+use App\Models\EventNotificationSubscriber;
+use App\ValueObjects\HashedToken;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\View\View;
+
+class EventNotificationSubscriberController extends Controller
+{
+    public function verify(string $token): View
+    {
+        try {
+            $subscriber = app(CompleteEventNotificationSubscription::class)->execute($token);
+
+            return view('public.event-notification-subscriber-status', [
+                'title' => __('Notification Confirmed'),
+                'heading' => __('You are on the list'),
+                'message' => __('We will email :email as soon as new shifts are available for :event.', [
+                    'email' => $subscriber->email,
+                    'event' => $subscriber->event->name,
+                ]),
+                'actionLabel' => __('Back to event signup'),
+                'actionUrl' => route('events.public', $subscriber->event->public_token),
+            ]);
+        } catch (ExpiredVerificationException) {
+            return view('public.event-notification-subscriber-status', [
+                'title' => __('Link Expired'),
+                'heading' => __('Verification link expired'),
+                'message' => __('Please submit the notification form again if you still want to be notified.'),
+                'actionLabel' => null,
+                'actionUrl' => null,
+            ]);
+        } catch (ModelNotFoundException) {
+            abort(404);
+        }
+    }
+
+    public function unsubscribe(string $token): View
+    {
+        $subscriber = EventNotificationSubscriber::query()
+            ->where('unsubscribe_token_hash', HashedToken::fromPlaintext($token)->hash)
+            ->firstOrFail();
+
+        $event = $subscriber->event;
+        $subscriber->delete();
+
+        return view('public.event-notification-subscriber-status', [
+            'title' => __('Unsubscribed'),
+            'heading' => __('Notifications turned off'),
+            'message' => __('You will no longer receive availability updates for :event.', [
+                'event' => $event->name,
+            ]),
+            'actionLabel' => __('Back to event signup'),
+            'actionUrl' => route('events.public', $event->public_token),
+        ]);
+    }
+}

--- a/app/Jobs/NotifyEventSubscribers.php
+++ b/app/Jobs/NotifyEventSubscribers.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\EventStatus;
+use App\Models\Event;
+use App\Notifications\EventNewShiftsAvailable;
+use App\ValueObjects\HashedToken;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+
+class NotifyEventSubscribers implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $uniqueFor = 120;
+
+    public function __construct(public int $eventId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->eventId;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $event = Event::query()->find($this->eventId);
+
+        if (! $event || $event->status !== EventStatus::PublishedOpen || $event->publicSignupJobs()->isEmpty()) {
+            return;
+        }
+
+        foreach ($event->notificationSubscribers()->verified()->get() as $subscriber) {
+            $plainToken = Str::random(64);
+
+            $subscriber->update([
+                'unsubscribe_token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+                'last_notified_at' => now(),
+            ]);
+
+            Notification::route('mail', $subscriber->email)->notify(
+                new EventNewShiftsAvailable(
+                    $event,
+                    route('events.public', $event->public_token),
+                    route('events.notifications.unsubscribe', $plainToken),
+                ),
+            );
+        }
+    }
+}

--- a/app/Livewire/Events/EventSettings.php
+++ b/app/Livewire/Events/EventSettings.php
@@ -85,6 +85,7 @@ class EventSettings extends Component
                 attendanceGraceMinutes: $this->form->attendanceGraceMinutes !== '' ? (int) $this->form->attendanceGraceMinutes : null,
                 visibility: EventVisibility::from($this->form->visibility),
                 notificationEmail: $this->form->notificationEmail ?: null,
+                priorityUnlockThresholdPercent: $this->form->priorityUnlockThresholdPercent !== '' ? (int) $this->form->priorityUnlockThresholdPercent : null,
                 causer: auth()->user(),
             );
 
@@ -116,6 +117,7 @@ class EventSettings extends Component
             'attendanceGraceMinutes' => $this->event->attendance_grace_minutes ?? '',
             'visibility' => $this->event->visibility?->value ?? 'public',
             'notificationEmail' => $this->event->notification_email ?? '',
+            'priorityUnlockThresholdPercent' => $this->event->priority_unlock_threshold_percent ?? '',
         ]);
         $this->selectedProjectId = $this->event->project_id ? (string) $this->event->project_id : '';
     }

--- a/app/Livewire/Events/EventShow.php
+++ b/app/Livewire/Events/EventShow.php
@@ -79,6 +79,27 @@ class EventShow extends Component
         return route('events.public', $this->event->public_token);
     }
 
+    /**
+     * @return array{is_visible: bool, is_open: bool, threshold_percent: ?int, filled_spots: int, total_spots: int, progress_percent: int, unlocked_at: ?string}
+     */
+    #[Computed]
+    public function priorityGateSummary(): array
+    {
+        $event = $this->event->fresh();
+        $filledSpots = $event->priorityFilledSpots();
+        $totalSpots = $event->priorityCapacityTotal();
+
+        return [
+            'is_visible' => $event->priority_unlock_threshold_percent !== null || $event->priority_gate_unlocked_at !== null || $totalSpots > 0,
+            'is_open' => $event->isPriorityGateOpen(),
+            'threshold_percent' => $event->priority_unlock_threshold_percent,
+            'filled_spots' => $filledSpots,
+            'total_spots' => $totalSpots,
+            'progress_percent' => $totalSpots === 0 ? 100 : min(100, (int) round(($filledSpots / $totalSpots) * 100)),
+            'unlocked_at' => $event->priority_gate_unlocked_at?->format('d.m.Y H:i'),
+        ];
+    }
+
     public function publishEvent(): void
     {
         Gate::authorize('publish', $this->event);

--- a/app/Livewire/Events/JobsAndShiftsManager.php
+++ b/app/Livewire/Events/JobsAndShiftsManager.php
@@ -10,11 +10,14 @@ use App\Actions\DeleteVolunteerJob;
 use App\Actions\UpdateShift;
 use App\Actions\UpdateVolunteerJob;
 use App\Concerns\ConvertsTimezone;
+use App\Exceptions\DomainException;
 use App\Exceptions\HasSignupsException;
 use App\Models\Event;
 use App\Models\Shift;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
@@ -38,6 +41,8 @@ class JobsAndShiftsManager extends Component
 
     public string $jobInstructions = '';
 
+    public bool $jobIsActive = true;
+
     // Shift form
     public bool $showShiftModal = false;
 
@@ -54,6 +59,8 @@ class JobsAndShiftsManager extends Component
     public string $shiftDisplayText = '';
 
     public int $shiftCapacity = 10;
+
+    public bool $shiftIsActive = true;
 
     public function mount(int $eventId): void
     {
@@ -83,6 +90,7 @@ class JobsAndShiftsManager extends Component
         Gate::authorize('manageJobs', $this->event);
 
         $this->reset('editingJobId', 'jobName', 'jobDescription', 'jobInstructions');
+        $this->jobIsActive = true;
         $this->showJobModal = true;
     }
 
@@ -95,6 +103,7 @@ class JobsAndShiftsManager extends Component
         $this->jobName = $job->name;
         $this->jobDescription = $job->description ?? '';
         $this->jobInstructions = $job->instructions ?? '';
+        $this->jobIsActive = $job->isActive();
         $this->showJobModal = true;
     }
 
@@ -102,10 +111,14 @@ class JobsAndShiftsManager extends Component
     {
         Gate::authorize('manageJobs', $this->event);
 
+        /** @var User $user */
+        $user = Auth::user();
+
         $this->validate([
             'jobName' => ['required', 'string', 'max:255'],
             'jobDescription' => ['nullable', 'string'],
             'jobInstructions' => ['nullable', 'string'],
+            'jobIsActive' => ['required', 'boolean'],
         ]);
 
         if ($this->editingJobId) {
@@ -115,7 +128,8 @@ class JobsAndShiftsManager extends Component
                 name: $this->jobName,
                 description: $this->jobDescription ?: null,
                 instructions: $this->jobInstructions ?: null,
-                causer: auth()->user(),
+                isActive: $this->jobIsActive,
+                causer: $user,
             );
         } else {
             app(CreateVolunteerJob::class)->execute(
@@ -123,12 +137,35 @@ class JobsAndShiftsManager extends Component
                 name: $this->jobName,
                 description: $this->jobDescription ?: null,
                 instructions: $this->jobInstructions ?: null,
-                causer: auth()->user(),
+                isActive: $this->jobIsActive,
+                causer: $user,
             );
         }
 
         $this->showJobModal = false;
         $this->reset('editingJobId', 'jobName', 'jobDescription', 'jobInstructions');
+        $this->jobIsActive = true;
+        unset($this->jobs);
+    }
+
+    public function toggleJobActive(int $jobId): void
+    {
+        Gate::authorize('manageJobs', $this->event);
+
+        /** @var User $user */
+        $user = Auth::user();
+
+        $job = $this->event->volunteerJobs()->findOrFail($jobId);
+
+        app(UpdateVolunteerJob::class)->execute(
+            job: $job,
+            name: $job->name,
+            description: $job->description,
+            instructions: $job->instructions,
+            isActive: ! $job->isActive(),
+            causer: $user,
+        );
+
         unset($this->jobs);
     }
 
@@ -153,10 +190,13 @@ class JobsAndShiftsManager extends Component
     {
         Gate::authorize('manageJobs', $this->event);
 
+        /** @var User $user */
+        $user = Auth::user();
+
         $job = $this->event->volunteerJobs()->findOrFail($jobId);
 
         try {
-            app(DeleteVolunteerJob::class)->execute($job, auth()->user());
+            app(DeleteVolunteerJob::class)->execute($job, $user);
         } catch (HasSignupsException $e) {
             $this->addError('job', $e->getMessage());
 
@@ -174,6 +214,7 @@ class JobsAndShiftsManager extends Component
 
         $this->reset('editingShiftId', 'shiftDate', 'shiftStartsAt', 'shiftEndsAt', 'shiftDisplayText');
         $this->shiftCapacity = 10;
+        $this->shiftIsActive = true;
         $this->shiftJobId = $jobId;
         $this->showShiftModal = true;
     }
@@ -191,6 +232,7 @@ class JobsAndShiftsManager extends Component
         $this->shiftEndsAt = $shift->ends_at ? $this->toLocal($shift->ends_at, $tz) : '';
         $this->shiftDisplayText = $shift->display_text ?? '';
         $this->shiftCapacity = $shift->capacity;
+        $this->shiftIsActive = $shift->isActive();
         $this->showShiftModal = true;
     }
 
@@ -198,12 +240,16 @@ class JobsAndShiftsManager extends Component
     {
         Gate::authorize('manageJobs', $this->event);
 
+        /** @var User $user */
+        $user = Auth::user();
+
         $rules = [
             'shiftDate' => ['required', 'date'],
             'shiftStartsAt' => ['nullable', 'date'],
             'shiftEndsAt' => ['nullable', 'date', 'after:shiftStartsAt', 'required_with:shiftStartsAt'],
             'shiftCapacity' => ['required', 'integer', 'min:1'],
             'shiftDisplayText' => [empty($this->shiftStartsAt) ? 'required' : 'nullable', 'string', 'max:255'],
+            'shiftIsActive' => ['required', 'boolean'],
         ];
 
         $this->validate($rules);
@@ -215,15 +261,22 @@ class JobsAndShiftsManager extends Component
 
         if ($this->editingShiftId) {
             $shift = $this->findShift($this->editingShiftId);
-            app(UpdateShift::class)->execute(
-                shift: $shift,
-                shiftDate: Carbon::parse($this->shiftDate),
-                startsAt: $startsAt,
-                endsAt: $endsAt,
-                capacity: $this->shiftCapacity,
-                displayText: $displayText,
-                causer: auth()->user(),
-            );
+            try {
+                app(UpdateShift::class)->execute(
+                    shift: $shift,
+                    shiftDate: Carbon::parse($this->shiftDate),
+                    startsAt: $startsAt,
+                    endsAt: $endsAt,
+                    capacity: $this->shiftCapacity,
+                    isActive: $this->shiftIsActive,
+                    displayText: $displayText,
+                    causer: $user,
+                );
+            } catch (DomainException $e) {
+                $this->addError('shift', $e->getMessage());
+
+                return;
+            }
         } else {
             $job = $this->event->volunteerJobs()->findOrFail($this->shiftJobId);
             app(CreateShift::class)->execute(
@@ -232,14 +285,45 @@ class JobsAndShiftsManager extends Component
                 startsAt: $startsAt,
                 endsAt: $endsAt,
                 capacity: $this->shiftCapacity,
+                isActive: $this->shiftIsActive,
                 displayText: $displayText,
-                causer: auth()->user(),
+                causer: $user,
             );
         }
 
         $this->showShiftModal = false;
         $this->reset('editingShiftId', 'shiftJobId', 'shiftDate', 'shiftStartsAt', 'shiftEndsAt', 'shiftDisplayText');
         $this->shiftCapacity = 10;
+        $this->shiftIsActive = true;
+        unset($this->jobs);
+    }
+
+    public function toggleShiftActive(int $shiftId): void
+    {
+        Gate::authorize('manageJobs', $this->event);
+
+        /** @var User $user */
+        $user = Auth::user();
+
+        $shift = $this->findShift($shiftId);
+
+        try {
+            app(UpdateShift::class)->execute(
+                shift: $shift,
+                shiftDate: $shift->shift_date,
+                startsAt: $shift->starts_at,
+                endsAt: $shift->ends_at,
+                capacity: $shift->capacity,
+                isActive: ! $shift->isActive(),
+                displayText: $shift->display_text,
+                causer: $user,
+            );
+        } catch (DomainException $e) {
+            $this->addError('shift', $e->getMessage());
+
+            return;
+        }
+
         unset($this->jobs);
     }
 
@@ -247,10 +331,13 @@ class JobsAndShiftsManager extends Component
     {
         Gate::authorize('manageJobs', $this->event);
 
+        /** @var User $user */
+        $user = Auth::user();
+
         $shift = $this->findShift($shiftId);
 
         try {
-            app(DeleteShift::class)->execute($shift, auth()->user());
+            app(DeleteShift::class)->execute($shift, $user);
         } catch (HasSignupsException $e) {
             $this->addError('shift', $e->getMessage());
 

--- a/app/Livewire/Events/JobsAndShiftsManager.php
+++ b/app/Livewire/Events/JobsAndShiftsManager.php
@@ -62,6 +62,8 @@ class JobsAndShiftsManager extends Component
 
     public bool $shiftIsActive = true;
 
+    public bool $shiftIsPriority = false;
+
     public function mount(int $eventId): void
     {
         $this->event = currentOrganization()->events()->findOrFail($eventId);
@@ -215,6 +217,7 @@ class JobsAndShiftsManager extends Component
         $this->reset('editingShiftId', 'shiftDate', 'shiftStartsAt', 'shiftEndsAt', 'shiftDisplayText');
         $this->shiftCapacity = 10;
         $this->shiftIsActive = true;
+        $this->shiftIsPriority = false;
         $this->shiftJobId = $jobId;
         $this->showShiftModal = true;
     }
@@ -233,6 +236,7 @@ class JobsAndShiftsManager extends Component
         $this->shiftDisplayText = $shift->display_text ?? '';
         $this->shiftCapacity = $shift->capacity;
         $this->shiftIsActive = $shift->isActive();
+        $this->shiftIsPriority = $shift->is_priority;
         $this->showShiftModal = true;
     }
 
@@ -250,6 +254,7 @@ class JobsAndShiftsManager extends Component
             'shiftCapacity' => ['required', 'integer', 'min:1'],
             'shiftDisplayText' => [empty($this->shiftStartsAt) ? 'required' : 'nullable', 'string', 'max:255'],
             'shiftIsActive' => ['required', 'boolean'],
+            'shiftIsPriority' => ['required', 'boolean'],
         ];
 
         $this->validate($rules);
@@ -269,6 +274,7 @@ class JobsAndShiftsManager extends Component
                     endsAt: $endsAt,
                     capacity: $this->shiftCapacity,
                     isActive: $this->shiftIsActive,
+                    isPriority: $this->shiftIsPriority,
                     displayText: $displayText,
                     causer: $user,
                 );
@@ -286,6 +292,7 @@ class JobsAndShiftsManager extends Component
                 endsAt: $endsAt,
                 capacity: $this->shiftCapacity,
                 isActive: $this->shiftIsActive,
+                isPriority: $this->shiftIsPriority,
                 displayText: $displayText,
                 causer: $user,
             );
@@ -295,6 +302,7 @@ class JobsAndShiftsManager extends Component
         $this->reset('editingShiftId', 'shiftJobId', 'shiftDate', 'shiftStartsAt', 'shiftEndsAt', 'shiftDisplayText');
         $this->shiftCapacity = 10;
         $this->shiftIsActive = true;
+        $this->shiftIsPriority = false;
         unset($this->jobs);
     }
 
@@ -315,6 +323,7 @@ class JobsAndShiftsManager extends Component
                 endsAt: $shift->ends_at,
                 capacity: $shift->capacity,
                 isActive: ! $shift->isActive(),
+                isPriority: $shift->is_priority,
                 displayText: $shift->display_text,
                 causer: $user,
             );

--- a/app/Livewire/Events/ManualEnrollment.php
+++ b/app/Livewire/Events/ManualEnrollment.php
@@ -120,6 +120,7 @@ class ManualEnrollment extends Component
             event: $this->event,
             shiftIds: $this->selectedShifts,
             sendNotification: $this->sendNotification,
+            bypassPriorityGate: true,
         );
 
         $this->enrollmentResult = [

--- a/app/Livewire/Forms/EventSettingsForm.php
+++ b/app/Livewire/Forms/EventSettingsForm.php
@@ -35,6 +35,9 @@ class EventSettingsForm extends Form
     #[Validate('nullable|email|max:255')]
     public string $notificationEmail = '';
 
+    #[Validate('nullable|integer|min:0|max:100')]
+    public $priorityUnlockThresholdPercent = '';
+
     /**
      * Dynamic rules for fields that need runtime context.
      *
@@ -62,5 +65,6 @@ class EventSettingsForm extends Form
         $this->attendanceGraceMinutes = $data['attendanceGraceMinutes'];
         $this->visibility = $data['visibility'];
         $this->notificationEmail = $data['notificationEmail'];
+        $this->priorityUnlockThresholdPercent = $data['priorityUnlockThresholdPercent'];
     }
 }

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -143,7 +143,11 @@ class EventSignup extends Component
                 ->withCount(['activeSignups as signups_count', 'activeReservations as active_reservations_count'])
                 ->orderBy('shift_date')
                 ->orderBy('starts_at')])
-            ->get();
+            ->get()
+            ->filter(fn ($job) => $job->shifts->contains(
+                fn ($shift) => ! $shift->isFull() || in_array((int) $shift->id, $this->existingShiftIds, true)
+            ))
+            ->values();
     }
 
     /**

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -137,7 +137,12 @@ class EventSignup extends Component
     public function jobs(): Collection
     {
         return $this->event->volunteerJobs()
-            ->with(['shifts' => fn ($q) => $q->withCount(['activeSignups as signups_count', 'activeReservations as active_reservations_count'])->orderBy('shift_date')->orderBy('starts_at')])
+            ->active()
+            ->whereHas('shifts', fn ($query) => $query->active())
+            ->with(['shifts' => fn ($query) => $query->active()
+                ->withCount(['activeSignups as signups_count', 'activeReservations as active_reservations_count'])
+                ->orderBy('shift_date')
+                ->orderBy('starts_at')])
             ->get();
     }
 
@@ -396,8 +401,8 @@ class EventSignup extends Component
                 'integer',
                 Rule::exists('shifts', 'id')->where(fn ($q) => $q->whereIn(
                     'volunteer_job_id',
-                    $this->event->volunteerJobs()->select('id'),
-                )),
+                    $this->event->volunteerJobs()->active()->select('id'),
+                )->where('is_active', true)),
             ],
         ]);
 

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -147,6 +147,26 @@ class EventSignup extends Component
     }
 
     /**
+     * @return array{is_open: bool, is_closed: bool, threshold_percent: ?int, filled_spots: int, total_spots: int, progress_percent: int}
+     */
+    #[Computed]
+    public function priorityGateStatus(): array
+    {
+        $event = $this->event->fresh();
+        $filledSpots = $event->priorityFilledSpots();
+        $totalSpots = $event->priorityCapacityTotal();
+
+        return [
+            'is_open' => $event->isPriorityGateOpen(),
+            'is_closed' => ! $event->isPriorityGateOpen(),
+            'threshold_percent' => $event->priority_unlock_threshold_percent,
+            'filled_spots' => $filledSpots,
+            'total_spots' => $totalSpots,
+            'progress_percent' => $totalSpots === 0 ? 100 : min(100, (int) round(($filledSpots / $totalSpots) * 100)),
+        ];
+    }
+
+    /**
      * Job IDs derived from the selected shifts. Uses the cached jobs computed.
      *
      * @return array<int>
@@ -422,11 +442,17 @@ class EventSignup extends Component
             return;
         }
 
-        $result = app(ReserveShifts::class)->execute(
-            shiftIds: $newShiftIds,
-            sessionId: session()->getId(),
-            event: $this->event,
-        );
+        try {
+            $result = app(ReserveShifts::class)->execute(
+                shiftIds: $newShiftIds,
+                sessionId: session()->getId(),
+                event: $this->event,
+            );
+        } catch (DomainException $e) {
+            $this->addError('selectedShiftIds', $e->getMessage());
+
+            return;
+        }
 
         if (! $result->hasReservations()) {
             $this->addError('selectedShiftIds', __('All selected shifts are full.'));

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Public;
 use App\Actions\ProcessVolunteerSignup;
 use App\Actions\ReserveShifts;
 use App\Actions\SendEmailVerification;
+use App\Actions\SubscribeToEventNotifications;
 use App\Enums\EventStatus;
 use App\Enums\GearItemType;
 use App\Enums\HintLocation;
@@ -54,6 +55,8 @@ class EventSignup extends Component
 
     public string $volunteerPhone = '';
 
+    public string $notificationSubscriptionEmail = '';
+
     #[Locked]
     public string $warningMessage = '';
 
@@ -79,6 +82,9 @@ class EventSignup extends Component
 
     #[Locked]
     public ?string $verificationStartedAt = null;
+
+    #[Locked]
+    public string $notificationSubscriptionMessage = '';
 
     public function mount(string $publicToken): void
     {
@@ -136,18 +142,7 @@ class EventSignup extends Component
     #[Computed]
     public function jobs(): Collection
     {
-        return $this->event->volunteerJobs()
-            ->active()
-            ->whereHas('shifts', fn ($query) => $query->active())
-            ->with(['shifts' => fn ($query) => $query->active()
-                ->withCount(['activeSignups as signups_count', 'activeReservations as active_reservations_count'])
-                ->orderBy('shift_date')
-                ->orderBy('starts_at')])
-            ->get()
-            ->filter(fn ($job) => $job->shifts->contains(
-                fn ($shift) => ! $shift->isFull() || in_array((int) $shift->id, $this->existingShiftIds, true)
-            ))
-            ->values();
+        return $this->event->publicSignupJobs($this->existingShiftIds);
     }
 
     /**
@@ -404,7 +399,44 @@ class EventSignup extends Component
             ));
         }
 
+        if ($this->notificationSubscriptionEmail === '') {
+            $this->notificationSubscriptionEmail = $this->volunteerEmail;
+        }
+
         $this->state = WizardState::SelectingShifts;
+    }
+
+    public function subscribeToNotifications(): void
+    {
+        if ($this->state !== WizardState::SelectingShifts || $this->jobs->isNotEmpty()) {
+            $this->addError('notificationSubscriptionEmail', __('Notifications are only available when no shifts can be selected.'));
+
+            return;
+        }
+
+        $this->validate([
+            'notificationSubscriptionEmail' => ['required', 'email', 'max:255'],
+        ]);
+
+        $ipKey = 'event-notification-subscribe:'.request()->ip();
+        if (RateLimiter::tooManyAttempts($ipKey, 10)) {
+            $this->addError('notificationSubscriptionEmail', __('Too many attempts. Please wait a moment before trying again.'));
+
+            return;
+        }
+        RateLimiter::hit($ipKey, 60);
+
+        $emailKey = 'event-notification-subscribe-email:'.$this->event->id.':'.strtolower(trim($this->notificationSubscriptionEmail));
+        if (RateLimiter::tooManyAttempts($emailKey, 3)) {
+            $this->addError('notificationSubscriptionEmail', __('Too many attempts for this email. Please wait a few minutes.'));
+
+            return;
+        }
+        RateLimiter::hit($emailKey, 300);
+
+        app(SubscribeToEventNotifications::class)->execute($this->event, $this->notificationSubscriptionEmail);
+
+        $this->notificationSubscriptionMessage = __('Check your inbox to confirm your notification signup. Once confirmed, we will email you when new shifts become available.');
     }
 
     /**
@@ -620,6 +652,8 @@ class EventSignup extends Component
         $this->reservationExpiresAt = '';
         $this->warningMessage = '';
         $this->lookupMessage = '';
+        $this->notificationSubscriptionEmail = '';
+        $this->notificationSubscriptionMessage = '';
         $this->verificationTokenId = null;
         $this->existingVolunteerId = null;
         $this->existingShiftIds = [];

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -8,6 +8,7 @@ use App\Enums\EventVisibility;
 use App\ValueObjects\PublicToken;
 use Database\Factories\EventFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -103,6 +104,11 @@ class Event extends Model
         return $this->hasMany(CustomRegistrationField::class)->orderBy('sort_order');
     }
 
+    public function notificationSubscribers(): HasMany
+    {
+        return $this->hasMany(EventNotificationSubscriber::class);
+    }
+
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
@@ -193,6 +199,25 @@ class Event extends Model
         return __('Please fill the priority shifts first. Other shifts unlock once :percent% of the priority slots are filled.', [
             'percent' => $this->priority_unlock_threshold_percent,
         ]);
+    }
+
+    /**
+     * @param  array<int>  $existingShiftIds
+     */
+    public function publicSignupJobs(array $existingShiftIds = []): Collection
+    {
+        return $this->volunteerJobs()
+            ->active()
+            ->whereHas('shifts', fn ($query) => $query->active())
+            ->with(['shifts' => fn ($query) => $query->active()
+                ->withCount(['activeSignups as signups_count', 'activeReservations as active_reservations_count'])
+                ->orderBy('shift_date')
+                ->orderBy('starts_at')])
+            ->get()
+            ->filter(fn ($job) => $job->shifts->contains(
+                fn ($shift) => ! $shift->isFull() || in_array((int) $shift->id, $existingShiftIds, true)
+            ))
+            ->values();
     }
 
     public function scopeActive(Builder $query): void

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Str;
 
 class Event extends Model
@@ -35,6 +36,8 @@ class Event extends Model
         'phone_required',
         'visibility',
         'notification_email',
+        'priority_unlock_threshold_percent',
+        'priority_gate_unlocked_at',
         'was_previously_published',
         'deletion_requested_at',
     ];
@@ -49,6 +52,8 @@ class Event extends Model
             'phone_required' => 'boolean',
             'visibility' => EventVisibility::class,
             'volunteer_count' => 'integer',
+            'priority_unlock_threshold_percent' => 'integer',
+            'priority_gate_unlocked_at' => 'datetime',
             'was_previously_published' => 'boolean',
             'deletion_requested_at' => 'datetime',
         ];
@@ -76,6 +81,11 @@ class Event extends Model
     public function eventArrivals(): HasMany
     {
         return $this->hasMany(EventArrival::class);
+    }
+
+    public function shifts(): HasManyThrough
+    {
+        return $this->hasManyThrough(Shift::class, VolunteerJob::class, 'event_id', 'volunteer_job_id');
     }
 
     public function emailTemplates(): HasMany
@@ -115,6 +125,74 @@ class Event extends Model
     public function isPendingDeletion(): bool
     {
         return $this->deletion_requested_at !== null;
+    }
+
+    public function hasActivePriorityShifts(): bool
+    {
+        return $this->shifts()
+            ->where('shifts.is_active', true)
+            ->where('shifts.is_priority', true)
+            ->exists();
+    }
+
+    public function priorityCapacityTotal(): int
+    {
+        return (int) $this->shifts()
+            ->where('shifts.is_active', true)
+            ->where('shifts.is_priority', true)
+            ->sum('shifts.capacity');
+    }
+
+    public function priorityFilledSpots(): int
+    {
+        return ShiftSignup::query()
+            ->active()
+            ->whereHas('shift', fn (Builder $query) => $query
+                ->where('shifts.is_active', true)
+                ->where('shifts.is_priority', true)
+                ->whereHas('volunteerJob', fn (Builder $jobQuery) => $jobQuery->where('event_id', $this->id)))
+            ->count();
+    }
+
+    public function priorityFillRate(): float
+    {
+        $capacityTotal = $this->priorityCapacityTotal();
+
+        if ($capacityTotal === 0) {
+            return 0.0;
+        }
+
+        return $this->priorityFilledSpots() / $capacityTotal;
+    }
+
+    public function isPriorityGateOpen(): bool
+    {
+        return $this->priority_unlock_threshold_percent === null
+            || $this->priority_unlock_threshold_percent <= 0
+            || $this->priority_gate_unlocked_at !== null
+            || ! $this->hasActivePriorityShifts();
+    }
+
+    public function evaluatePriorityGate(): void
+    {
+        if ($this->isPriorityGateOpen()) {
+            return;
+        }
+
+        if (($this->priorityFillRate() * 100) < $this->priority_unlock_threshold_percent) {
+            return;
+        }
+
+        $this->forceFill([
+            'priority_gate_unlocked_at' => now(),
+        ])->save();
+    }
+
+    public function priorityGateMessage(): string
+    {
+        return __('Please fill the priority shifts first. Other shifts unlock once :percent% of the priority slots are filled.', [
+            'percent' => $this->priority_unlock_threshold_percent,
+        ]);
     }
 
     public function scopeActive(Builder $query): void

--- a/app/Models/EventNotificationSubscriber.php
+++ b/app/Models/EventNotificationSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventNotificationSubscriberFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EventNotificationSubscriber extends Model
+{
+    /** @use HasFactory<EventNotificationSubscriberFactory> */
+    use HasFactory;
+
+    use MassPrunable;
+
+    protected $fillable = [
+        'event_id',
+        'email',
+        'verification_token_hash',
+        'verification_expires_at',
+        'verified_at',
+        'unsubscribe_token_hash',
+        'last_notified_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'verification_expires_at' => 'datetime',
+            'verified_at' => 'datetime',
+            'last_notified_at' => 'datetime',
+        ];
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->verified_at !== null;
+    }
+
+    public function prunable(): Builder
+    {
+        return static::query()
+            ->whereNull('verified_at')
+            ->where('verification_expires_at', '<', now());
+    }
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    public function scopeVerified(Builder $query): void
+    {
+        $query->whereNotNull('verified_at');
+    }
+}

--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\AttendanceStatus;
 use Carbon\CarbonInterface;
 use Database\Factories\ShiftFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -22,6 +23,7 @@ class Shift extends Model
         'ends_at',
         'display_text',
         'capacity',
+        'is_active',
     ];
 
     protected function casts(): array
@@ -31,6 +33,7 @@ class Shift extends Model
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
             'capacity' => 'integer',
+            'is_active' => 'boolean',
         ];
     }
 
@@ -66,6 +69,21 @@ class Shift extends Model
     public function activeReservations(): HasMany
     {
         return $this->hasMany(ShiftReservation::class)->active();
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('is_active', true);
+    }
+
+    public function scopeInactive(Builder $query): void
+    {
+        $query->where('is_active', false);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->is_active;
     }
 
     public function isFull(): bool

--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -24,6 +24,7 @@ class Shift extends Model
         'display_text',
         'capacity',
         'is_active',
+        'is_priority',
     ];
 
     protected function casts(): array
@@ -34,6 +35,7 @@ class Shift extends Model
             'ends_at' => 'datetime',
             'capacity' => 'integer',
             'is_active' => 'boolean',
+            'is_priority' => 'boolean',
         ];
     }
 
@@ -79,6 +81,16 @@ class Shift extends Model
     public function scopeInactive(Builder $query): void
     {
         $query->where('is_active', false);
+    }
+
+    public function scopePriority(Builder $query): void
+    {
+        $query->where('is_priority', true);
+    }
+
+    public function scopeNonPriority(Builder $query): void
+    {
+        $query->where('is_priority', false);
     }
 
     public function isActive(): bool

--- a/app/Models/VolunteerJob.php
+++ b/app/Models/VolunteerJob.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Database\Factories\VolunteerJobFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class VolunteerJob extends Model
 {
-    /** @use HasFactory<\Database\Factories\VolunteerJobFactory> */
+    /** @use HasFactory<VolunteerJobFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -17,7 +19,15 @@ class VolunteerJob extends Model
         'name',
         'description',
         'instructions',
+        'is_active',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
 
     public function event(): BelongsTo
     {
@@ -27,5 +37,20 @@ class VolunteerJob extends Model
     public function shifts(): HasMany
     {
         return $this->hasMany(Shift::class);
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('is_active', true);
+    }
+
+    public function scopeInactive(Builder $query): void
+    {
+        $query->where('is_active', false);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->is_active;
     }
 }

--- a/app/Notifications/EventNewShiftsAvailable.php
+++ b/app/Notifications/EventNewShiftsAvailable.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Event;
+use App\Notifications\Concerns\HasRetryStrategy;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class EventNewShiftsAvailable extends Notification implements ShouldQueue
+{
+    use HasRetryStrategy;
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Event $event,
+        public string $signupUrl,
+        public string $unsubscribeUrl,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject(__('New shifts are available for :event', ['event' => $this->event->name]))
+            ->greeting(__('Hello!'))
+            ->line(__('New shifts are now available for :event.', ['event' => $this->event->name]))
+            ->line(__('Open the signup page to choose your shifts.'))
+            ->action(__('Open signup page'), $this->signupUrl)
+            ->line(__('If you no longer want these updates, you can unsubscribe here: :url', ['url' => $this->unsubscribeUrl]));
+
+        return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
+    }
+}

--- a/app/Notifications/EventNotificationSubscriptionVerification.php
+++ b/app/Notifications/EventNotificationSubscriptionVerification.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Event;
+use App\Notifications\Concerns\HasRetryStrategy;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class EventNotificationSubscriptionVerification extends Notification implements ShouldQueue
+{
+    use HasRetryStrategy;
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Event $event,
+        public string $verificationUrl,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject(__('Confirm shift notifications for :event', ['event' => $this->event->name]))
+            ->greeting(__('Hello!'))
+            ->line(__('You asked to be notified when new shifts become available for :event.', ['event' => $this->event->name]))
+            ->line(__('Please confirm your email address to activate this notification.'))
+            ->action(__('Confirm notifications'), $this->verificationUrl);
+
+        return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -33,6 +33,8 @@ class EventFactory extends Factory
             'ends_at' => $endsAt,
             'status' => EventStatus::Draft,
             'visibility' => EventVisibility::Public,
+            'priority_unlock_threshold_percent' => null,
+            'priority_gate_unlocked_at' => null,
         ];
     }
 

--- a/database/factories/EventNotificationSubscriberFactory.php
+++ b/database/factories/EventNotificationSubscriberFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventNotificationSubscriber;
+use App\ValueObjects\HashedToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventNotificationSubscriber>
+ */
+class EventNotificationSubscriberFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'email' => fake()->safeEmail(),
+            'verification_token_hash' => HashedToken::fromPlaintext(fake()->sha256())->hash,
+            'verification_expires_at' => now()->addDays(7),
+            'verified_at' => null,
+            'unsubscribe_token_hash' => null,
+            'last_notified_at' => null,
+        ];
+    }
+
+    public function verified(): static
+    {
+        return $this->state(fn () => [
+            'verified_at' => now(),
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn () => [
+            'verification_expires_at' => now()->subMinute(),
+        ]);
+    }
+}

--- a/database/factories/ShiftFactory.php
+++ b/database/factories/ShiftFactory.php
@@ -25,6 +25,7 @@ class ShiftFactory extends Factory
             'ends_at' => $endsAt,
             'capacity' => fake()->numberBetween(5, 30),
             'is_active' => true,
+            'is_priority' => false,
         ];
     }
 
@@ -47,5 +48,10 @@ class ShiftFactory extends Factory
     public function inactive(): static
     {
         return $this->state(fn () => ['is_active' => false]);
+    }
+
+    public function priority(): static
+    {
+        return $this->state(fn () => ['is_priority' => true]);
     }
 }

--- a/database/factories/ShiftFactory.php
+++ b/database/factories/ShiftFactory.php
@@ -24,6 +24,7 @@ class ShiftFactory extends Factory
             'starts_at' => $startsAt,
             'ends_at' => $endsAt,
             'capacity' => fake()->numberBetween(5, 30),
+            'is_active' => true,
         ];
     }
 
@@ -41,5 +42,10 @@ class ShiftFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'capacity' => 0,
         ]);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn () => ['is_active' => false]);
     }
 }

--- a/database/factories/VolunteerJobFactory.php
+++ b/database/factories/VolunteerJobFactory.php
@@ -7,7 +7,7 @@ use App\Models\VolunteerJob;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VolunteerJob>
+ * @extends Factory<VolunteerJob>
  */
 class VolunteerJobFactory extends Factory
 {
@@ -20,6 +20,12 @@ class VolunteerJobFactory extends Factory
             'name' => fake()->jobTitle(),
             'description' => fake()->sentence(),
             'instructions' => fake()->paragraph(),
+            'is_active' => true,
         ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn () => ['is_active' => false]);
     }
 }

--- a/database/migrations/2026_04_30_124322_add_is_active_to_volunteer_jobs_and_shifts_tables.php
+++ b/database/migrations/2026_04_30_124322_add_is_active_to_volunteer_jobs_and_shifts_tables.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('volunteer_jobs', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('instructions');
+        });
+
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('capacity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+
+        Schema::table('volunteer_jobs', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/database/migrations/2026_04_30_130551_add_priority_gate_fields_to_events_table.php
+++ b/database/migrations/2026_04_30_130551_add_priority_gate_fields_to_events_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->unsignedTinyInteger('priority_unlock_threshold_percent')->nullable()->after('notification_email');
+            $table->dateTime('priority_gate_unlocked_at')->nullable()->after('priority_unlock_threshold_percent');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn(['priority_unlock_threshold_percent', 'priority_gate_unlocked_at']);
+        });
+    }
+};

--- a/database/migrations/2026_04_30_130552_add_is_priority_to_shifts_table.php
+++ b/database/migrations/2026_04_30_130552_add_is_priority_to_shifts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->boolean('is_priority')->default(false)->after('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->dropColumn('is_priority');
+        });
+    }
+};

--- a/database/migrations/2026_04_30_133803_create_event_notification_subscribers_table.php
+++ b/database/migrations/2026_04_30_133803_create_event_notification_subscribers_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_notification_subscribers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->string('verification_token_hash')->nullable();
+            $table->dateTime('verification_expires_at')->nullable();
+            $table->dateTime('verified_at')->nullable();
+            $table->string('unsubscribe_token_hash')->nullable();
+            $table->dateTime('last_notified_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['event_id', 'email']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_notification_subscribers');
+    }
+};

--- a/resources/views/livewire/events/event-list.blade.php
+++ b/resources/views/livewire/events/event-list.blade.php
@@ -73,9 +73,10 @@
                                     </flux:badge>
                                 </div>
                                 <div class="mt-1 flex flex-col gap-1 text-sm text-zinc-500 dark:text-zinc-400">
+                                    @php($projectTimezone = $event->project->timezone ?: 'UTC')
                                     <span class="inline-flex items-center gap-1">
                                         <flux:icon name="calendar" variant="mini" class="size-4 shrink-0" />
-                                        {{ $event->starts_at->setTimezone($event->project->timezone ?? 'UTC')->format('M d, Y g:i A') }} &mdash; {{ $event->ends_at->setTimezone($event->project->timezone ?? 'UTC')->format('g:i A') }}
+                                        {{ $event->starts_at->setTimezone($projectTimezone)->format('M d, Y g:i A') }} &mdash; {{ $event->ends_at->setTimezone($projectTimezone)->format('g:i A') }}
                                     </span>
                                     @if ($event->location)
                                         <span class="inline-flex items-center gap-1">

--- a/resources/views/livewire/events/event-settings.blade.php
+++ b/resources/views/livewire/events/event-settings.blade.php
@@ -90,6 +90,13 @@
                             </flux:select>
                         </flux:field>
                     @endif
+
+                    <flux:field>
+                        <flux:label>{{ __('Priority Shift Unlock Threshold (%)') }}</flux:label>
+                        <flux:input type="number" wire:model="form.priorityUnlockThresholdPercent" min="0" max="100" placeholder="{{ __('Disabled') }}" />
+                        <flux:description>{{ __('Leave empty to disable shift priority gating for this event. 80 means regular shifts unlock once 80% of priority slots are filled.') }}</flux:description>
+                        <flux:error name="form.priorityUnlockThresholdPercent" />
+                    </flux:field>
                 </div>
             </flux:card>
 

--- a/resources/views/livewire/events/event-show.blade.php
+++ b/resources/views/livewire/events/event-show.blade.php
@@ -198,6 +198,43 @@
             </flux:card>
         </div>
 
+        @if ($this->priorityGateSummary['is_visible'])
+            <flux:card class="mb-6">
+                <div class="space-y-3">
+                    <div class="flex items-center justify-between gap-3">
+                        <div>
+                            <flux:heading size="sm">{{ __('Priority Shift Gate') }}</flux:heading>
+                            @if ($this->priorityGateSummary['is_open'])
+                                <flux:text size="sm">
+                                    {{ $this->priorityGateSummary['unlocked_at']
+                                        ? __('Gate open since :date', ['date' => $this->priorityGateSummary['unlocked_at']])
+                                        : __('Gate currently open') }}
+                                </flux:text>
+                            @else
+                                <flux:text size="sm">{{ __('Gate closed until the priority threshold is reached.') }}</flux:text>
+                            @endif
+                        </div>
+                        <flux:badge size="sm" :color="$this->priorityGateSummary['is_open'] ? 'emerald' : 'amber'">
+                            {{ $this->priorityGateSummary['is_open'] ? __('Open') : __('Closed') }}
+                        </flux:badge>
+                    </div>
+
+                    @if ($this->priorityGateSummary['threshold_percent'] !== null)
+                        <flux:text size="sm">
+                            {{ __(':filled of :total priority slots filled. Unlock threshold: :threshold%.', [
+                                'filled' => $this->priorityGateSummary['filled_spots'],
+                                'total' => $this->priorityGateSummary['total_spots'],
+                                'threshold' => $this->priorityGateSummary['threshold_percent'],
+                            ]) }}
+                        </flux:text>
+                        <div class="h-2 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+                            <div class="h-full rounded-full bg-amber-500 transition-all" style="width: {{ $this->priorityGateSummary['progress_percent'] }}%;"></div>
+                        </div>
+                    @endif
+                </div>
+            </flux:card>
+        @endif
+
         {{-- Title image --}}
         @if ($event->titleImageUrl())
             <div class="mb-6">

--- a/resources/views/livewire/events/jobs-and-shifts-manager.blade.php
+++ b/resources/views/livewire/events/jobs-and-shifts-manager.blade.php
@@ -86,6 +86,7 @@
                                         <flux:table.column>{{ __('Time') }}</flux:table.column>
                                         <flux:table.column>{{ __('Signups') }}</flux:table.column>
                                         <flux:table.column>{{ __('Status') }}</flux:table.column>
+                                        <flux:table.column>{{ __('Priority') }}</flux:table.column>
                                         @if ($this->canManage)
                                             <flux:table.column align="end">{{ __('Actions') }}</flux:table.column>
                                         @endif
@@ -107,6 +108,13 @@
                                                         <flux:badge size="sm" color="red">{{ __('Full') }}</flux:badge>
                                                     @else
                                                         <flux:badge size="sm" color="emerald">{{ __('Open') }}</flux:badge>
+                                                    @endif
+                                                </flux:table.cell>
+                                                <flux:table.cell>
+                                                    @if ($shift->is_priority)
+                                                        <flux:badge size="sm" color="amber">{{ __('Priority') }}</flux:badge>
+                                                    @else
+                                                        <flux:text size="sm" variant="subtle">{{ __('Regular') }}</flux:text>
                                                     @endif
                                                 </flux:table.cell>
                                                 @if ($this->canManage)
@@ -236,6 +244,14 @@
                         <flux:text size="sm">{{ __('Inactive shifts stay visible in admin but are hidden from public signup.') }}</flux:text>
                     </div>
                     <flux:switch wire:model="shiftIsActive" />
+                </div>
+
+                <div class="flex items-center justify-between rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
+                    <div>
+                        <flux:text class="font-medium">{{ __('Priority Shift') }}</flux:text>
+                        <flux:text size="sm">{{ __('Priority shifts must fill first before regular shifts unlock on the public signup page.') }}</flux:text>
+                    </div>
+                    <flux:switch wire:model="shiftIsPriority" />
                 </div>
 
                 <div class="flex">

--- a/resources/views/livewire/events/jobs-and-shifts-manager.blade.php
+++ b/resources/views/livewire/events/jobs-and-shifts-manager.blade.php
@@ -45,13 +45,25 @@
                         {{-- Job header --}}
                         <div class="flex flex-wrap items-center justify-between gap-2 p-4 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
                             <div>
-                                <flux:heading size="sm">{{ $job->name }}</flux:heading>
+                                <div class="flex items-center gap-2">
+                                    <flux:heading size="sm">{{ $job->name }}</flux:heading>
+                                    @unless ($job->is_active)
+                                        <flux:badge size="sm" color="zinc">{{ __('Inactive') }}</flux:badge>
+                                    @endunless
+                                </div>
                                 @if ($job->description)
                                     <flux:text size="sm" class="mt-1">{{ $job->description }}</flux:text>
                                 @endif
                             </div>
                             @if ($this->canManage)
                                 <div class="flex items-center gap-2">
+                                    <flux:button
+                                        variant="ghost"
+                                        size="sm"
+                                        icon="power"
+                                        wire:click="toggleJobActive({{ $job->id }})"
+                                        wire:confirm="{{ $job->is_active ? __('Deactivate this job? It will disappear from public signup but remain available for existing signups.') : __('Reactivate this job for public signup?') }}"
+                                    />
                                     <flux:button variant="ghost" size="sm" icon="pencil" wire:click="openEditJob({{ $job->id }})" />
                                     <flux:button variant="ghost" size="sm" icon="square-2-stack"
                                         wire:click="cloneJob({{ $job->id }})"
@@ -73,7 +85,7 @@
                                     <flux:table.columns>
                                         <flux:table.column>{{ __('Time') }}</flux:table.column>
                                         <flux:table.column>{{ __('Signups') }}</flux:table.column>
-                                        <flux:table.column>{{ __('Capacity') }}</flux:table.column>
+                                        <flux:table.column>{{ __('Status') }}</flux:table.column>
                                         @if ($this->canManage)
                                             <flux:table.column align="end">{{ __('Actions') }}</flux:table.column>
                                         @endif
@@ -89,7 +101,9 @@
                                                     {{ $shift->signups_count }} / {{ $shift->capacity }}
                                                 </flux:table.cell>
                                                 <flux:table.cell>
-                                                    @if ($shift->signups_count >= $shift->capacity)
+                                                    @if (! $shift->is_active)
+                                                        <flux:badge size="sm" color="zinc">{{ __('Inactive') }}</flux:badge>
+                                                    @elseif ($shift->signups_count >= $shift->capacity)
                                                         <flux:badge size="sm" color="red">{{ __('Full') }}</flux:badge>
                                                     @else
                                                         <flux:badge size="sm" color="emerald">{{ __('Open') }}</flux:badge>
@@ -98,6 +112,13 @@
                                                 @if ($this->canManage)
                                                     <flux:table.cell align="end">
                                                         <div class="flex items-center justify-end gap-1">
+                                                            <flux:button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                icon="power"
+                                                                wire:click="toggleShiftActive({{ $shift->id }})"
+                                                                wire:confirm="{{ $shift->is_active ? __('Deactivate this shift? It will disappear from public signup but remain on existing signups.') : __('Reactivate this shift for public signup?') }}"
+                                                            />
                                                             <flux:button variant="ghost" size="sm" icon="pencil" wire:click="openEditShift({{ $shift->id }})" />
                                                             <flux:button variant="ghost" size="sm" icon="trash" wire:click="deleteShift({{ $shift->id }})"
                                                                 wire:confirm="{{ __('Delete this shift?') }}" />
@@ -150,6 +171,14 @@
                     <flux:error name="jobInstructions" />
                 </flux:field>
 
+                <div class="flex items-center justify-between rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
+                    <div>
+                        <flux:text class="font-medium">{{ __('Active') }}</flux:text>
+                        <flux:text size="sm">{{ __('Inactive jobs stay visible in admin but are hidden from public signup.') }}</flux:text>
+                    </div>
+                    <flux:switch wire:model="jobIsActive" />
+                </div>
+
                 <div class="flex">
                     <flux:spacer />
                     <flux:button type="submit" variant="primary">{{ $editingJobId ? __('Save Changes') : __('Add Job') }}</flux:button>
@@ -200,6 +229,14 @@
                     <flux:input type="number" wire:model="shiftCapacity" min="1" />
                     <flux:error name="shiftCapacity" />
                 </flux:field>
+
+                <div class="flex items-center justify-between rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
+                    <div>
+                        <flux:text class="font-medium">{{ __('Active') }}</flux:text>
+                        <flux:text size="sm">{{ __('Inactive shifts stay visible in admin but are hidden from public signup.') }}</flux:text>
+                    </div>
+                    <flux:switch wire:model="shiftIsActive" />
+                </div>
 
                 <div class="flex">
                     <flux:spacer />

--- a/resources/views/livewire/public/event-signup.blade.php
+++ b/resources/views/livewire/public/event-signup.blade.php
@@ -307,92 +307,124 @@
                     </div>
                 @endif
 
-                @foreach ($this->jobs as $job)
-                    <div class="rounded-lg overflow-hidden" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);" wire:key="job-{{ $job->id }}">
-                        <div class="p-4" style="background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);">
-                            <h3 class="text-sm font-semibold text-white">{{ $job->name }}</h3>
-                            @if ($job->description)
-                                <p class="mt-1 text-sm" style="color: #a1a1aa;">{{ $job->description }}</p>
-                            @endif
-                            @if ($job->instructions)
-                                <a href="{{ route('events.jobs.cheat-sheet', ['publicToken' => $event->public_token, 'jobId' => $job->id]) }}" target="_blank"
-                                   class="inline-flex items-center gap-1 mt-2 text-sm" style="color: var(--brand); text-decoration: none;">
-                                    <flux:icon name="document-text" variant="mini" class="size-4" />
-                                    {{ __('View Instructions') }}
-                                </a>
-                            @endif
-                        </div>
+                @if ($this->jobs->isEmpty())
+                    <div class="rounded-2xl p-6" style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);">
+                        <div class="flex items-start gap-3">
+                            <flux:icon name="bell-alert" class="size-6 shrink-0" style="color: var(--brand);" />
+                            <div class="w-full">
+                                <h3 class="text-lg font-semibold text-white">{{ __('No shifts are available right now') }}</h3>
+                                <p class="mt-2 text-sm" style="color: #d4d4d8;">{{ __('All shifts are currently full or still being planned. Enter your email to get notified as soon as new shifts open up for this event.') }}</p>
 
-                        <div class="p-4 space-y-3">
-                            @foreach ($job->shifts as $shift)
-                                @php
-                                    $spotsLeft = $shift->spotsRemaining();
-                                    $isFull = $spotsLeft === 0;
-                                    $isSelected = in_array($shift->id, $selectedShiftIds);
-                                    $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
-                                    $isExisting = in_array($shift->id, $existingShiftIds);
-                                    $isLockedByPriorityGate = $this->priorityGateStatus['is_closed'] && ! $shift->is_priority && ! $isExisting;
-                                    $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
-                                @endphp
-                                <label
-                                    class="flex items-center justify-between p-3 rounded-lg transition-all duration-200"
-                                    style="border: 2px solid {{ $isExisting ? 'rgba(59,130,246,0.3)' : ($isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)')) }};
-                                           background: {{ $isExisting ? 'rgba(59,130,246,0.08)' : ($isSelected && $isConflicting ? 'rgba(244,208,63,0.08)' : ($isSelected ? 'rgba(5,150,105,0.08)' : 'transparent')) }};
-                                           {{ $isExisting ? 'opacity: 0.7; cursor: default;' : ($isFull || $isLockedByPriorityGate ? 'opacity: 0.4; cursor: not-allowed;' : 'cursor: pointer;') }}"
-                                    wire:key="shift-{{ $shift->id }}"
-                                >
-                                    <div class="flex items-center gap-3">
-                                        <input type="checkbox" value="{{ $shift->id }}"
-                                            wire:model.live="selectedShiftIds"
-                                            @disabled($isFull || $isExisting || $isLockedByPriorityGate)
-                                            @checked($isExisting)
-                                            @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
-                                            @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
-                                            @if ($isLockedByPriorityGate) aria-label="{{ $shiftTimeLabel }} — {{ __('Locked until priority shifts are filled') }}" @endif
-                                            class="accent-emerald-600"
-                                        />
-                                        <div>
-                                            <span class="text-sm font-medium text-white">
-                                                {{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}
-                                            </span>
-                                            @if ($shift->is_priority)
-                                                <span class="ml-2 inline-flex rounded px-2 py-0.5 text-xs font-semibold" style="background: rgba(245,158,11,0.15); color: #fbbf24;">{{ __('Priority') }}</span>
-                                            @endif
-                                            @if ($isExisting)
-                                                <span class="block text-sm font-semibold" style="color: #93c5fd;">
-                                                    {{ __('Already signed up') }}
-                                                </span>
-                                            @elseif ($isLockedByPriorityGate)
-                                                <span class="block text-sm" style="color: #a1a1aa;">
-                                                    {{ __('Locked until the priority shift threshold is reached.') }}
-                                                </span>
-                                            @elseif ($spotsLeft <= 3 && $spotsLeft > 0)
-                                                <span class="block text-sm font-semibold urgency-pulse" style="color: var(--yellow);">
-                                                    {{ __('Nur noch :count Plätze!', ['count' => $spotsLeft]) }}
-                                                </span>
-                                            @else
-                                                <span class="block text-sm" style="color: #a1a1aa;">
-                                                    {{ $spotsLeft }} {{ __('spots remaining') }}
-                                                </span>
-                                            @endif
-                                        </div>
+                                <div class="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto]">
+                                    <flux:field>
+                                        <flux:label>{{ __('Email') }}</flux:label>
+                                        <flux:input type="email" wire:model="notificationSubscriptionEmail" placeholder="{{ __('your@email.com') }}" />
+                                        <flux:error name="notificationSubscriptionEmail" />
+                                    </flux:field>
+
+                                    <div class="flex items-end">
+                                        <button wire:click="subscribeToNotifications" wire:loading.attr="disabled" class="public-btn-primary w-full md:w-auto">
+                                            {{ __('Notify me') }}
+                                        </button>
                                     </div>
-                                    @if ($isExisting)
-                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
-                                    @elseif ($isLockedByPriorityGate)
-                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(161,161,170,0.15); color: #d4d4d8;">{{ __('Locked') }}</span>
-                                    @elseif ($isFull)
-                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Full') }}</span>
-                                    @elseif ($isConflicting && $isSelected)
-                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(244,208,63,0.15); color: #fbbf24;">{{ __('Conflict') }}</span>
-                                    @else
-                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(5,150,105,0.15); color: #6ee7b7;">{{ __('Open') }}</span>
-                                    @endif
-                                </label>
-                            @endforeach
+                                </div>
+
+                                @if ($notificationSubscriptionMessage)
+                                    <p class="mt-4 text-sm" style="color: #6ee7b7;">{{ $notificationSubscriptionMessage }}</p>
+                                @endif
+
+                                <p class="mt-4 text-xs" style="color: #9a9a9a;">{{ __('We only use your email for this event notification. Every update email includes an unsubscribe link.') }}</p>
+                            </div>
                         </div>
                     </div>
-                @endforeach
+                @else
+                    @foreach ($this->jobs as $job)
+                        <div class="rounded-lg overflow-hidden" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);" wire:key="job-{{ $job->id }}">
+                            <div class="p-4" style="background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);">
+                                <h3 class="text-sm font-semibold text-white">{{ $job->name }}</h3>
+                                @if ($job->description)
+                                    <p class="mt-1 text-sm" style="color: #a1a1aa;">{{ $job->description }}</p>
+                                @endif
+                                @if ($job->instructions)
+                                    <a href="{{ route('events.jobs.cheat-sheet', ['publicToken' => $event->public_token, 'jobId' => $job->id]) }}" target="_blank"
+                                       class="inline-flex items-center gap-1 mt-2 text-sm" style="color: var(--brand); text-decoration: none;">
+                                        <flux:icon name="document-text" variant="mini" class="size-4" />
+                                        {{ __('View Instructions') }}
+                                    </a>
+                                @endif
+                            </div>
+
+                            <div class="p-4 space-y-3">
+                                @foreach ($job->shifts as $shift)
+                                    @php
+                                        $spotsLeft = $shift->spotsRemaining();
+                                        $isFull = $spotsLeft === 0;
+                                        $isSelected = in_array($shift->id, $selectedShiftIds);
+                                        $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
+                                        $isExisting = in_array($shift->id, $existingShiftIds);
+                                        $isLockedByPriorityGate = $this->priorityGateStatus['is_closed'] && ! $shift->is_priority && ! $isExisting;
+                                        $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
+                                    @endphp
+                                    <label
+                                        class="flex items-center justify-between p-3 rounded-lg transition-all duration-200"
+                                        style="border: 2px solid {{ $isExisting ? 'rgba(59,130,246,0.3)' : ($isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)')) }};
+                                               background: {{ $isExisting ? 'rgba(59,130,246,0.08)' : ($isSelected && $isConflicting ? 'rgba(244,208,63,0.08)' : ($isSelected ? 'rgba(5,150,105,0.08)' : 'transparent')) }};
+                                               {{ $isExisting ? 'opacity: 0.7; cursor: default;' : ($isFull || $isLockedByPriorityGate ? 'opacity: 0.4; cursor: not-allowed;' : 'cursor: pointer;') }}"
+                                        wire:key="shift-{{ $shift->id }}"
+                                    >
+                                        <div class="flex items-center gap-3">
+                                            <input type="checkbox" value="{{ $shift->id }}"
+                                                wire:model.live="selectedShiftIds"
+                                                @disabled($isFull || $isExisting || $isLockedByPriorityGate)
+                                                @checked($isExisting)
+                                                @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
+                                                @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
+                                                @if ($isLockedByPriorityGate) aria-label="{{ $shiftTimeLabel }} — {{ __('Locked until priority shifts are filled') }}" @endif
+                                                class="accent-emerald-600"
+                                            />
+                                            <div>
+                                                <span class="text-sm font-medium text-white">
+                                                    {{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}
+                                                </span>
+                                                @if ($shift->is_priority)
+                                                    <span class="ml-2 inline-flex rounded px-2 py-0.5 text-xs font-semibold" style="background: rgba(245,158,11,0.15); color: #fbbf24;">{{ __('Priority') }}</span>
+                                                @endif
+                                                @if ($isExisting)
+                                                    <span class="block text-sm font-semibold" style="color: #93c5fd;">
+                                                        {{ __('Already signed up') }}
+                                                    </span>
+                                                @elseif ($isLockedByPriorityGate)
+                                                    <span class="block text-sm" style="color: #a1a1aa;">
+                                                        {{ __('Locked until the priority shift threshold is reached.') }}
+                                                    </span>
+                                                @elseif ($spotsLeft <= 3 && $spotsLeft > 0)
+                                                    <span class="block text-sm font-semibold urgency-pulse" style="color: var(--yellow);">
+                                                        {{ __('Nur noch :count Plätze!', ['count' => $spotsLeft]) }}
+                                                    </span>
+                                                @else
+                                                    <span class="block text-sm" style="color: #a1a1aa;">
+                                                        {{ $spotsLeft }} {{ __('spots remaining') }}
+                                                    </span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        @if ($isExisting)
+                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
+                                        @elseif ($isLockedByPriorityGate)
+                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(161,161,170,0.15); color: #d4d4d8;">{{ __('Locked') }}</span>
+                                        @elseif ($isFull)
+                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Full') }}</span>
+                                        @elseif ($isConflicting && $isSelected)
+                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(244,208,63,0.15); color: #fbbf24;">{{ __('Conflict') }}</span>
+                                        @else
+                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(5,150,105,0.15); color: #6ee7b7;">{{ __('Open') }}</span>
+                                        @endif
+                                    </label>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endforeach
+                @endif
             </div>
 
             @if (count($this->overlappingShiftIds) > 0)
@@ -405,9 +437,11 @@
                 <button wire:click="goBack" class="flex-1 public-btn-ghost">
                     {{ __('Back') }}
                 </button>
-                <button wire:click="reserveAndAdvance" wire:loading.attr="disabled" class="flex-1 public-btn-primary">
-                    {{ __('Continue') }}
-                </button>
+                @if ($this->jobs->isNotEmpty())
+                    <button wire:click="reserveAndAdvance" wire:loading.attr="disabled" class="flex-1 public-btn-primary">
+                        {{ __('Continue') }}
+                    </button>
+                @endif
             </div>
         </div>
 

--- a/resources/views/livewire/public/event-signup.blade.php
+++ b/resources/views/livewire/public/event-signup.blade.php
@@ -287,6 +287,26 @@
                     @endif
                 </div>
 
+                @if ($this->priorityGateStatus['is_closed'])
+                    <div class="rounded-lg p-4" style="background: rgba(244,208,63,0.1); border: 1px solid rgba(244,208,63,0.25);">
+                        <div class="flex items-start gap-3">
+                            <flux:icon name="lock-closed" class="size-5 shrink-0" style="color: #fbbf24;" />
+                            <div class="w-full">
+                                <p class="text-sm font-semibold text-white">{{ __('Priority shifts first') }}</p>
+                                <p class="mt-1 text-sm" style="color: #fcd34d;">
+                                    {{ __('Once :percent% of the priority slots are filled, the remaining shifts unlock.', ['percent' => $this->priorityGateStatus['threshold_percent']]) }}
+                                </p>
+                                <p class="mt-1 text-sm" style="color: #a1a1aa;">
+                                    {{ __(':filled of :total priority slots are filled.', ['filled' => $this->priorityGateStatus['filled_spots'], 'total' => $this->priorityGateStatus['total_spots']]) }}
+                                </p>
+                                <div class="mt-3 h-2 w-full overflow-hidden rounded-full" style="background: rgba(255,255,255,0.08);">
+                                    <div class="h-full rounded-full transition-all duration-300" style="width: {{ $this->priorityGateStatus['progress_percent'] }}%; background: linear-gradient(90deg, #f59e0b, #10b981);"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+
                 @foreach ($this->jobs as $job)
                     <div class="rounded-lg overflow-hidden" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);" wire:key="job-{{ $job->id }}">
                         <div class="p-4" style="background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);">
@@ -311,31 +331,40 @@
                                     $isSelected = in_array($shift->id, $selectedShiftIds);
                                     $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
                                     $isExisting = in_array($shift->id, $existingShiftIds);
+                                    $isLockedByPriorityGate = $this->priorityGateStatus['is_closed'] && ! $shift->is_priority && ! $isExisting;
                                     $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
                                 @endphp
                                 <label
                                     class="flex items-center justify-between p-3 rounded-lg transition-all duration-200"
                                     style="border: 2px solid {{ $isExisting ? 'rgba(59,130,246,0.3)' : ($isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)')) }};
                                            background: {{ $isExisting ? 'rgba(59,130,246,0.08)' : ($isSelected && $isConflicting ? 'rgba(244,208,63,0.08)' : ($isSelected ? 'rgba(5,150,105,0.08)' : 'transparent')) }};
-                                           {{ $isExisting ? 'opacity: 0.7; cursor: default;' : ($isFull ? 'opacity: 0.4; cursor: not-allowed;' : 'cursor: pointer;') }}"
+                                           {{ $isExisting ? 'opacity: 0.7; cursor: default;' : ($isFull || $isLockedByPriorityGate ? 'opacity: 0.4; cursor: not-allowed;' : 'cursor: pointer;') }}"
                                     wire:key="shift-{{ $shift->id }}"
                                 >
                                     <div class="flex items-center gap-3">
                                         <input type="checkbox" value="{{ $shift->id }}"
                                             wire:model.live="selectedShiftIds"
-                                            @disabled($isFull || $isExisting)
+                                            @disabled($isFull || $isExisting || $isLockedByPriorityGate)
                                             @checked($isExisting)
                                             @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
                                             @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
+                                            @if ($isLockedByPriorityGate) aria-label="{{ $shiftTimeLabel }} — {{ __('Locked until priority shifts are filled') }}" @endif
                                             class="accent-emerald-600"
                                         />
                                         <div>
                                             <span class="text-sm font-medium text-white">
                                                 {{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}
                                             </span>
+                                            @if ($shift->is_priority)
+                                                <span class="ml-2 inline-flex rounded px-2 py-0.5 text-xs font-semibold" style="background: rgba(245,158,11,0.15); color: #fbbf24;">{{ __('Priority') }}</span>
+                                            @endif
                                             @if ($isExisting)
                                                 <span class="block text-sm font-semibold" style="color: #93c5fd;">
                                                     {{ __('Already signed up') }}
+                                                </span>
+                                            @elseif ($isLockedByPriorityGate)
+                                                <span class="block text-sm" style="color: #a1a1aa;">
+                                                    {{ __('Locked until the priority shift threshold is reached.') }}
                                                 </span>
                                             @elseif ($spotsLeft <= 3 && $spotsLeft > 0)
                                                 <span class="block text-sm font-semibold urgency-pulse" style="color: var(--yellow);">
@@ -350,6 +379,8 @@
                                     </div>
                                     @if ($isExisting)
                                         <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
+                                    @elseif ($isLockedByPriorityGate)
+                                        <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(161,161,170,0.15); color: #d4d4d8;">{{ __('Locked') }}</span>
                                     @elseif ($isFull)
                                         <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(230,57,70,0.15); color: #fca5a5;">{{ __('Full') }}</span>
                                     @elseif ($isConflicting && $isSelected)

--- a/resources/views/public/event-notification-subscriber-status.blade.php
+++ b/resources/views/public/event-notification-subscriber-status.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.public')
+
+@section('content')
+    <section class="mx-auto max-w-2xl pt-12">
+        <div class="rounded-2xl p-8" style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);">
+            <p class="text-sm font-semibold uppercase tracking-[0.2em]" style="color: var(--brand);">{{ $title }}</p>
+            <h1 class="mt-3 font-bebas text-4xl text-white" style="letter-spacing: 0.04em;">{{ $heading }}</h1>
+            <p class="mt-4 text-base" style="color: #d4d4d8;">{{ $message }}</p>
+
+            @if ($actionUrl && $actionLabel)
+                <div class="mt-6">
+                    <a href="{{ $actionUrl }}" class="public-btn-primary inline-flex items-center justify-center" style="text-decoration: none;">
+                        {{ $actionLabel }}
+                    </a>
+                </div>
+            @endif
+        </div>
+    </section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\EventNotificationSubscriberController;
 use App\Http\Controllers\GuestPassController;
 use App\Http\Controllers\VolunteerExportController;
 use App\Livewire\ActivityFeed;
@@ -60,6 +61,8 @@ if (app()->environment('local')) {
 Route::livewire('p/{publicToken}', ProjectWebsite::class)->name('projects.public');
 Route::livewire('events/{publicToken}', EventSignup::class)->name('events.public')->middleware('throttle:60,1');
 Route::livewire('events/{publicToken}/jobs/{jobId}/cheat-sheet', JobCheatSheet::class)->name('events.jobs.cheat-sheet');
+Route::get('event-notifications/verify/{token}', [EventNotificationSubscriberController::class, 'verify'])->name('events.notifications.verify');
+Route::get('event-notifications/unsubscribe/{token}', [EventNotificationSubscriberController::class, 'unsubscribe'])->name('events.notifications.unsubscribe');
 Route::get('guest-pass/{entry}', GuestPassController::class)->middleware('signed')->name('guest.pass.show');
 Route::livewire('my-ticket/{magicToken}', VolunteerTicket::class)->name('volunteer.ticket');
 Route::livewire('my-portal/{magicToken}', VolunteerPortal::class)->name('volunteer.portal');

--- a/tests/Feature/Actions/CancelShiftSignupTest.php
+++ b/tests/Feature/Actions/CancelShiftSignupTest.php
@@ -78,3 +78,21 @@ it('derives project internally from signup', function () {
 
     expect($this->signup->fresh()->cancelled_at)->not->toBeNull();
 });
+
+it('does not relock an unlocked priority gate after cancellation', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 50]);
+    $this->shift->update(['is_priority' => true, 'capacity' => 2]);
+
+    $secondSignup = ShiftSignup::factory()->create([
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+        'shift_id' => $this->shift->id,
+    ]);
+
+    $this->event->fresh()->evaluatePriorityGate();
+    $unlockedAt = $this->event->fresh()->priority_gate_unlocked_at;
+
+    $this->action->execute($secondSignup);
+
+    expect($this->event->fresh()->priority_gate_unlocked_at?->equalTo($unlockedAt))->toBeTrue()
+        ->and($this->event->fresh()->isPriorityGateOpen())->toBeTrue();
+});

--- a/tests/Feature/Actions/CreateShiftTest.php
+++ b/tests/Feature/Actions/CreateShiftTest.php
@@ -2,12 +2,14 @@
 
 use App\Actions\CreateShift;
 use App\Events\Activity\ShiftCreated;
+use App\Jobs\NotifyEventSubscribers;
 use App\Models\Event;
 use App\Models\Organization;
 use App\Models\User;
 use App\Models\VolunteerJob;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event as EventFacade;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     $this->org = Organization::factory()->create();
@@ -101,4 +103,23 @@ it('creates inactive shifts when requested', function () {
     );
 
     expect($shift->is_active)->toBeFalse();
+});
+
+it('queues one subscriber notification batch when availability opens up', function () {
+    Queue::fake();
+
+    foreach (range(1, 3) as $index) {
+        $this->action->execute(
+            job: $this->job,
+            shiftDate: Carbon::parse('2026-07-0'.$index),
+            startsAt: Carbon::parse('2026-07-0'.$index.' 09:00'),
+            endsAt: Carbon::parse('2026-07-0'.$index.' 13:00'),
+            capacity: 10,
+            isActive: true,
+            causer: $this->user,
+        );
+    }
+
+    Queue::assertPushed(NotifyEventSubscribers::class, 1);
+    Queue::assertPushed(NotifyEventSubscribers::class, fn (NotifyEventSubscribers $job) => $job->eventId === $this->event->id && $job->delay !== null);
 });

--- a/tests/Feature/Actions/CreateShiftTest.php
+++ b/tests/Feature/Actions/CreateShiftTest.php
@@ -24,6 +24,7 @@ it('creates a shift with date and times', function () {
         startsAt: Carbon::parse('2026-07-01 09:00'),
         endsAt: Carbon::parse('2026-07-01 13:00'),
         capacity: 10,
+        isActive: true,
         causer: $this->user,
     );
 
@@ -43,6 +44,7 @@ it('creates a shift with date only and no times', function () {
         startsAt: null,
         endsAt: null,
         capacity: 5,
+        isActive: true,
         displayText: 'Ganzer Tag',
         causer: $this->user,
     );
@@ -62,6 +64,7 @@ it('creates a shift with custom display text overriding time display', function 
         startsAt: Carbon::parse('2026-07-01 09:00'),
         endsAt: Carbon::parse('2026-07-01 13:00'),
         capacity: 10,
+        isActive: true,
         displayText: 'Vormittag',
         causer: $this->user,
     );
@@ -79,8 +82,23 @@ it('dispatches ShiftCreated activity event with causer', function () {
         startsAt: Carbon::parse('2026-07-01 09:00'),
         endsAt: Carbon::parse('2026-07-01 13:00'),
         capacity: 10,
+        isActive: true,
         causer: $this->user,
     );
 
     EventFacade::assertDispatched(ShiftCreated::class, fn ($e) => $e->causer->id === $this->user->id);
+});
+
+it('creates inactive shifts when requested', function () {
+    $shift = $this->action->execute(
+        job: $this->job,
+        shiftDate: Carbon::parse('2026-07-01'),
+        startsAt: Carbon::parse('2026-07-01 09:00'),
+        endsAt: Carbon::parse('2026-07-01 13:00'),
+        capacity: 10,
+        isActive: false,
+        causer: $this->user,
+    );
+
+    expect($shift->is_active)->toBeFalse();
 });

--- a/tests/Feature/Actions/CreateVolunteerJobTest.php
+++ b/tests/Feature/Actions/CreateVolunteerJobTest.php
@@ -20,6 +20,7 @@ it('creates a job for the event', function () {
         name: 'Ticket Scanner',
         description: 'Scan tickets at the gate',
         instructions: 'Use the app to scan QR codes',
+        isActive: true,
         causer: $this->user,
     );
 
@@ -36,6 +37,7 @@ it('allows nullable description and instructions', function () {
         name: 'Setup Crew',
         description: null,
         instructions: null,
+        isActive: true,
         causer: $this->user,
     );
 
@@ -51,8 +53,22 @@ it('dispatches JobCreated activity event with causer', function () {
         name: 'Dispatch Test',
         description: null,
         instructions: null,
+        isActive: true,
         causer: $this->user,
     );
 
     EventFacade::assertDispatched(JobCreated::class, fn ($e) => $e->causer->id === $this->user->id);
+});
+
+it('creates inactive jobs when requested', function () {
+    $job = $this->action->execute(
+        event: $this->event,
+        name: 'Hidden Job',
+        description: null,
+        instructions: null,
+        isActive: false,
+        causer: $this->user,
+    );
+
+    expect($job->is_active)->toBeFalse();
 });

--- a/tests/Feature/Actions/ProcessVolunteerSignupTest.php
+++ b/tests/Feature/Actions/ProcessVolunteerSignupTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\ProcessVolunteerSignup;
+use App\Exceptions\DomainException;
 use App\Models\CustomFieldResponse;
 use App\Models\CustomRegistrationField;
 use App\Models\EmailVerificationToken;
@@ -311,4 +312,38 @@ it('auto-assigns Typ 2 gear alongside Typ 1 selections', function () {
 
     expect(VolunteerGear::where('project_gear_item_id', $tshirt->id)->first()->size)->toBe('L');
     expect(VolunteerGear::where('project_gear_item_id', $drinks->id)->first()->quantity_entitled)->toBe(2);
+});
+
+it('blocks non-priority shifts while the priority gate is closed', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+    $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+    $regularShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 5]);
+
+    $action = app(ProcessVolunteerSignup::class);
+
+    expect(fn () => $action->execute(
+        firstName: 'Gate',
+        lastName: 'Blocked',
+        email: 'gate-blocked@example.com',
+        event: $this->event,
+        shiftIds: [$priorityShift->id, $regularShift->id],
+    ))->toThrow(DomainException::class, 'Please fill the priority shifts first. Other shifts unlock once 80% of the priority slots are filled.');
+});
+
+it('allows priority-only signup while the priority gate is closed', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+    $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+
+    $action = app(ProcessVolunteerSignup::class);
+
+    $result = $action->execute(
+        firstName: 'Gate',
+        lastName: 'Allowed',
+        email: 'gate-allowed@example.com',
+        event: $this->event,
+        shiftIds: [$priorityShift->id],
+    );
+
+    expect($result->hasNewSignups())->toBeTrue()
+        ->and(ShiftSignup::whereHas('volunteer', fn ($query) => $query->where('email', 'gate-allowed@example.com'))->exists())->toBeTrue();
 });

--- a/tests/Feature/Actions/ReserveShiftsTest.php
+++ b/tests/Feature/Actions/ReserveShiftsTest.php
@@ -88,6 +88,27 @@ it('throws DomainException for shifts not belonging to event', function () {
     ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
 });
 
+it('throws DomainException for inactive shifts', function () {
+    $inactiveShift = Shift::factory()->for($this->job, 'volunteerJob')->inactive()->create(['capacity' => 5]);
+
+    expect(fn () => $this->action->execute(
+        shiftIds: [$inactiveShift->id],
+        sessionId: 'test-session',
+        event: $this->event,
+    ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
+});
+
+it('throws DomainException for shifts on inactive jobs', function () {
+    $inactiveJob = VolunteerJob::factory()->for($this->event)->inactive()->create();
+    $inactiveJobShift = Shift::factory()->for($inactiveJob, 'volunteerJob')->create(['capacity' => 5]);
+
+    expect(fn () => $this->action->execute(
+        shiftIds: [$inactiveJobShift->id],
+        sessionId: 'test-session',
+        event: $this->event,
+    ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
+});
+
 it('replaces existing reservations for same session on re-selection', function () {
     // First reservation
     $this->action->execute(

--- a/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
+++ b/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
@@ -213,6 +213,29 @@ it('throws DomainException when a shift does not belong to the event', function 
     ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
 });
 
+it('throws DomainException when a shift is inactive', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create();
+    $inactiveShift = Shift::factory()->for($this->job, 'volunteerJob')->inactive()->create(['capacity' => 5]);
+
+    expect(fn () => $this->action->execute(
+        volunteer: $volunteer,
+        event: $this->event,
+        shiftIds: [$inactiveShift->id],
+    ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
+});
+
+it('throws DomainException when a shift belongs to an inactive job', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->create();
+    $inactiveJob = VolunteerJob::factory()->for($this->event)->inactive()->create();
+    $inactiveJobShift = Shift::factory()->for($inactiveJob, 'volunteerJob')->create(['capacity' => 5]);
+
+    expect(fn () => $this->action->execute(
+        volunteer: $volunteer,
+        event: $this->event,
+        shiftIds: [$inactiveJobShift->id],
+    ))->toThrow(DomainException::class, 'One or more shifts do not belong to this event.');
+});
+
 it('cancelled signups do not count toward capacity', function () {
     $volunteer = Volunteer::factory()->for($this->project)->create();
     $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);

--- a/tests/Feature/Actions/UpdateShiftTest.php
+++ b/tests/Feature/Actions/UpdateShiftTest.php
@@ -30,6 +30,7 @@ it('updates shift times and capacity', function () {
         startsAt: Carbon::parse('2026-07-01 14:00'),
         endsAt: Carbon::parse('2026-07-01 18:00'),
         capacity: 20,
+        isActive: true,
         causer: $this->user,
     );
 
@@ -53,6 +54,7 @@ it('throws DomainException when reducing capacity below current signups', functi
         startsAt: Carbon::parse('2026-07-01 14:00'),
         endsAt: Carbon::parse('2026-07-01 18:00'),
         capacity: 2,
+        isActive: true,
         causer: $this->user,
     ))->toThrow(DomainException::class, 'Cannot reduce capacity below current number of signups.');
 });
@@ -71,6 +73,7 @@ it('allows reducing capacity to exactly current signups', function () {
         startsAt: Carbon::parse('2026-07-01 14:00'),
         endsAt: Carbon::parse('2026-07-01 18:00'),
         capacity: 3,
+        isActive: true,
         causer: $this->user,
     );
 
@@ -88,8 +91,25 @@ it('dispatches ShiftUpdated activity event with causer', function () {
         startsAt: Carbon::parse('2026-07-01 14:00'),
         endsAt: Carbon::parse('2026-07-01 18:00'),
         capacity: 20,
+        isActive: true,
         causer: $this->user,
     );
 
     EventFacade::assertDispatched(ShiftUpdated::class, fn ($e) => $e->causer->id === $this->user->id);
+});
+
+it('can deactivate a shift', function () {
+    $shift = Shift::factory()->for($this->job, 'volunteerJob')->create(['is_active' => true]);
+
+    $updated = $this->action->execute(
+        shift: $shift,
+        shiftDate: $shift->shift_date,
+        startsAt: $shift->starts_at,
+        endsAt: $shift->ends_at,
+        capacity: $shift->capacity,
+        isActive: false,
+        causer: $this->user,
+    );
+
+    expect($updated->is_active)->toBeFalse();
 });

--- a/tests/Feature/Actions/UpdateShiftTest.php
+++ b/tests/Feature/Actions/UpdateShiftTest.php
@@ -3,6 +3,7 @@
 use App\Actions\UpdateShift;
 use App\Events\Activity\ShiftUpdated;
 use App\Exceptions\DomainException;
+use App\Jobs\NotifyEventSubscribers;
 use App\Models\Event;
 use App\Models\Organization;
 use App\Models\Shift;
@@ -12,6 +13,7 @@ use App\Models\Volunteer;
 use App\Models\VolunteerJob;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event as EventFacade;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     $this->org = Organization::factory()->create();
@@ -112,4 +114,22 @@ it('can deactivate a shift', function () {
     );
 
     expect($updated->is_active)->toBeFalse();
+});
+
+it('queues subscriber notifications when an inactive shift becomes available', function () {
+    Queue::fake();
+
+    $shift = Shift::factory()->for($this->job, 'volunteerJob')->inactive()->create();
+
+    $this->action->execute(
+        shift: $shift,
+        shiftDate: $shift->shift_date,
+        startsAt: $shift->starts_at,
+        endsAt: $shift->ends_at,
+        capacity: $shift->capacity,
+        isActive: true,
+        causer: $this->user,
+    );
+
+    Queue::assertPushed(NotifyEventSubscribers::class, fn (NotifyEventSubscribers $job) => $job->eventId === $this->event->id);
 });

--- a/tests/Feature/Actions/UpdateVolunteerJobTest.php
+++ b/tests/Feature/Actions/UpdateVolunteerJobTest.php
@@ -23,6 +23,7 @@ it('updates job fields', function () {
         name: 'Updated Job',
         description: 'New description',
         instructions: 'New instructions',
+        isActive: true,
         causer: $this->user,
     );
 
@@ -41,8 +42,24 @@ it('dispatches JobUpdated activity event with causer', function () {
         name: 'Changed Name',
         description: 'New description',
         instructions: 'New instructions',
+        isActive: true,
         causer: $this->user,
     );
 
     EventFacade::assertDispatched(JobUpdated::class, fn ($e) => $e->causer->id === $this->user->id);
+});
+
+it('can deactivate a job', function () {
+    $job = VolunteerJob::factory()->for($this->event)->create(['is_active' => true]);
+
+    $updated = $this->action->execute(
+        job: $job,
+        name: $job->name,
+        description: $job->description,
+        instructions: $job->instructions,
+        isActive: false,
+        causer: $this->user,
+    );
+
+    expect($updated->is_active)->toBeFalse();
 });

--- a/tests/Feature/Actions/UpdateVolunteerJobTest.php
+++ b/tests/Feature/Actions/UpdateVolunteerJobTest.php
@@ -2,11 +2,14 @@
 
 use App\Actions\UpdateVolunteerJob;
 use App\Events\Activity\JobUpdated;
+use App\Jobs\NotifyEventSubscribers;
 use App\Models\Event;
 use App\Models\Organization;
+use App\Models\Shift;
 use App\Models\User;
 use App\Models\VolunteerJob;
 use Illuminate\Support\Facades\Event as EventFacade;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     $this->org = Organization::factory()->create();
@@ -62,4 +65,22 @@ it('can deactivate a job', function () {
     );
 
     expect($updated->is_active)->toBeFalse();
+});
+
+it('queues subscriber notifications when a job activation opens availability', function () {
+    Queue::fake();
+
+    $job = VolunteerJob::factory()->for($this->event)->inactive()->create();
+    Shift::factory()->for($job, 'volunteerJob')->create();
+
+    $this->action->execute(
+        job: $job,
+        name: $job->name,
+        description: $job->description,
+        instructions: $job->instructions,
+        isActive: true,
+        causer: $this->user,
+    );
+
+    Queue::assertPushed(NotifyEventSubscribers::class, fn (NotifyEventSubscribers $job) => $job->eventId === $this->event->id);
 });

--- a/tests/Feature/Events/EventListTest.php
+++ b/tests/Feature/Events/EventListTest.php
@@ -42,6 +42,20 @@ it('does not show events from other organizations', function () {
         ->assertDontSee('Other Org Event');
 });
 
+it('falls back to UTC when a project timezone is blank', function () {
+    $project = Project::factory()->for($this->org)->create(['timezone' => '']);
+
+    Event::factory()
+        ->for($this->org)
+        ->for($project)
+        ->published()
+        ->create(['name' => 'Timezone Fallback Event']);
+
+    Livewire::actingAs($this->user)
+        ->test(EventList::class)
+        ->assertSee('Timezone Fallback Event');
+});
+
 it('filters events by status', function () {
     Event::factory()->for($this->org)->published()->create(['name' => 'Published Event']);
     Event::factory()->for($this->org)->create(['name' => 'Draft Event', 'status' => EventStatus::Draft]);

--- a/tests/Feature/Events/EventShowTest.php
+++ b/tests/Feature/Events/EventShowTest.php
@@ -149,3 +149,14 @@ it('displays event details in read-only mode', function () {
         ->assertSee('Berlin')
         ->assertSee('Date & Time');
 });
+
+it('shows priority gate status when configured', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    Shift::factory()->for($job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+
+    Livewire::actingAs($this->user)
+        ->test(EventShow::class, ['eventId' => $this->event->id])
+        ->assertSee('Priority Shift Gate')
+        ->assertSee('Gate closed until the priority threshold is reached.');
+});

--- a/tests/Feature/Events/JobsAndShiftsManagerTest.php
+++ b/tests/Feature/Events/JobsAndShiftsManagerTest.php
@@ -104,11 +104,13 @@ it('allows organizer to create a shift', function () {
         ->set('shiftEndsAt', '2026-07-01T13:00')
         ->set('shiftCapacity', 20)
         ->set('shiftIsActive', false)
+        ->set('shiftIsPriority', true)
         ->call('saveShift')
         ->assertHasNoErrors();
 
     expect(Shift::where('volunteer_job_id', $job->id)->count())->toBe(1)
-        ->and(Shift::where('volunteer_job_id', $job->id)->first()->is_active)->toBeFalse();
+        ->and(Shift::where('volunteer_job_id', $job->id)->first()->is_active)->toBeFalse()
+        ->and(Shift::where('volunteer_job_id', $job->id)->first()->is_priority)->toBeTrue();
 });
 
 it('allows organizer to edit a shift', function () {
@@ -120,10 +122,12 @@ it('allows organizer to edit a shift', function () {
         ->call('openEditShift', $shift->id)
         ->assertSet('shiftCapacity', 5)
         ->set('shiftCapacity', 25)
+        ->set('shiftIsPriority', true)
         ->call('saveShift')
         ->assertHasNoErrors();
 
-    expect($shift->fresh()->capacity)->toBe(25);
+    expect($shift->fresh()->capacity)->toBe(25)
+        ->and($shift->fresh()->is_priority)->toBeTrue();
 });
 
 it('allows organizer to delete a shift', function () {

--- a/tests/Feature/Events/JobsAndShiftsManagerTest.php
+++ b/tests/Feature/Events/JobsAndShiftsManagerTest.php
@@ -46,11 +46,13 @@ it('allows organizer to create a job', function () {
         ->call('openCreateJob')
         ->set('jobName', 'Setup Crew')
         ->set('jobDescription', 'Help set up the event')
+        ->set('jobIsActive', false)
         ->call('saveJob')
         ->assertHasNoErrors()
         ->assertSee('Setup Crew');
 
-    expect(VolunteerJob::where('name', 'Setup Crew')->exists())->toBeTrue();
+    expect(VolunteerJob::where('name', 'Setup Crew')->exists())->toBeTrue()
+        ->and(VolunteerJob::where('name', 'Setup Crew')->first()->is_active)->toBeFalse();
 });
 
 it('allows organizer to edit a job', function () {
@@ -101,10 +103,12 @@ it('allows organizer to create a shift', function () {
         ->set('shiftStartsAt', '2026-07-01T09:00')
         ->set('shiftEndsAt', '2026-07-01T13:00')
         ->set('shiftCapacity', 20)
+        ->set('shiftIsActive', false)
         ->call('saveShift')
         ->assertHasNoErrors();
 
-    expect(Shift::where('volunteer_job_id', $job->id)->count())->toBe(1);
+    expect(Shift::where('volunteer_job_id', $job->id)->count())->toBe(1)
+        ->and(Shift::where('volunteer_job_id', $job->id)->first()->is_active)->toBeFalse();
 });
 
 it('allows organizer to edit a shift', function () {
@@ -153,6 +157,39 @@ it('shows full badge when shift is at capacity', function () {
     Livewire::actingAs($this->user)
         ->test(JobsAndShiftsManager::class, ['eventId' => $this->event->id])
         ->assertSee('Full');
+});
+
+it('shows inactive badges for jobs and shifts in admin', function () {
+    $job = VolunteerJob::factory()->for($this->event)->inactive()->create(['name' => 'Info Desk']);
+    Shift::factory()->for($job, 'volunteerJob')->inactive()->create();
+
+    Livewire::actingAs($this->user)
+        ->test(JobsAndShiftsManager::class, ['eventId' => $this->event->id])
+        ->assertSee('Info Desk')
+        ->assertSee('Inactive');
+});
+
+it('allows organizer to toggle a job back active', function () {
+    $job = VolunteerJob::factory()->for($this->event)->inactive()->create();
+
+    Livewire::actingAs($this->user)
+        ->test(JobsAndShiftsManager::class, ['eventId' => $this->event->id])
+        ->call('toggleJobActive', $job->id)
+        ->assertHasNoErrors();
+
+    expect($job->fresh()->is_active)->toBeTrue();
+});
+
+it('allows organizer to toggle a shift back active', function () {
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    $shift = Shift::factory()->for($job, 'volunteerJob')->inactive()->create();
+
+    Livewire::actingAs($this->user)
+        ->test(JobsAndShiftsManager::class, ['eventId' => $this->event->id])
+        ->call('toggleShiftActive', $shift->id)
+        ->assertHasNoErrors();
+
+    expect($shift->fresh()->is_active)->toBeTrue();
 });
 
 it('denies non-member access', function () {

--- a/tests/Feature/Http/EventNotificationSubscriberControllerTest.php
+++ b/tests/Feature/Http/EventNotificationSubscriberControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventNotificationSubscriber;
+use App\Models\Organization;
+use App\Models\Project;
+use App\ValueObjects\HashedToken;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'name' => 'Community Kitchen',
+    ]);
+});
+
+it('verifies a subscriber from the confirmation link', function () {
+    $plainToken = Str::random(64);
+
+    $subscriber = EventNotificationSubscriber::factory()->for($this->event)->create([
+        'email' => 'notify@example.com',
+        'verification_token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+        'verification_expires_at' => now()->addDays(7),
+    ]);
+
+    $this->get(route('events.notifications.verify', $plainToken))
+        ->assertOk()
+        ->assertSee('You are on the list')
+        ->assertSee('notify@example.com');
+
+    expect($subscriber->fresh()->verified_at)->not->toBeNull();
+});
+
+it('unsubscribes a subscriber from the mail link', function () {
+    $plainToken = Str::random(64);
+
+    $subscriber = EventNotificationSubscriber::factory()->for($this->event)->verified()->create([
+        'unsubscribe_token_hash' => HashedToken::fromPlaintext($plainToken)->hash,
+    ]);
+
+    $this->get(route('events.notifications.unsubscribe', $plainToken))
+        ->assertOk()
+        ->assertSee('Notifications turned off')
+        ->assertSee('Community Kitchen');
+
+    expect(EventNotificationSubscriber::query()->find($subscriber->id))->toBeNull();
+});
+
+it('returns 404 for invalid unsubscribe links', function () {
+    $this->get(route('events.notifications.unsubscribe', 'invalid-token'))
+        ->assertNotFound();
+});

--- a/tests/Feature/Jobs/NotifyEventSubscribersTest.php
+++ b/tests/Feature/Jobs/NotifyEventSubscribersTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Jobs\NotifyEventSubscribers;
+use App\Models\Event;
+use App\Models\EventNotificationSubscriber;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
+use App\Models\Volunteer;
+use App\Models\VolunteerJob;
+use App\Notifications\EventNewShiftsAvailable;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'name' => 'City Marathon',
+    ]);
+    $this->job = VolunteerJob::factory()->for($this->event)->create();
+    $this->shift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 5]);
+});
+
+it('notifies verified subscribers for the matching event only', function () {
+    $subscriber = EventNotificationSubscriber::factory()->for($this->event)->verified()->create([
+        'email' => 'one@example.com',
+    ]);
+
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+    EventNotificationSubscriber::factory()->for($otherEvent)->verified()->create([
+        'email' => 'two@example.com',
+    ]);
+
+    (new NotifyEventSubscribers($this->event->id))->handle();
+
+    Notification::assertSentTo(
+        new AnonymousNotifiable,
+        EventNewShiftsAvailable::class,
+        function ($notification, $channels, $notifiable) {
+            return $notifiable->routes['mail'] === 'one@example.com'
+                && str_contains($notification->signupUrl, $this->event->public_token)
+                && str_contains($notification->unsubscribeUrl, 'event-notifications/unsubscribe/');
+        },
+    );
+
+    Notification::assertSentOnDemandTimes(EventNewShiftsAvailable::class, 1);
+
+    expect($subscriber->fresh()->unsubscribe_token_hash)->not->toBeNull()
+        ->and($subscriber->fresh()->last_notified_at)->not->toBeNull();
+});
+
+it('skips sending notifications when the event still has no available shifts', function () {
+    EventNotificationSubscriber::factory()->for($this->event)->verified()->create([
+        'email' => 'one@example.com',
+    ]);
+
+    $this->shift->update(['capacity' => 1]);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $this->shift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    (new NotifyEventSubscribers($this->event->id))->handle();
+
+    Notification::assertSentOnDemandTimes(EventNewShiftsAvailable::class, 0);
+});

--- a/tests/Feature/Livewire/Events/EventSettingsTest.php
+++ b/tests/Feature/Livewire/Events/EventSettingsTest.php
@@ -82,11 +82,21 @@ it('can update signup settings', function () {
     Livewire::actingAs($this->organizer)
         ->test(EventSettings::class, ['eventId' => $this->event->id])
         ->set('form.visibility', 'private')
+        ->set('form.priorityUnlockThresholdPercent', 80)
         ->call('saveEvent')
         ->assertHasNoErrors();
 
     $this->event->refresh();
-    expect($this->event->visibility)->toBe(EventVisibility::Private);
+    expect($this->event->visibility)->toBe(EventVisibility::Private)
+        ->and($this->event->priority_unlock_threshold_percent)->toBe(80);
+});
+
+it('validates priority threshold range', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(EventSettings::class, ['eventId' => $this->event->id])
+        ->set('form.priorityUnlockThresholdPercent', 101)
+        ->call('saveEvent')
+        ->assertHasErrors(['form.priorityUnlockThresholdPercent']);
 });
 
 it('can set notification email', function () {

--- a/tests/Feature/Livewire/ManualEnrollmentTest.php
+++ b/tests/Feature/Livewire/ManualEnrollmentTest.php
@@ -233,6 +233,25 @@ it('can create volunteer and then enroll them into shifts', function () {
     expect(ShiftSignup::where('volunteer_id', $volunteer->id)->where('shift_id', $shift->id)->exists())->toBeTrue();
 });
 
+it('lets organizers enroll into regular shifts even when the public priority gate is closed', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->create();
+    $job = VolunteerJob::factory()->for($this->event)->create();
+    $seedShift = Shift::factory()->for($job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+    ShiftSignup::factory()->create(['volunteer_id' => $volunteer->id, 'shift_id' => $seedShift->id]);
+    $regularShift = Shift::factory()->for($job, 'volunteerJob')->create(['capacity' => 5]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ManualEnrollment::class, ['eventId' => $this->event->id])
+        ->call('selectVolunteer', $volunteer->id)
+        ->set('selectedShifts', [$regularShift->id])
+        ->call('enroll')
+        ->assertSee('1 shift(s) enrolled successfully.');
+
+    expect(ShiftSignup::where('volunteer_id', $volunteer->id)->where('shift_id', $regularShift->id)->exists())->toBeTrue();
+});
+
 it('displays the selected volunteer full name in the shift selection heading', function () {
     $volunteer = Volunteer::factory()->for($this->project)->create([
         'first_name' => 'Alice',

--- a/tests/Feature/Models/EventPriorityGateTest.php
+++ b/tests/Feature/Models/EventPriorityGateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\Event;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
+use App\Models\Volunteer;
+use App\Models\VolunteerJob;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->create([
+        'priority_unlock_threshold_percent' => 80,
+    ]);
+    $this->job = VolunteerJob::factory()->for($this->event)->create();
+});
+
+it('treats events without priority shifts as open', function () {
+    Shift::factory()->for($this->job, 'volunteerJob')->count(2)->create();
+
+    expect($this->event->fresh()->isPriorityGateOpen())->toBeTrue();
+});
+
+it('treats events with disabled threshold as open', function () {
+    Shift::factory()->for($this->job, 'volunteerJob')->priority()->create();
+    $this->event->update(['priority_unlock_threshold_percent' => null]);
+
+    expect($this->event->fresh()->isPriorityGateOpen())->toBeTrue();
+});
+
+it('unlocks once the configured priority threshold is reached', function () {
+    $priorityShiftA = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 2]);
+    $priorityShiftB = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 3]);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $priorityShiftA->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $priorityShiftA->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $priorityShiftB->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    $event = $this->event->fresh();
+
+    expect($event->priorityFillRate())->toBe(0.6)
+        ->and($event->priority_gate_unlocked_at)->toBeNull();
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $priorityShiftB->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    $event = $this->event->fresh();
+    $event->evaluatePriorityGate();
+
+    expect($event->fresh()->priority_gate_unlocked_at)->not->toBeNull()
+        ->and($event->fresh()->isPriorityGateOpen())->toBeTrue();
+});
+
+it('keeps the gate open after cancellations once unlocked', function () {
+    $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 2]);
+
+    $signups = collect(range(1, 2))->map(fn () => ShiftSignup::factory()->create([
+        'shift_id' => $priorityShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]));
+
+    $event = $this->event->fresh();
+    $event->update(['priority_unlock_threshold_percent' => 50]);
+    $event->fresh()->evaluatePriorityGate();
+
+    $unlockedAt = $event->fresh()->priority_gate_unlocked_at;
+    $signups->first()->update(['cancelled_at' => now()]);
+
+    expect($this->event->fresh()->priority_gate_unlocked_at?->equalTo($unlockedAt))->toBeTrue()
+        ->and($this->event->fresh()->isPriorityGateOpen())->toBeTrue();
+});

--- a/tests/Feature/Notifications/EventNotificationSubscriptionNotificationsTest.php
+++ b/tests/Feature/Notifications/EventNotificationSubscriptionNotificationsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\Event;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Notifications\EventNewShiftsAvailable;
+use App\Notifications\EventNotificationSubscriptionVerification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\AnonymousNotifiable;
+
+beforeEach(function () {
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->create([
+        'name' => 'Harbor Cleanup',
+    ]);
+});
+
+it('builds the subscription verification mail', function () {
+    $notification = new EventNotificationSubscriptionVerification($this->event, 'https://example.com/verify');
+    $mail = $notification->toMail(new AnonymousNotifiable);
+
+    expect($mail->subject)->toBe('Confirm shift notifications for Harbor Cleanup')
+        ->and($mail->actionText)->toBe('Confirm notifications')
+        ->and($mail->actionUrl)->toBe('https://example.com/verify');
+});
+
+it('builds the new shifts available mail with an unsubscribe link', function () {
+    $notification = new EventNewShiftsAvailable($this->event, 'https://example.com/signup', 'https://example.com/unsubscribe');
+    $mail = $notification->toMail(new AnonymousNotifiable);
+
+    expect($mail->subject)->toBe('New shifts are available for Harbor Cleanup')
+        ->and($mail->actionText)->toBe('Open signup page')
+        ->and($mail->actionUrl)->toBe('https://example.com/signup')
+        ->and(implode(' ', $mail->outroLines))->toContain('https://example.com/unsubscribe');
+});
+
+it('queues both notification mails', function () {
+    expect(new EventNotificationSubscriptionVerification($this->event, 'https://example.com/verify'))
+        ->toBeInstanceOf(ShouldQueue::class)
+        ->and(new EventNewShiftsAvailable($this->event, 'https://example.com/signup', 'https://example.com/unsubscribe'))
+        ->toBeInstanceOf(ShouldQueue::class);
+});

--- a/tests/Feature/Public/EventSignupNotificationSubscriptionTest.php
+++ b/tests/Feature/Public/EventSignupNotificationSubscriptionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\Livewire\Public\EventSignup;
+use App\Models\EmailVerificationToken;
+use App\Models\Event;
+use App\Models\EventNotificationSubscriber;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
+use App\Models\Volunteer;
+use App\Models\VolunteerJob;
+use App\Notifications\EventNotificationSubscriptionVerification;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+
+function moveToEmptyShiftState(Testable $component, string $email = 'volunteer@example.com'): Testable
+{
+    $component
+        ->set('volunteerEmail', $email)
+        ->call('submitEmail');
+
+    $token = EmailVerificationToken::where('email', $email)->latest()->first();
+    expect($token)->not->toBeNull();
+    $token->update(['verified_at' => now()]);
+
+    return $component
+        ->call('checkVerification')
+        ->set('volunteerFirstName', 'Taylor')
+        ->set('volunteerLastName', 'Helper')
+        ->call('advanceToShifts');
+}
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->org = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->org)->create();
+    $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create([
+        'name' => 'Night Shift Support',
+    ]);
+    $this->job = VolunteerJob::factory()->for($this->event)->create(['name' => 'Info Desk']);
+    $this->shift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $this->shift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+});
+
+it('shows the notification empty state when no jobs are available', function () {
+    moveToEmptyShiftState(Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token]))
+        ->assertSee('No shifts are available right now')
+        ->assertSee('Notify me')
+        ->assertSee('Every update email includes an unsubscribe link.');
+});
+
+it('creates an unverified subscriber and sends a verification email', function () {
+    moveToEmptyShiftState(Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token]))
+        ->set('notificationSubscriptionEmail', 'subscriber@example.com')
+        ->call('subscribeToNotifications')
+        ->assertSee('Check your inbox to confirm your notification signup.');
+
+    $subscriber = EventNotificationSubscriber::query()
+        ->where('event_id', $this->event->id)
+        ->where('email', 'subscriber@example.com')
+        ->first();
+
+    expect($subscriber)->not->toBeNull()
+        ->and($subscriber->verified_at)->toBeNull()
+        ->and($subscriber->verification_token_hash)->not->toBeNull();
+
+    Notification::assertSentTo(
+        new AnonymousNotifiable,
+        EventNotificationSubscriptionVerification::class,
+        function ($notification, $channels, $notifiable) {
+            return $notifiable->routes['mail'] === 'subscriber@example.com';
+        },
+    );
+});
+
+it('keeps re-subscribe idempotent for an already verified subscriber', function () {
+    EventNotificationSubscriber::factory()->for($this->event)->verified()->create([
+        'email' => 'subscriber@example.com',
+    ]);
+
+    moveToEmptyShiftState(Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token]))
+        ->set('notificationSubscriptionEmail', 'subscriber@example.com')
+        ->call('subscribeToNotifications')
+        ->assertSee('Check your inbox to confirm your notification signup.');
+
+    expect(EventNotificationSubscriber::query()
+        ->where('event_id', $this->event->id)
+        ->where('email', 'subscriber@example.com')
+        ->count())->toBe(1);
+
+    Notification::assertSentOnDemandTimes(EventNotificationSubscriptionVerification::class, 0);
+});
+
+it('rate limits notification subscription requests', function () {
+    $ipKey = 'event-notification-subscribe:127.0.0.1';
+    foreach (range(1, 10) as $attempt) {
+        RateLimiter::hit($ipKey, 60);
+    }
+
+    moveToEmptyShiftState(Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token]))
+        ->set('notificationSubscriptionEmail', 'rate-limited@example.com')
+        ->call('subscribeToNotifications')
+        ->assertHasErrors(['notificationSubscriptionEmail']);
+
+    expect(EventNotificationSubscriber::query()->count())->toBe(0);
+
+    RateLimiter::clear($ipKey);
+});
+
+it('does not allow notification subscriptions while selectable shifts are still available', function () {
+    ShiftSignup::query()->delete();
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'available@example.com')
+        ->call('submitEmail');
+
+    $token = EmailVerificationToken::where('email', 'available@example.com')->latest()->first();
+    expect($token)->not->toBeNull();
+    $token->update(['verified_at' => now()]);
+
+    $component
+        ->call('checkVerification')
+        ->set('volunteerFirstName', 'Taylor')
+        ->set('volunteerLastName', 'Helper')
+        ->call('advanceToShifts')
+        ->set('notificationSubscriptionEmail', 'subscriber@example.com')
+        ->call('subscribeToNotifications')
+        ->assertHasErrors(['notificationSubscriptionEmail']);
+
+    expect(EventNotificationSubscriber::query()->count())->toBe(0);
+});

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -127,6 +127,41 @@ it('shows full badge for shifts at capacity', function () {
         ->assertSee('Full');
 });
 
+it('shows a priority gate banner and locks regular shifts while the gate is closed', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+    $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+    $regularShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 10, 'display_text' => 'Regular Shift']);
+
+    collect(range(1, 3))->each(fn () => ShiftSignup::factory()->create([
+        'shift_id' => $priorityShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]));
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->call('advanceToShifts')
+        ->assertSee('Priority shifts first')
+        ->assertSee('3 of 5 priority slots are filled.')
+        ->assertSee('Locked until the priority shift threshold is reached.')
+        ->assertSee('Regular Shift');
+});
+
+it('hides the priority gate banner once the gate is unlocked', function () {
+    $this->event->update(['priority_unlock_threshold_percent' => 80]);
+    $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 5]);
+
+    collect(range(1, 4))->each(fn () => ShiftSignup::factory()->create([
+        'shift_id' => $priorityShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]));
+
+    $this->event->fresh()->evaluatePriorityGate();
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->call('advanceToShifts')
+        ->assertDontSee('Priority shifts first')
+        ->assertDontSee('Locked until the priority shift threshold is reached.');
+});
+
 // --- Email entry step ---
 
 it('starts on the email entry step', function () {

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -64,6 +64,17 @@ it('shows event info on public page', function () {
         ->assertSee('Litter Pickup');
 });
 
+it('hides inactive jobs and shifts from public signup', function () {
+    $inactiveJob = VolunteerJob::factory()->for($this->event)->inactive()->create(['name' => 'Hidden Job']);
+    Shift::factory()->for($inactiveJob, 'volunteerJob')->create(['capacity' => 10]);
+    Shift::factory()->for($this->job, 'volunteerJob')->inactive()->create(['capacity' => 10, 'display_text' => 'Hidden Shift']);
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->assertSee('Litter Pickup')
+        ->assertDontSee('Hidden Job')
+        ->assertDontSee('Hidden Shift');
+});
+
 it('displays title image on public page', function () {
     Storage::fake('public');
 
@@ -312,6 +323,22 @@ it('shows warning and advances with partial availability', function () {
         ->assertSet('state', WizardState::Confirming)
         ->assertSet('warningMessage', '1 shift(s) were full and removed from your selection.')
         ->assertSet('selectedShiftIds', [$this->shift->id]);
+});
+
+it('rejects inactive shifts during reservation even if submitted directly', function () {
+    $inactiveShift = Shift::factory()->for($this->job, 'volunteerJob')->inactive()->create(['capacity' => 10]);
+
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'test@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'test@example.com');
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$inactiveShift->id])
+        ->call('reserveAndAdvance')
+        ->assertHasErrors(['selectedShiftIds.0'])
+        ->assertSet('state', WizardState::SelectingShifts);
 });
 
 it('blocks reserveAndAdvance when selected shifts overlap in time', function () {

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -127,6 +127,97 @@ it('shows full badge for shifts at capacity', function () {
         ->assertSee('Full');
 });
 
+it('hides fully booked jobs while keeping jobs with open shifts visible', function () {
+    $fullJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Info Desk']);
+
+    collect(range(1, 2))->each(function () use ($fullJob) {
+        $shift = Shift::factory()->for($fullJob, 'volunteerJob')->create(['capacity' => 1]);
+
+        ShiftSignup::factory()->create([
+            'shift_id' => $shift->id,
+            'volunteer_id' => Volunteer::factory()->for($this->project),
+        ]);
+    });
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->assertSee('Litter Pickup')
+        ->assertDontSee('Info Desk');
+});
+
+it('keeps partially full jobs visible with their full shifts', function () {
+    Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1, 'display_text' => 'Morning Shift']);
+    $fullShift = Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 1, 'display_text' => 'Noon Shift']);
+    Shift::factory()->for($this->job, 'volunteerJob')->create(['capacity' => 3, 'display_text' => 'Evening Shift']);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $fullShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->assertSee('Litter Pickup')
+        ->assertSee('Morning Shift')
+        ->assertSee('Noon Shift')
+        ->assertSee('Evening Shift')
+        ->assertSee('Full');
+});
+
+it('keeps a returning volunteers fully booked job visible when they already hold a shift in it', function () {
+    $fullJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Backstage']);
+    $returningVolunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'returning-full@example.com',
+        'first_name' => 'Returning',
+        'last_name' => 'Volunteer',
+    ]);
+
+    $existingShift = Shift::factory()->for($fullJob, 'volunteerJob')->create(['capacity' => 1, 'display_text' => 'Load In']);
+    $otherFullShift = Shift::factory()->for($fullJob, 'volunteerJob')->create(['capacity' => 1, 'display_text' => 'Load Out']);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $existingShift->id,
+        'volunteer_id' => $returningVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $otherFullShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning-full@example.com')
+        ->call('submitEmail');
+
+    simulateVerification($component, 'returning-full@example.com');
+
+    $component
+        ->call('advanceToShifts')
+        ->assertSee('Backstage')
+        ->assertSee('Load In')
+        ->assertSee('Already signed up')
+        ->assertSee('Load Out');
+});
+
+it('returns an empty jobs collection when all jobs are fully booked and the volunteer has no existing signup', function () {
+    $this->shift->update(['capacity' => 1]);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $this->shift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    $fullJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Merch']);
+    $fullShift = Shift::factory()->for($fullJob, 'volunteerJob')->create(['capacity' => 1]);
+
+    ShiftSignup::factory()->create([
+        'shift_id' => $fullShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token]);
+
+    expect($component->instance()->jobs)->toHaveCount(0);
+});
+
 it('shows a priority gate banner and locks regular shifts while the gate is closed', function () {
     $this->event->update(['priority_unlock_threshold_percent' => 80]);
     $priorityShift = Shift::factory()->for($this->job, 'volunteerJob')->priority()->create(['capacity' => 5]);


### PR DESCRIPTION
## Summary
- add active-state controls for volunteer jobs and shifts so event teams can explicitly hide unavailable signup options from both the public flow and internal enrollment surfaces
- enforce Phase 2 availability rules in signup logic by prioritizing priority shifts, filtering fully booked jobs from public signup, and keeping reservation, signup, cancellation, and event views aligned with the new gating behavior
- add empty-state signup messaging with opt-in event availability notifications, including subscriber persistence, verification, scheduling, and delivery when new shifts become available

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Public/EventSignupTest.php tests/Feature/Public/EventSignupNotificationSubscriptionTest.php tests/Feature/Models/EventPriorityGateTest.php tests/Feature/Jobs/NotifyEventSubscribersTest.php tests/Feature/Http/EventNotificationSubscriberControllerTest.php tests/Feature/Events/JobsAndShiftsManagerTest.php tests/Feature/Actions/CreateShiftTest.php tests/Feature/Actions/UpdateShiftTest.php tests/Feature/Actions/CreateVolunteerJobTest.php tests/Feature/Actions/UpdateVolunteerJobTest.php tests/Feature/Actions/ReserveShiftsTest.php tests/Feature/Actions/SignUpVolunteerForShiftsTest.php tests/Feature/Actions/CancelShiftSignupTest.php tests/Feature/Events/EventListTest.php tests/Feature/Events/EventShowTest.php tests/Feature/Livewire/Events/EventSettingsTest.php tests/Feature/Livewire/ManualEnrollmentTest.php tests/Feature/Notifications/EventNotificationSubscriptionNotificationsTest.php`
- `237` tests passed, `683` assertions

Closes #168
Closes #203
Closes #206
Closes #207