### PR TITLE
Phase 3 organizer workflow improvements

### DIFF
--- a/app/Actions/CreateInvitedUser.php
+++ b/app/Actions/CreateInvitedUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class CreateInvitedUser
+{
+    public function __construct(private CreateOrganization $createOrganization) {}
+
+    /**
+     * @return array{user: User, temporaryPassword: string}
+     */
+    public function execute(string $name, string $email): array
+    {
+        $temporaryPassword = Str::random(16);
+
+        $user = DB::transaction(function () use ($name, $email, $temporaryPassword): User {
+            $user = User::create([
+                'name' => $name,
+                'email' => $email,
+                'password' => $temporaryPassword,
+                'must_change_password' => true,
+                'email_verified_at' => now(),
+            ]);
+
+            $this->createOrganization->execute($user, $user->name."'s Organization", isPersonal: true);
+
+            return $user;
+        });
+
+        return [
+            'user' => $user,
+            'temporaryPassword' => $temporaryPassword,
+        ];
+    }
+}

--- a/app/Actions/InviteMember.php
+++ b/app/Actions/InviteMember.php
@@ -9,12 +9,10 @@ use App\Models\Organization;
 use App\Models\User;
 use App\Notifications\AddedToOrganization;
 use App\Notifications\StaffInvitation;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class InviteMember
 {
-    public function __construct(private CreateOrganization $createOrganization) {}
+    public function __construct(private CreateInvitedUser $createInvitedUser) {}
 
     public function execute(Organization $organization, string $name, string $email, StaffRole $role, ?User $causer = null): User
     {
@@ -22,23 +20,9 @@ class InviteMember
         $isExistingUser = (bool) $user;
 
         if (! $user) {
-            $password = Str::random(16);
+            ['user' => $user, 'temporaryPassword' => $temporaryPassword] = $this->createInvitedUser->execute($name, $email);
 
-            $user = DB::transaction(function () use ($name, $email, $password) {
-                $user = User::create([
-                    'name' => $name,
-                    'email' => $email,
-                    'password' => $password,
-                    'must_change_password' => true,
-                    'email_verified_at' => now(),
-                ]);
-
-                $this->createOrganization->execute($user, $user->name."'s Organization", isPersonal: true);
-
-                return $user;
-            });
-
-            $user->notify(new StaffInvitation($organization, $password));
+            $user->notify(new StaffInvitation($organization, $temporaryPassword));
         }
 
         if ($organization->users()->where('user_id', $user->id)->exists()) {

--- a/app/Actions/UpdateVolunteerGearSelection.php
+++ b/app/Actions/UpdateVolunteerGearSelection.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\ActivityCategory;
+use App\Enums\GearItemType;
+use App\Exceptions\DomainException;
+use App\Models\ActivityLog;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Volunteer;
+use App\Models\VolunteerGear;
+use App\Notifications\VolunteerEventUpdatedNotification;
+
+class UpdateVolunteerGearSelection
+{
+    public function __construct(
+        private GenerateMagicLink $generateMagicLink,
+    ) {}
+
+    public function execute(VolunteerGear $gear, Event $event, string $selection, User $causer): VolunteerGear
+    {
+        $gear->loadMissing('gearItem', 'volunteer');
+
+        if ($gear->gearItem->project_id !== $event->project_id || $gear->volunteer->project_id !== $event->project_id) {
+            throw new DomainException('Dieses Gear gehört nicht zu diesem Event.');
+        }
+
+        if ($gear->gearItem->type !== GearItemType::SizeSelection || ! $gear->gearItem->requires_size) {
+            throw new DomainException('Nur Gear vom Typ 1 kann hier bearbeitet werden.');
+        }
+
+        if (! in_array($selection, $gear->gearItem->available_sizes ?? [], true)) {
+            throw new DomainException('Die gewählte Auswahl ist für dieses Gear nicht verfügbar.');
+        }
+
+        if ($gear->size === $selection) {
+            return $gear->refresh();
+        }
+
+        $previousSelection = $gear->size ?? 'Auswahl ausstehend';
+
+        $gear->update(['size' => $selection]);
+
+        ActivityLog::create([
+            'organization_id' => $event->organization_id,
+            'project_id' => $event->project_id,
+            'event_id' => $event->id,
+            'causer_type' => $causer::class,
+            'causer_id' => $causer->id,
+            'subject_type' => Volunteer::class,
+            'subject_id' => $gear->volunteer->id,
+            'action' => 'updated',
+            'category' => ActivityCategory::Volunteer,
+            'description' => "Updated {$gear->gearItem->name} selection for {$gear->volunteer->full_name}",
+            'properties' => [
+                'gear_item_name' => $gear->gearItem->name,
+                'previous_selection' => $previousSelection,
+                'new_selection' => $selection,
+            ],
+        ]);
+
+        ['plainToken' => $plainToken] = $this->generateMagicLink->execute($gear->volunteer);
+
+        $gear->volunteer->notify(new VolunteerEventUpdatedNotification(
+            event: $event,
+            organizerNote: "Die Auswahl fuer \"{$gear->gearItem->name}\" wurde von \"{$previousSelection}\" auf \"{$selection}\" geaendert.",
+            magicLinkToken: $plainToken,
+        ));
+
+        return $gear->refresh();
+    }
+}

--- a/app/Livewire/Events/VolunteerDetail.php
+++ b/app/Livewire/Events/VolunteerDetail.php
@@ -3,13 +3,16 @@
 namespace App\Livewire\Events;
 
 use App\Actions\DeleteVolunteerProfile;
+use App\Actions\GenerateMagicLink;
 use App\Actions\PromoteVolunteer;
 use App\Actions\RecordArrival;
 use App\Actions\RecordGearPickup;
+use App\Enums\ActivityCategory;
 use App\Enums\ArrivalMethod;
 use App\Enums\ScannerType;
 use App\Enums\StaffRole;
 use App\Exceptions\DomainException;
+use App\Models\ActivityLog;
 use App\Models\CustomRegistrationField;
 use App\Models\Event;
 use App\Models\EventArrival;
@@ -17,9 +20,11 @@ use App\Models\ProjectScanner;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
+use App\Notifications\TicketResendNotification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
@@ -39,6 +44,8 @@ class VolunteerDetail extends Component
     public bool $showDeleteModal = false;
 
     public bool $deleteConfirmed = false;
+
+    public string $successMessage = '';
 
     public string $promoteRole = 'organizer';
 
@@ -183,6 +190,63 @@ class VolunteerDetail extends Component
         }
 
         $this->redirect(route('events.volunteers', $this->event));
+    }
+
+    public function resendTicketEmail(): void
+    {
+        Gate::authorize('update', $this->event);
+
+        $this->resetErrorBag('resend');
+        $this->successMessage = '';
+
+        if (! $this->volunteer->isEmailVerified()) {
+            $this->addError('resend', 'Die E-Mail-Adresse dieses Volunteers ist noch nicht verifiziert.');
+
+            return;
+        }
+
+        $volunteerKey = 'qr-resend:'.$this->volunteer->id;
+        if (RateLimiter::tooManyAttempts($volunteerKey, 1)) {
+            $this->addError('resend', 'Bitte warte einige Minuten, bevor du es erneut versuchst.');
+
+            return;
+        }
+
+        $organizerKey = 'qr-resend-admin-user:'.Auth::id();
+        if (RateLimiter::tooManyAttempts($organizerKey, 10)) {
+            $this->addError('resend', 'Zu viele Anfragen. Bitte versuche es später erneut.');
+
+            return;
+        }
+
+        RateLimiter::hit($volunteerKey, 300);
+        RateLimiter::hit($organizerKey, 3600);
+
+        $result = app(GenerateMagicLink::class)->execute($this->volunteer);
+
+        $this->volunteer->notify(new TicketResendNotification(
+            $this->volunteer->project,
+            $result['plainToken'],
+        ));
+
+        ActivityLog::create([
+            'organization_id' => $this->event->organization_id,
+            'project_id' => $this->event->project_id,
+            'event_id' => $this->event->id,
+            'causer_type' => Auth::user()::class,
+            'causer_id' => Auth::id(),
+            'subject_type' => Volunteer::class,
+            'subject_id' => $this->volunteer->id,
+            'action' => 'resent',
+            'category' => ActivityCategory::Email,
+            'description' => "Resent volunteer portal link to {$this->volunteer->full_name}",
+            'properties' => [
+                'volunteer_name' => $this->volunteer->full_name,
+                'volunteer_email' => $this->volunteer->email,
+            ],
+        ]);
+
+        $this->successMessage = __('Mail wurde an :email gesendet.', ['email' => $this->volunteer->email]);
     }
 
     public function markAsArrived(): void

--- a/app/Livewire/Events/VolunteerDetail.php
+++ b/app/Livewire/Events/VolunteerDetail.php
@@ -7,8 +7,10 @@ use App\Actions\GenerateMagicLink;
 use App\Actions\PromoteVolunteer;
 use App\Actions\RecordArrival;
 use App\Actions\RecordGearPickup;
+use App\Actions\UpdateVolunteerGearSelection;
 use App\Enums\ActivityCategory;
 use App\Enums\ArrivalMethod;
+use App\Enums\GearItemType;
 use App\Enums\ScannerType;
 use App\Enums\StaffRole;
 use App\Exceptions\DomainException;
@@ -50,6 +52,21 @@ class VolunteerDetail extends Component
     public string $promoteRole = 'organizer';
 
     public string $selectedScannerId = '';
+
+    public bool $showGearSelectionModal = false;
+
+    public ?int $editingGearId = null;
+
+    public string $editingGearName = '';
+
+    public string $gearSelection = '';
+
+    /**
+     * @var array<int, string>
+     */
+    public array $gearSelectionOptions = [];
+
+    public bool $editingGearPickedUp = false;
 
     public function mount(int $eventId, int $volunteerId): void
     {
@@ -275,8 +292,7 @@ class VolunteerDetail extends Component
     {
         Gate::authorize('trackGearPickup', $this->event);
 
-        $gear = VolunteerGear::whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id))
-            ->findOrFail($gearId);
+        $gear = $this->findVolunteerGear($gearId);
 
         try {
             app(RecordGearPickup::class)->execute($gear, Auth::user());
@@ -291,11 +307,81 @@ class VolunteerDetail extends Component
     {
         Gate::authorize('trackGearPickup', $this->event);
 
-        $gear = VolunteerGear::whereHas('gearItem', fn ($q) => $q->where('project_id', $this->event->project_id))
-            ->findOrFail($gearId);
+        $gear = $this->findVolunteerGear($gearId);
 
         $gear->pickups()->latest('picked_up_at')->first()?->delete();
 
         unset($this->volunteerGear);
+    }
+
+    public function openGearSelectionModal(int $gearId): void
+    {
+        Gate::authorize('update', $this->event);
+
+        $this->resetErrorBag('gearSelection');
+
+        $gear = $this->findVolunteerGear($gearId);
+
+        if ($gear->gearItem->type !== GearItemType::SizeSelection || ! $gear->gearItem->requires_size) {
+            abort(404);
+        }
+
+        $this->editingGearId = $gear->id;
+        $this->editingGearName = $gear->gearItem->name;
+        $this->gearSelection = $gear->size ?? '';
+        $this->gearSelectionOptions = $gear->gearItem->available_sizes ?? [];
+        $this->editingGearPickedUp = $gear->isPickedUp();
+        $this->showGearSelectionModal = true;
+    }
+
+    public function closeGearSelectionModal(): void
+    {
+        $this->showGearSelectionModal = false;
+        $this->editingGearId = null;
+        $this->editingGearName = '';
+        $this->gearSelection = '';
+        $this->gearSelectionOptions = [];
+        $this->editingGearPickedUp = false;
+        $this->resetErrorBag('gearSelection');
+    }
+
+    public function saveGearSelection(UpdateVolunteerGearSelection $action): void
+    {
+        Gate::authorize('update', $this->event);
+
+        $this->validate([
+            'gearSelection' => ['required', 'string'],
+        ]);
+
+        if ($this->editingGearId === null) {
+            abort(404);
+        }
+
+        try {
+            $action->execute(
+                gear: $this->findVolunteerGear($this->editingGearId),
+                event: $this->event,
+                selection: $this->gearSelection,
+                causer: Auth::user(),
+            );
+        } catch (DomainException $e) {
+            $this->addError('gearSelection', $e->getMessage());
+
+            return;
+        }
+
+        $this->closeGearSelectionModal();
+        $this->successMessage = __('Gear-Auswahl wurde aktualisiert.');
+
+        unset($this->volunteerGear);
+    }
+
+    private function findVolunteerGear(int $gearId): VolunteerGear
+    {
+        return VolunteerGear::query()
+            ->where('volunteer_id', $this->volunteer->id)
+            ->whereHas('gearItem', fn ($query) => $query->where('project_id', $this->event->project_id))
+            ->with('gearItem')
+            ->findOrFail($gearId);
     }
 }

--- a/app/Livewire/Projects/ProjectMembers.php
+++ b/app/Livewire/Projects/ProjectMembers.php
@@ -3,13 +3,17 @@
 namespace App\Livewire\Projects;
 
 use App\Actions\AddProjectMember;
+use App\Actions\CreateInvitedUser;
 use App\Actions\RemoveProjectMember;
 use App\Exceptions\DomainException;
 use App\Exceptions\MemberAlreadyExistsException;
 use App\Models\Project;
 use App\Models\User;
+use App\Notifications\StaffInvitation;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
@@ -48,7 +52,7 @@ class ProjectMembers extends Component
         return currentOrganization()->users()->orderBy('name')->get();
     }
 
-    public function inviteMember(AddProjectMember $action): void
+    public function inviteMember(AddProjectMember $action, CreateInvitedUser $createInvitedUser): void
     {
         Gate::authorize('manageMembers', $this->project);
 
@@ -59,13 +63,20 @@ class ProjectMembers extends Component
         $user = User::where('email', $this->inviteEmail)->first();
 
         if (! $user) {
-            $this->addError('inviteEmail', 'No user found with this email address.');
+            $invitedUser = $createInvitedUser->execute(
+                $this->resolveInviteName(),
+                $this->inviteEmail,
+            );
 
-            return;
+            $user = $invitedUser['user'];
+            $user->notify(new StaffInvitation($this->project->organization, $invitedUser['temporaryPassword']));
         }
 
+        /** @var User $causer */
+        $causer = Auth::user();
+
         try {
-            $action->execute($this->project, $user, auth()->user());
+            $action->execute($this->project, $user, $causer);
         } catch (MemberAlreadyExistsException) {
             $this->addError('inviteEmail', 'This user is already a project member.');
 
@@ -80,6 +91,24 @@ class ProjectMembers extends Component
         unset($this->members);
 
         $this->dispatch('member-added');
+    }
+
+    protected function resolveInviteName(): string
+    {
+        $volunteer = $this->project->volunteers()
+            ->where('email', $this->inviteEmail)
+            ->first();
+
+        if ($volunteer) {
+            return $volunteer->full_name;
+        }
+
+        return Str::of($this->inviteEmail)
+            ->before('@')
+            ->replace(['.', '_', '-'], ' ')
+            ->squish()
+            ->title()
+            ->value();
     }
 
     public function confirmRemoveMember(int $userId): void
@@ -102,7 +131,10 @@ class ProjectMembers extends Component
             return;
         }
 
-        $action->execute($this->project, $user, auth()->user());
+        /** @var User $causer */
+        $causer = Auth::user();
+
+        $action->execute($this->project, $user, $causer);
 
         $this->showRemoveModal = false;
         $this->reset('removeMemberId');

--- a/app/Notifications/VolunteerEventUpdatedNotification.php
+++ b/app/Notifications/VolunteerEventUpdatedNotification.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\EmailTemplateType;
+use App\Models\Event;
+use App\Notifications\Concerns\HasRetryStrategy;
+use App\Notifications\Concerns\UsesOrganizationMailer;
+use App\Services\EmailTemplateRenderer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class VolunteerEventUpdatedNotification extends Notification implements ShouldQueue
+{
+    use HasRetryStrategy;
+    use Queueable;
+    use UsesOrganizationMailer;
+
+    public function __construct(
+        public Event $event,
+        public string $organizerNote,
+        public string $magicLinkToken,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $renderer = app(EmailTemplateRenderer::class);
+        $rendered = $renderer->render(
+            EmailTemplateType::EventUpdated,
+            $this->event,
+            [
+                'vorname' => $notifiable->first_name,
+                'nachname' => $notifiable->last_name,
+                'event_name' => $this->event->name,
+                'organizer_note' => $this->organizerNote,
+                'portal_link' => route('volunteer.portal', $this->magicLinkToken),
+            ],
+        );
+
+        $mail = (new MailMessage)
+            ->subject($rendered['subject'])
+            ->greeting("Hallo {$notifiable->first_name}!");
+
+        foreach (explode("\n", $rendered['body']) as $line) {
+            $trimmed = trim($line);
+
+            if ($trimmed !== '') {
+                $mail->line($trimmed);
+            }
+        }
+
+        $portalUrl = route('volunteer.portal', $this->magicLinkToken);
+        $mail->action('Portal oeffnen', $portalUrl);
+
+        return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
+    }
+}

--- a/e2e/pre-shift-reminder-relative-day.spec.ts
+++ b/e2e/pre-shift-reminder-relative-day.spec.ts
@@ -14,7 +14,9 @@ type MailpitInbox = {
     messages?: MailpitMessage[];
 };
 
-const mailpitBaseUrl = 'http://mailpit:8025';
+const mailpitBaseUrl = (globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+}).process?.env?.MAILPIT_BASE_URL ?? 'http://localhost:8025';
 
 test('24-hour pre-shift reminders use today and tomorrow wording', async ({ request }) => {
     await expect.poll(async () => {

--- a/resources/views/livewire/events/volunteer-detail.blade.php
+++ b/resources/views/livewire/events/volunteer-detail.blade.php
@@ -19,12 +19,22 @@
                         <flux:button variant="danger" size="sm" icon="trash" wire:click="$set('showDeleteModal', true)">
                             {{ __('Volunteer löschen') }}
                         </flux:button>
+                        @if ($volunteer->isEmailVerified())
+                            <flux:button variant="ghost" size="sm" icon="envelope" wire:click="resendTicketEmail" wire:loading.attr="disabled">
+                                <span wire:loading.remove wire:target="resendTicketEmail">{{ __('QR-Code erneut senden') }}</span>
+                                <span wire:loading wire:target="resendTicketEmail">{{ __('Wird gesendet...') }}</span>
+                            </flux:button>
+                        @endif
                         <flux:button variant="primary" size="sm" icon="arrow-up-circle" wire:click="$set('showPromoteModal', true)">
                             {{ __('Promote to Staff') }}
                         </flux:button>
                     </div>
                 @endif
             </div>
+            @if ($successMessage !== '')
+                <flux:callout variant="success" class="mb-4">{{ $successMessage }}</flux:callout>
+            @endif
+            <flux:error name="resend" class="mb-4" />
             <div class="grid gap-4 sm:grid-cols-2">
                 <div>
                     <flux:text size="sm" class="!text-zinc-500 dark:!text-zinc-400">{{ __('Name') }}</flux:text>

--- a/resources/views/livewire/events/volunteer-detail.blade.php
+++ b/resources/views/livewire/events/volunteer-detail.blade.php
@@ -155,8 +155,12 @@
                         <flux:table.row :key="'gear-'.$gear->id">
                             <flux:table.cell>{{ $gear->gearItem->name }}</flux:table.cell>
                             <flux:table.cell>
-                                @if ($gear->size)
-                                    <flux:badge size="sm" color="zinc">{{ $gear->size }}</flux:badge>
+                                @if ($gear->gearItem->type === \App\Enums\GearItemType::SizeSelection)
+                                    @if ($gear->size)
+                                        <flux:badge size="sm" color="zinc">{{ $gear->size }}</flux:badge>
+                                    @else
+                                        <flux:badge size="sm" color="amber">{{ __('Auswahl ausstehend') }}</flux:badge>
+                                    @endif
                                 @else
                                     —
                                 @endif
@@ -171,30 +175,40 @@
                                 @endif
                             </flux:table.cell>
                             <flux:table.cell>
-                                @can('trackGearPickup', $event)
-                                    @if ($gear->quantity_entitled !== null)
-                                        @if ($gear->remainingQuantity() > 0)
-                                            <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Record pickup') }}">
-                                                <flux:icon name="plus" class="size-4" />
+                                <div class="flex items-center gap-2">
+                                    @can('update', $event)
+                                        @if ($gear->gearItem->type === \App\Enums\GearItemType::SizeSelection && $gear->gearItem->requires_size)
+                                            <flux:button size="xs" variant="ghost" wire:click="openGearSelectionModal({{ $gear->id }})">
+                                                {{ $gear->size ? __('Auswahl ändern') : __('Auswahl setzen') }}
                                             </flux:button>
                                         @endif
-                                        @if ($gear->totalPickedUp() > 0)
-                                            <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo last pickup') }}">
-                                                <flux:icon name="minus" class="size-4" />
-                                            </flux:button>
-                                        @endif
-                                    @else
-                                        @if ($gear->isPickedUp())
-                                            <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo pickup') }}">
-                                                <flux:icon name="arrow-uturn-left" class="size-4" />
-                                            </flux:button>
+                                    @endcan
+
+                                    @can('trackGearPickup', $event)
+                                        @if ($gear->quantity_entitled !== null)
+                                            @if ($gear->remainingQuantity() > 0)
+                                                <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Record pickup') }}">
+                                                    <flux:icon name="plus" class="size-4" />
+                                                </flux:button>
+                                            @endif
+                                            @if ($gear->totalPickedUp() > 0)
+                                                <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo last pickup') }}">
+                                                    <flux:icon name="minus" class="size-4" />
+                                                </flux:button>
+                                            @endif
                                         @else
-                                            <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Mark as picked up') }}">
-                                                <flux:icon name="hand-raised" class="size-4" />
-                                            </flux:button>
+                                            @if ($gear->isPickedUp())
+                                                <flux:button size="xs" variant="ghost" wire:click="undoGearPickup({{ $gear->id }})" aria-label="{{ __('Undo pickup') }}">
+                                                    <flux:icon name="arrow-uturn-left" class="size-4" />
+                                                </flux:button>
+                                            @else
+                                                <flux:button size="xs" variant="ghost" wire:click="recordGearPickup({{ $gear->id }})" aria-label="{{ __('Mark as picked up') }}">
+                                                    <flux:icon name="hand-raised" class="size-4" />
+                                                </flux:button>
+                                            @endif
                                         @endif
-                                    @endif
-                                @endcan
+                                    @endcan
+                                </div>
                             </flux:table.cell>
                         </flux:table.row>
                     @endforeach
@@ -204,6 +218,33 @@
 
             <flux:error name="gear" />
         @endif
+
+        <flux:modal wire:model="showGearSelectionModal" focusable class="max-w-lg">
+            <div class="space-y-4">
+                <flux:heading size="lg">{{ __('Gear-Auswahl ändern') }}</flux:heading>
+                <flux:text>{{ __('Passe die Auswahl für :item an.', ['item' => $editingGearName]) }}</flux:text>
+
+                @if ($editingGearPickedUp)
+                    <flux:callout variant="warning">
+                        {{ __('Dieses Gear wurde bereits ausgegeben. Du kannst die Auswahl trotzdem anpassen.') }}
+                    </flux:callout>
+                @endif
+
+                <flux:select wire:model="gearSelection" :label="__('Auswahl')">
+                    <flux:select.option value="">{{ __('Bitte wählen...') }}</flux:select.option>
+                    @foreach ($gearSelectionOptions as $option)
+                        <flux:select.option :value="$option">{{ $option }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+
+                <flux:error name="gearSelection" />
+
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" wire:click="closeGearSelectionModal">{{ __('Abbrechen') }}</flux:button>
+                    <flux:button variant="primary" wire:click="saveGearSelection">{{ __('Speichern') }}</flux:button>
+                </div>
+            </div>
+        </flux:modal>
 
         {{-- Promote modal --}}
         <flux:modal wire:model="showPromoteModal" focusable class="max-w-lg">

--- a/resources/views/livewire/projects/project-members.blade.php
+++ b/resources/views/livewire/projects/project-members.blade.php
@@ -71,7 +71,7 @@
     <flux:card>
         <flux:heading size="lg" class="mb-4">{{ __('Add Project Member') }}</flux:heading>
         <flux:text size="sm" class="mb-4 text-zinc-500 dark:text-zinc-400">
-            {{ __('Add an existing user to this project by their email address.') }}
+            {{ __('Invite a project member by email. If they do not have an account yet, one will be created automatically.') }}
         </flux:text>
 
         <form wire:submit="inviteMember" class="space-y-4">

--- a/tests/Feature/Actions/UpdateVolunteerGearSelectionTest.php
+++ b/tests/Feature/Actions/UpdateVolunteerGearSelectionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Actions\UpdateVolunteerGearSelection;
+use App\Enums\ActivityCategory;
+use App\Models\ActivityLog;
+use App\Models\Event;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ProjectGearItem;
+use App\Models\User;
+use App\Models\Volunteer;
+use App\Models\VolunteerGear;
+use App\Notifications\VolunteerEventUpdatedNotification;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create();
+    $this->project = Project::factory()->for($this->organization)->create();
+    $this->event = Event::factory()->for($this->organization)->for($this->project)->published()->create([
+        'name' => 'Sommerfest',
+    ]);
+    $this->organizer = User::factory()->create();
+    $this->volunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'first_name' => 'Jane',
+        'last_name' => 'Doe',
+        'email' => 'jane@example.com',
+    ]);
+});
+
+it('updates a volunteer gear selection, logs the change, and sends the standard update email', function () {
+    Notification::fake();
+
+    $gearItem = ProjectGearItem::factory()->sized(['M', 'L', 'XL'])->for($this->project)->create([
+        'name' => 'T-Shirt',
+    ]);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => 'L',
+    ]);
+
+    $updatedGear = app(UpdateVolunteerGearSelection::class)->execute(
+        gear: $gear,
+        event: $this->event,
+        selection: 'XL',
+        causer: $this->organizer,
+    );
+
+    expect($updatedGear->size)->toBe('XL');
+
+    $log = ActivityLog::query()->latest('id')->first();
+
+    expect($log)->not->toBeNull()
+        ->and($log->category)->toBe(ActivityCategory::Volunteer)
+        ->and($log->action)->toBe('updated')
+        ->and($log->subject_type)->toBe(Volunteer::class)
+        ->and($log->subject_id)->toBe($this->volunteer->id)
+        ->and($log->causer_id)->toBe($this->organizer->id)
+        ->and($log->properties['gear_item_name'])->toBe('T-Shirt')
+        ->and($log->properties['previous_selection'])->toBe('L')
+        ->and($log->properties['new_selection'])->toBe('XL');
+
+    Notification::assertSentTo($this->volunteer, VolunteerEventUpdatedNotification::class, function (VolunteerEventUpdatedNotification $notification) {
+        return $notification->event->is($this->event)
+            && str_contains($notification->organizerNote, 'T-Shirt')
+            && str_contains($notification->organizerNote, 'L')
+            && str_contains($notification->organizerNote, 'XL');
+    });
+});
+
+it('allows setting a pending gear selection for the first time', function () {
+    Notification::fake();
+
+    $gearItem = ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create([
+        'name' => 'T-Shirt',
+    ]);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => null,
+    ]);
+
+    $updatedGear = app(UpdateVolunteerGearSelection::class)->execute(
+        gear: $gear,
+        event: $this->event,
+        selection: 'M',
+        causer: $this->organizer,
+    );
+
+    expect($updatedGear->size)->toBe('M');
+
+    $log = ActivityLog::query()->latest('id')->first();
+
+    expect($log->properties['previous_selection'])->toBe('Auswahl ausstehend')
+        ->and($log->properties['new_selection'])->toBe('M');
+});

--- a/tests/Feature/Events/VolunteerDetailTest.php
+++ b/tests/Feature/Events/VolunteerDetailTest.php
@@ -4,6 +4,7 @@ use App\Enums\ArrivalMethod;
 use App\Enums\AttendanceStatus;
 use App\Enums\StaffRole;
 use App\Livewire\Events\VolunteerDetail;
+use App\Models\ActivityLog;
 use App\Models\AttendanceRecord;
 use App\Models\CustomFieldResponse;
 use App\Models\CustomRegistrationField;
@@ -20,7 +21,9 @@ use App\Models\Volunteer;
 use App\Models\VolunteerGear;
 use App\Models\VolunteerGearPickup;
 use App\Models\VolunteerJob;
+use App\Notifications\TicketResendNotification;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -28,7 +31,7 @@ beforeEach(function () {
     app()->instance(Organization::class, $this->org);
     $this->project = Project::factory()->for($this->org)->create();
     $this->event = Event::factory()->for($this->org)->for($this->project)->published()->create();
-    $this->volunteer = Volunteer::factory()->for($this->project)->create(['first_name' => 'Jane', 'last_name' => 'Doe', 'email' => 'jane@example.com', 'phone' => '+1234567890']);
+    $this->volunteer = Volunteer::factory()->verified()->for($this->project)->create(['first_name' => 'Jane', 'last_name' => 'Doe', 'email' => 'jane@example.com', 'phone' => '+1234567890']);
     $this->job = VolunteerJob::factory()->for($this->event)->create();
     $this->shift = Shift::factory()->for($this->job, 'volunteerJob')->create();
     ShiftSignup::factory()->create(['volunteer_id' => $this->volunteer->id, 'shift_id' => $this->shift->id]);
@@ -110,6 +113,7 @@ it('shows promote button for organizer when not promoted', function () {
     Livewire::actingAs($this->user)
         ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
         ->assertSee('Volunteer löschen')
+        ->assertSee('QR-Code erneut senden')
         ->assertSee('Promote to Staff');
 });
 
@@ -133,6 +137,91 @@ it('allows project members to view volunteer detail but forbids deletion', funct
         ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
         ->call('deleteVolunteer')
         ->assertForbidden();
+});
+
+it('resends ticket email from volunteer detail for organizers', function () {
+    Notification::fake();
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('resendTicketEmail')
+        ->assertSee('Mail wurde an jane@example.com gesendet.');
+
+    Notification::assertSentTo($this->volunteer, TicketResendNotification::class);
+
+    expect(ActivityLog::query()
+        ->where('action', 'resent')
+        ->where('event_id', $this->event->id)
+        ->where('subject_type', Volunteer::class)
+        ->where('subject_id', $this->volunteer->id)
+        ->where('causer_id', $this->user->id)
+        ->exists())->toBeTrue();
+});
+
+it('rate limits volunteer detail ticket resends to once per five minutes', function () {
+    Notification::fake();
+
+    $component = Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('resendTicketEmail')
+        ->assertSee('Mail wurde an jane@example.com gesendet.');
+
+    $component->call('resendTicketEmail')
+        ->assertSee('Bitte warte einige Minuten, bevor du es erneut versuchst.');
+
+    Notification::assertSentToTimes($this->volunteer, TicketResendNotification::class, 1);
+});
+
+it('rate limits volunteer detail ticket resends per organizer', function () {
+    Notification::fake();
+
+    $organizerKey = 'qr-resend-admin-user:'.$this->user->id;
+
+    for ($attempt = 0; $attempt < 10; $attempt++) {
+        RateLimiter::hit($organizerKey, 3600);
+    }
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('resendTicketEmail')
+        ->assertSee('Zu viele Anfragen. Bitte versuche es später erneut.');
+
+    Notification::assertNothingSent();
+});
+
+it('forbids ticket resend from volunteer detail for non-organizers', function () {
+    Notification::fake();
+
+    $member = User::factory()->create();
+    $this->project->users()->attach($member, ['role' => StaffRole::VolunteerAdmin]);
+
+    Livewire::actingAs($member)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('resendTicketEmail')
+        ->assertForbidden();
+
+    Notification::assertNothingSent();
+});
+
+it('does not show resend button for unverified volunteers', function () {
+    $this->volunteer->update(['email_verified_at' => null]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertDontSee('QR-Code erneut senden');
+});
+
+it('does not resend ticket email for unverified volunteers', function () {
+    Notification::fake();
+
+    $this->volunteer->update(['email_verified_at' => null]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('resendTicketEmail')
+        ->assertHasErrors('resend');
+
+    Notification::assertNothingSent();
 });
 
 it('hides promote button when already promoted', function () {

--- a/tests/Feature/Events/VolunteerDetailTest.php
+++ b/tests/Feature/Events/VolunteerDetailTest.php
@@ -22,6 +22,7 @@ use App\Models\VolunteerGear;
 use App\Models\VolunteerGearPickup;
 use App\Models\VolunteerJob;
 use App\Notifications\TicketResendNotification;
+use App\Notifications\VolunteerEventUpdatedNotification;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Livewire;
@@ -427,6 +428,75 @@ it('shows gear assignments with size info', function () {
         ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
         ->assertSee('T-Shirt')
         ->assertSee('L');
+});
+
+it('shows pending gear selections on volunteer detail', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->sized(['S', 'M', 'L'])
+        ->for($this->project)
+        ->create(['name' => 'T-Shirt']);
+
+    VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => null,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->assertSee('Auswahl ausstehend')
+        ->assertSee('Auswahl setzen');
+});
+
+it('allows organizers to change sized gear selections from volunteer detail', function () {
+    Notification::fake();
+
+    $gearItem = ProjectGearItem::factory()
+        ->sized(['M', 'L', 'XL'])
+        ->for($this->project)
+        ->create(['name' => 'T-Shirt']);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => 'L',
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('openGearSelectionModal', $gear->id)
+        ->assertSet('showGearSelectionModal', true)
+        ->set('gearSelection', 'XL')
+        ->call('saveGearSelection')
+        ->assertHasNoErrors()
+        ->assertSet('showGearSelectionModal', false)
+        ->assertSee('Gear-Auswahl wurde aktualisiert.');
+
+    expect($gear->fresh()->size)->toBe('XL');
+
+    Notification::assertSentTo($this->volunteer, VolunteerEventUpdatedNotification::class);
+});
+
+it('shows a warning when editing gear that was already picked up', function () {
+    $gearItem = ProjectGearItem::factory()
+        ->sized(['M', 'L', 'XL'])
+        ->for($this->project)
+        ->create(['name' => 'T-Shirt']);
+
+    $gear = VolunteerGear::factory()->create([
+        'project_gear_item_id' => $gearItem->id,
+        'volunteer_id' => $this->volunteer->id,
+        'size' => 'L',
+    ]);
+
+    VolunteerGearPickup::factory()->create([
+        'volunteer_gear_id' => $gear->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(VolunteerDetail::class, ['eventId' => $this->event->id, 'volunteerId' => $this->volunteer->id])
+        ->call('openGearSelectionModal', $gear->id)
+        ->assertSee('Dieses Gear wurde bereits ausgegeben. Du kannst die Auswahl trotzdem anpassen.');
 });
 
 it('shows gear assignments with quantity pickup progress', function () {

--- a/tests/Feature/Livewire/ProjectMembersTest.php
+++ b/tests/Feature/Livewire/ProjectMembersTest.php
@@ -5,6 +5,9 @@ use App\Livewire\Projects\ProjectMembers;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\User;
+use App\Models\Volunteer;
+use App\Notifications\StaffInvitation;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -66,12 +69,32 @@ it('adds a project member by email', function () {
     expect($this->project->users()->where('user_id', $user->id)->exists())->toBeTrue();
 });
 
-it('shows error when user not found', function () {
+it('invites a volunteer email by creating a project member user', function () {
+    Notification::fake();
+
+    $volunteer = Volunteer::factory()->for($this->project)->create([
+        'first_name' => 'Taylor',
+        'last_name' => 'Volunteer',
+        'email' => 'volunteer@example.com',
+    ]);
+
     Livewire::actingAs($this->organizer)
         ->test(ProjectMembers::class, ['projectId' => $this->project->id])
-        ->set('inviteEmail', 'nonexistent@example.com')
+        ->set('inviteEmail', $volunteer->email)
         ->call('inviteMember')
-        ->assertHasErrors('inviteEmail');
+        ->assertHasNoErrors()
+        ->assertDispatched('member-added');
+
+    $newUser = User::where('email', $volunteer->email)->first();
+
+    expect($newUser)->not->toBeNull()
+        ->and($newUser->name)->toBe($volunteer->full_name)
+        ->and($newUser->must_change_password)->toBeTrue()
+        ->and($newUser->email_verified_at)->not->toBeNull()
+        ->and($this->project->users()->where('user_id', $newUser->id)->exists())->toBeTrue()
+        ->and($this->org->users()->where('user_id', $newUser->id)->exists())->toBeFalse();
+
+    Notification::assertSentTo($newUser, StaffInvitation::class);
 });
 
 it('shows error when user is already a member', function () {


### PR DESCRIPTION
## Summary
- let organizers edit volunteer gear selections directly from the volunteer detail view and add the QR code or portal-link resend action for follow-up communication
- let project organizers invite missing members directly by email without routing through the organization workflow
- make the pre-shift reminder E2E spec honor a configurable Mailpit base URL so the suite passes in the normal host workflow as well as Sail

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Actions/UpdateVolunteerGearSelectionTest.php tests/Feature/Events/VolunteerDetailTest.php tests/Feature/Livewire/ProjectMembersTest.php`
- `vendor/bin/sail exec -e MAILPIT_BASE_URL=http://mailpit:8025 laravel.test npm run test:e2e -- e2e/pre-shift-reminder-relative-day.spec.ts`

Closes #182
Closes #172
Closes #171