### PR TITLE
feat(scanner): add dedicated gear scanner workflow

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,8 +1,8 @@
 ---
 pipeline_status: in_progress
 current_stage: complete
-current_focus: "Issue #207 complete — empty-state notification opt-in, double opt-in subscriber flow, unsubscribe links, and queued event-availability notifications are implemented for public signup"
-current_milestone: issue-207-signup-empty-state-notifications
+current_focus: "Issue #201 complete — gear scanners now support volunteer and guest gear workflows with pool-scoped volunteer pickups, guest-group filtering, and scanner E2E coverage"
+current_milestone: issue-201-gear-scanner-type
 entry_point: implement
 stages_to_run:
   - plan
@@ -14,7 +14,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-04-30T20:18:00+02:00"
+last_updated: "2026-04-30T19:30:14+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -44,6 +44,7 @@ last_updated: "2026-04-30T20:18:00+02:00"
 | issue-203-priority-shift-gate | Priority Shift Gate | #203 event-level priority gating for public signup with organizer override and progress UI | m10-signup, issue-168-shifts-jobs-active-state | complete |
 | issue-206-hide-fully-booked-jobs | Hide Fully Booked Jobs | #206 hide fully booked public-signup jobs while keeping partial/full returning-volunteer context | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate | complete |
 | issue-207-signup-empty-state-notifications | Signup Empty-State Notifications | #207 empty-state opt-in, double opt-in verification, unsubscribe flow, and queued availability notices for public signup | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs | complete |
+| issue-201-gear-scanner-type | Gear Scanner Type | #201 dedicated gear scanner for volunteer and guest gear with pool events and guest group filters | m11-scanner, m12-guest-lists, issue-196-scanner-arrival-duplicate-status | complete |
 
 ## Artifacts
 
@@ -70,6 +71,7 @@ last_updated: "2026-04-30T20:18:00+02:00"
 | `.tall-pipeline/issue-203-priority-shift-gate.md` | plan+implement+test | issue-203 | Issue #203 tracking for event-level priority shift gating, organizer override, and signup UI progress | complete |
 | `.tall-pipeline/issue-206-hide-fully-booked-jobs.md` | plan+implement+test | issue-206 | Issue #206 tracking for hiding fully booked jobs from public signup while preserving returning-volunteer visibility | complete |
 | `.tall-pipeline/issue-207-signup-empty-state-notifications.md` | plan+implement+test | issue-207 | Issue #207 tracking for empty-state notification opt-in, verification, unsubscribe, and queued event availability notifications | complete |
+| `.tall-pipeline/issue-201-gear-scanner-type.md` | plan+implement+test+security | issue-201 | Issue #201 tracking for dedicated gear scanners, pool-scoped volunteer pickups, guest filtering, and scanner E2E coverage | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/issue-201-gear-scanner-type.md
+++ b/.tall-pipeline/issue-201-gear-scanner-type.md
@@ -1,0 +1,54 @@
+# Milestone: issue-201-gear-scanner-type — Gear Scanner Type
+
+**GitHub Issue:** [#201](https://github.com/reneweiser/voluntify/issues/201)
+**Features:** #201
+**Dependencies:** m11-scanner, m12-guest-lists, issue-196-scanner-arrival-duplicate-status
+**Branch:** `milestone/phase-4-scanner-gear-expansion`
+
+## Plan
+- **Status:** complete
+- **Gate summary:** finish the dedicated `gear` scanner path by enforcing pooled volunteer gear access, keeping guest-group filtering intact, trimming the gear payload away from attendance data, and covering the workflow with focused Pest and Playwright tests.
+
+### Scope
+- Keep the existing Gear scanner type, management form, migration, and scanner UI additions already present in the codebase
+- Restrict volunteer gear pickup to volunteers inside the configured scanner pool
+- Return gear scanner volunteer payloads without shift attendance detail
+- Verify guest-group filtering and all-confirmed-list fallback for guest gear access
+- Add Playwright coverage for gear scanner volunteer and guest lookup flows
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: expose the remaining mismatch via focused scanner API and management tests
+  - [x] GREEN: scope volunteer gear pickup queries to the scanner pool and suppress attendance payloads for `gear` scanner data responses
+  - [x] GREEN: fix stale test expectations/imports introduced by the Gear scanner expansion
+  - [x] GREEN: add a deterministic Playwright gear scanner fixture and browser spec
+  - [x] REFACTOR: keep the changes inside the existing scanner controller, tests, and E2E setup without introducing new abstractions
+- **Gate summary:** the Gear scanner now respects `pool_event_ids` for volunteer pickups, keeps guest access filtered by confirmed guest lists and optional guest groups, and exposes only the reduced data contract the Gear UI needs.
+
+## Test
+- **Status:** complete
+- **Gate summary:** focused backend, Livewire, JS, formatting, and Playwright scanner coverage all passed from a clean E2E seed.
+
+### Verification
+- `vendor/bin/sail artisan test --compact --filter=ProjectScanner`
+- `vendor/bin/sail artisan test --compact --filter=ScannerDataController`
+- `vendor/bin/sail artisan test --compact --filter=ScannerManagement`
+- `vendor/bin/sail artisan test --compact --filter=ScannerApp`
+- `vendor/bin/sail artisan test --compact --filter=GearPickup`
+- `vendor/bin/sail npm run test -- --run tests/js/scanner/alpine-scanner.test.ts tests/js/scanner/idb-store.test.ts`
+- `vendor/bin/sail bin pint --dirty --format agent`
+- `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/gear-scanner.spec.ts e2e/entry-staff-volunteer-lookup.spec.ts e2e/entry-staff-scanner-event-split.spec.ts e2e/va-scanner-shift-list.spec.ts e2e/va-scanner-arrival-status.spec.ts e2e/scanner-auth-timezone.spec.ts`
+
+## Security Audit
+- **Status:** complete
+- **Gate summary:** manual review of the new Gear scanner boundary found no unresolved critical or high issues after tightening volunteer gear pickup to scanner-pool membership and keeping guest gear access constrained to confirmed project guest lists plus optional `guest_group_ids`.
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| HTTP | `ScannerDataController::data()` now returns reduced volunteer payloads for `gear` scanners; `gearPickup()` now requires pooled volunteer membership |
+| E2E | `e2e/setup.sh` seeds `e2e-gear-scanner-token`; `e2e/gear-scanner.spec.ts` covers volunteer and guest lookup flows |
+| Tests | Gear scanner coverage expanded across `ScannerDataControllerTest`, `ScannerDataControllerGuestTest`, `GuestGearPickupApiTest`, and `ScannerManagementTest` |

--- a/app/Actions/CreateProjectScanner.php
+++ b/app/Actions/CreateProjectScanner.php
@@ -12,10 +12,14 @@ class CreateProjectScanner
         $rawCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
         $entryEventId = (int) $data['entry_event_id'];
         $poolEventIds = array_values(array_unique(array_map('intval', $data['pool_event_ids'])));
+        $guestGroupIds = isset($data['guest_group_ids']) && is_array($data['guest_group_ids'])
+            ? array_values(array_unique(array_map('intval', $data['guest_group_ids'])))
+            : null;
 
         return $project->scanners()->create([
             'entry_event_id' => $entryEventId,
             'pool_event_ids' => $poolEventIds,
+            'guest_group_ids' => $guestGroupIds !== [] ? $guestGroupIds : null,
             'requires_configuration_review' => false,
             'name' => $data['name'],
             'type' => $data['type'],

--- a/app/Actions/UpdateProjectScanner.php
+++ b/app/Actions/UpdateProjectScanner.php
@@ -12,6 +12,9 @@ class UpdateProjectScanner
         $poolEventIds = isset($data['pool_event_ids']) && is_array($data['pool_event_ids'])
             ? array_values(array_unique(array_map('intval', $data['pool_event_ids'])))
             : $scanner->configuredPoolEventIds();
+        $guestGroupIds = array_key_exists('guest_group_ids', $data) && is_array($data['guest_group_ids'])
+            ? array_values(array_unique(array_map('intval', $data['guest_group_ids'])))
+            : $scanner->configuredGuestGroupIds();
 
         $scanner->update([
             'name' => $data['name'] ?? $scanner->name,
@@ -19,6 +22,9 @@ class UpdateProjectScanner
             'modes' => $data['modes'] ?? $scanner->modes,
             'entry_event_id' => $entryEventId,
             'pool_event_ids' => $poolEventIds,
+            'guest_group_ids' => array_key_exists('guest_group_ids', $data)
+                ? ($guestGroupIds !== [] ? $guestGroupIds : null)
+                : $scanner->guest_group_ids,
             'requires_configuration_review' => $this->shouldClearReviewFlag($entryEventId, $poolEventIds) ? false : $scanner->requires_configuration_review,
             'gear_item_ids' => array_key_exists('gear_item_ids', $data) ? $data['gear_item_ids'] : $scanner->gear_item_ids,
             'hint_text' => array_key_exists('hint_text', $data) ? $data['hint_text'] : $scanner->hint_text,

--- a/app/Enums/ScannerType.php
+++ b/app/Enums/ScannerType.php
@@ -5,5 +5,6 @@ namespace App\Enums;
 enum ScannerType: string
 {
     case EntryStaff = 'entry_staff';
+    case Gear = 'gear';
     case VolunteerAdmin = 'volunteer_admin';
 }

--- a/app/Http/Controllers/ScannerDataController.php
+++ b/app/Http/Controllers/ScannerDataController.php
@@ -24,6 +24,7 @@ use App\Models\Volunteer;
 use App\Models\VolunteerGear;
 use App\Services\JwtKeyService;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -42,19 +43,23 @@ class ScannerDataController extends Controller
         $projectId = $scanner->project_id;
         $entryEventId = $scanner->entry_event_id;
         $poolEventIds = $scanner->configuredPoolEventIds();
+        $includesVolunteerShiftData = ! $scanner->isGearScanner();
 
         $volunteerQuery = Volunteer::forEvents($poolEventIds);
 
         $eagerLoads = [
             'tickets' => fn ($q) => $q->where('project_id', $projectId),
-            'shiftSignups' => function ($q) use ($poolEventIds) {
-                $q->whereHas('shift.volunteerJob', fn ($sq) => $sq->whereIn('event_id', $poolEventIds));
-            },
-            'shiftSignups.shift.volunteerJob',
-            'shiftSignups.attendanceRecord',
         ];
 
-        if ($scanner->type === ScannerType::VolunteerAdmin) {
+        if ($includesVolunteerShiftData) {
+            $eagerLoads['shiftSignups'] = function ($q) use ($poolEventIds) {
+                $q->whereHas('shift.volunteerJob', fn ($sq) => $sq->whereIn('event_id', $poolEventIds));
+            };
+            $eagerLoads['shiftSignups.shift.volunteerJob'] = fn ($q) => $q;
+            $eagerLoads['shiftSignups.attendanceRecord'] = fn ($q) => $q;
+        }
+
+        if ($scanner->supportsVolunteerGear()) {
             $eagerLoads['volunteerGear'] = fn ($q) => $q->whereHas('gearItem', fn ($sq) => $sq->where('project_id', $projectId));
             $eagerLoads['volunteerGear.gearItem'] = fn ($q) => $q;
             $eagerLoads['volunteerGear.pickups'] = fn ($q) => $q;
@@ -67,17 +72,23 @@ class ScannerDataController extends Controller
             ->orderBy('name')
             ->get();
 
-        $arrivals = EventArrival::where('event_id', $entryEventId)->get();
+        $arrivals = $includesVolunteerShiftData
+            ? EventArrival::where('event_id', $entryEventId)->get()
+            : collect();
 
-        $shiftSignupIds = $volunteers->flatMap(fn ($v) => $v->shiftSignups->pluck('id'));
-        $attendanceRecords = AttendanceRecord::whereIn('shift_signup_id', $shiftSignupIds)->get();
+        $attendanceRecords = $includesVolunteerShiftData
+            ? AttendanceRecord::whereIn(
+                'shift_signup_id',
+                $volunteers->flatMap(fn ($volunteer) => $volunteer->shiftSignups->pluck('id')),
+            )->get()
+            : collect();
 
         $guestEntries = $this->loadGuestEntries($scanner);
 
         $gearItems = [];
         $volunteerGearMap = (object) [];
 
-        if ($scanner->type === ScannerType::VolunteerAdmin) {
+        if ($scanner->supportsVolunteerGear()) {
             $gearItems = ProjectGearItem::where('project_id', $projectId)
                 ->orderBy('sort_order')
                 ->get()
@@ -129,25 +140,27 @@ class ScannerDataController extends Controller
                 'email' => $v->email,
                 'phone' => $v->phone,
                 'ticket' => $v->tickets->first(),
-                'shift_signups' => $v->shiftSignups->map(fn ($signup) => [
-                    'id' => $signup->id,
-                    'shift' => [
-                        'id' => $signup->shift->id,
-                        'shift_date' => $signup->shift->shift_date->toDateString(),
-                        'starts_at' => $signup->shift->starts_at,
-                        'ends_at' => $signup->shift->ends_at,
-                        'display_text' => $signup->shift->display_text,
-                        'volunteer_job' => [
-                            'id' => $signup->shift->volunteerJob->id,
-                            'name' => $signup->shift->volunteerJob->name,
+                'shift_signups' => $includesVolunteerShiftData
+                    ? $v->shiftSignups->map(fn ($signup) => [
+                        'id' => $signup->id,
+                        'shift' => [
+                            'id' => $signup->shift->id,
+                            'shift_date' => $signup->shift->shift_date->toDateString(),
+                            'starts_at' => $signup->shift->starts_at,
+                            'ends_at' => $signup->shift->ends_at,
+                            'display_text' => $signup->shift->display_text,
+                            'volunteer_job' => [
+                                'id' => $signup->shift->volunteerJob->id,
+                                'name' => $signup->shift->volunteerJob->name,
+                            ],
                         ],
-                    ],
-                    'attendance_record' => $signup->attendanceRecord ? [
-                        'id' => $signup->attendanceRecord->id,
-                        'shift_signup_id' => $signup->attendanceRecord->shift_signup_id,
-                        'status' => $signup->attendanceRecord->status->value,
-                    ] : null,
-                ]),
+                        'attendance_record' => $signup->attendanceRecord ? [
+                            'id' => $signup->attendanceRecord->id,
+                            'shift_signup_id' => $signup->attendanceRecord->shift_signup_id,
+                            'status' => $signup->attendanceRecord->status->value,
+                        ] : null,
+                    ])
+                    : [],
             ]),
             'arrivals' => $arrivals,
             'attendance_records' => $attendanceRecords,
@@ -224,8 +237,8 @@ class ScannerDataController extends Controller
             return response()->json(['error' => 'Scanner ID mismatch.'], 403);
         }
 
-        if ($scanner->type !== ScannerType::VolunteerAdmin) {
-            return response()->json(['error' => 'Only volunteer admin scanners can record gear pickups.'], 403);
+        if (! $scanner->supportsVolunteerGear()) {
+            return response()->json(['error' => 'Only gear-enabled scanners can record gear pickups.'], 403);
         }
 
         $request->validate([
@@ -234,7 +247,9 @@ class ScannerDataController extends Controller
             'quantity' => ['nullable', 'integer', 'min:1'],
         ]);
 
-        $gear = VolunteerGear::whereHas('gearItem', fn ($q) => $q->where('project_id', $scanner->project_id))
+        $gear = VolunteerGear::query()
+            ->whereHas('gearItem', fn ($query) => $query->where('project_id', $scanner->project_id))
+            ->whereHas('volunteer', fn ($query) => $query->forEvents($scanner->configuredPoolEventIds()))
             ->findOrFail($request->integer('volunteer_gear_id'));
 
         try {
@@ -307,8 +322,8 @@ class ScannerDataController extends Controller
             return response()->json(['error' => 'Scanner ID mismatch.'], 403);
         }
 
-        if ($scanner->type !== ScannerType::VolunteerAdmin) {
-            return response()->json(['error' => 'Only volunteer admin scanners can record guest gear pickups.'], 403);
+        if (! $scanner->supportsGuestGear()) {
+            return response()->json(['error' => 'Only gear-enabled scanners can record guest gear pickups.'], 403);
         }
 
         $request->validate([
@@ -318,9 +333,7 @@ class ScannerDataController extends Controller
             'quantity' => ['nullable', 'integer', 'min:1'],
         ]);
 
-        $gear = GuestEntryGear::whereHas('entry.group.guestList', function ($q) use ($scanner) {
-            $q->confirmed()->where('project_id', $scanner->project_id);
-        })->findOrFail($request->integer('guest_entry_gear_id'));
+        $gear = $this->guestEntryGearQuery($scanner)->findOrFail($request->integer('guest_entry_gear_id'));
 
         $result = $recordGuestGearPickup->execute($gear, $request->only(['selection', 'status', 'quantity']));
 
@@ -473,6 +486,50 @@ class ScannerDataController extends Controller
             ])->all();
         }
 
+        if ($scanner->isGearScanner()) {
+            $entries = $this->gearGuestEntriesQuery($scanner)
+                ->with(['group', 'gear.gearItem'])
+                ->get();
+
+            return $entries->map(fn (GuestEntry $e) => [
+                'id' => $e->id,
+                'guest_group_id' => $e->guest_group_id,
+                'group_label' => $e->group->label,
+                'group_guest_count' => $e->group->guest_count,
+                'number' => $e->number,
+                'name' => $e->name,
+                'qr_token' => $e->qr_token,
+                'checked_in_at' => $e->checked_in_at,
+                'gear' => $e->gear->map(fn ($g) => [
+                    'id' => $g->id,
+                    'gear_item_name' => $g->gearItem->name,
+                    'gear_item_type' => $g->gearItem->type->value,
+                    'available_sizes' => $g->gearItem->available_sizes,
+                    'available_states' => $g->gearItem->available_states,
+                    'quantity' => $g->quantity,
+                    'picked_up_count' => $g->picked_up_count,
+                    'selection' => $g->selection,
+                    'status' => $g->status,
+                ]),
+            ])->all();
+        }
+
         return [];
+    }
+
+    private function gearGuestEntriesQuery(ProjectScanner $scanner): Builder
+    {
+        $guestGroupIds = $scanner->configuredGuestGroupIds();
+
+        return GuestEntry::query()
+            ->whereHas('group.guestList', function ($query) use ($scanner) {
+                $query->confirmed()->where('project_id', $scanner->project_id);
+            })
+            ->when($guestGroupIds !== [], fn ($query) => $query->whereIn('guest_group_id', $guestGroupIds));
+    }
+
+    private function guestEntryGearQuery(ProjectScanner $scanner): Builder
+    {
+        return GuestEntryGear::query()->whereIn('guest_entry_id', $this->gearGuestEntriesQuery($scanner)->select('guest_entries.id'));
     }
 }

--- a/app/Livewire/Forms/ScannerForm.php
+++ b/app/Livewire/Forms/ScannerForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Forms;
 
+use App\Models\GuestList;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Validate;
 use Livewire\Form;
@@ -11,7 +12,7 @@ class ScannerForm extends Form
     #[Validate('required|string|max:255')]
     public string $name = '';
 
-    #[Validate('required|string|in:entry_staff,volunteer_admin')]
+    #[Validate('required|string|in:entry_staff,gear,volunteer_admin')]
     public string $type = 'entry_staff';
 
     #[Validate('required|array|min:1')]
@@ -20,6 +21,8 @@ class ScannerForm extends Form
     public ?int $entryEventId = null;
 
     public array $poolEventIds = [];
+
+    public array $guestGroupIds = [];
 
     public array $gearItemIds = [];
 
@@ -53,6 +56,16 @@ class ScannerForm extends Form
                 }
             }],
             'poolEventIds.*' => ['integer', Rule::exists('events', 'id')->where('project_id', $this->component->projectId)],
+            'guestGroupIds' => ['array'],
+            'guestGroupIds.*' => [
+                'integer',
+                Rule::exists('guest_groups', 'id')->where(function ($query) {
+                    $query->whereIn('guest_list_id', GuestList::query()
+                        ->confirmed()
+                        ->forProject($this->component->projectId)
+                        ->select('id'));
+                }),
+            ],
         ];
     }
 
@@ -68,6 +81,7 @@ class ScannerForm extends Form
         $this->modes = $data['modes'];
         $this->entryEventId = $data['entryEventId'];
         $this->poolEventIds = $data['poolEventIds'];
+        $this->guestGroupIds = $data['guestGroupIds'];
         $this->gearItemIds = $data['gearItemIds'];
         $this->hintText = $data['hintText'];
         $this->startsAt = $data['startsAt'];
@@ -100,6 +114,9 @@ class ScannerForm extends Form
             'modes' => $this->modes,
             'entry_event_id' => $this->entryEventId,
             'pool_event_ids' => array_values(array_unique(array_map('intval', $this->poolEventIds))),
+            'guest_group_ids' => ! empty($this->guestGroupIds)
+                ? array_values(array_unique(array_map('intval', $this->guestGroupIds)))
+                : null,
             'gear_item_ids' => ! empty($this->gearItemIds) ? $this->gearItemIds : null,
             'hint_text' => $this->hintText ?: null,
             'starts_at' => $this->startsAt,

--- a/app/Livewire/Projects/ScannerManagement.php
+++ b/app/Livewire/Projects/ScannerManagement.php
@@ -15,6 +15,7 @@ use App\Events\Activity\ScannerAssigneeRemoved;
 use App\Exceptions\HasGuestListsException;
 use App\Livewire\Forms\ScannerForm;
 use App\Models\Event;
+use App\Models\GuestGroup;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
@@ -61,11 +62,22 @@ class ScannerManagement extends Component
     {
         if ($value === ScannerType::EntryStaff->value) {
             $this->form->modes = [ScannerMode::Checkin->value];
+            $this->form->guestGroupIds = [];
 
             $this->ensureEntryEventIsIncludedInPool();
 
             return;
         }
+
+        if ($value === ScannerType::Gear->value) {
+            $this->form->modes = [ScannerMode::GearPickup->value];
+
+            $this->ensureEntryEventIsIncludedInPool();
+
+            return;
+        }
+
+        $this->form->guestGroupIds = [];
 
         $this->synchronizeVolunteerAdminPool();
     }
@@ -102,6 +114,28 @@ class ScannerManagement extends Component
         }
 
         $this->ensureEntryEventIsIncludedInPool();
+    }
+
+    /** @return Collection<int, GuestGroup> */
+    #[Computed]
+    public function guestGroups(): Collection
+    {
+        return GuestGroup::query()
+            ->whereHas('guestList', fn ($query) => $query->confirmed()->forProject($this->projectId))
+            ->with('guestList')
+            ->orderBy('label')
+            ->get();
+    }
+
+    /** @return array<int, string> */
+    #[Computed]
+    public function guestGroupLabelsById(): array
+    {
+        return $this->guestGroups
+            ->mapWithKeys(fn (GuestGroup $group) => [
+                $group->id => $group->guestList->name.' - '.$group->label,
+            ])
+            ->all();
     }
 
     /** @return Collection<int, ProjectScanner> */
@@ -190,6 +224,7 @@ class ScannerManagement extends Component
             'modes' => $scanner->modes ?? ['checkin'],
             'entryEventId' => $entryEventId,
             'poolEventIds' => $poolEventIds,
+            'guestGroupIds' => $scanner->configuredGuestGroupIds(),
             'gearItemIds' => $scanner->gear_item_ids ?? [],
             'hintText' => $scanner->hint_text ?? '',
             'startsAt' => $this->toLocal($scanner->starts_at, $tz),
@@ -317,6 +352,7 @@ class ScannerManagement extends Component
         $this->editingScannerId = null;
         $this->form->type = ScannerType::EntryStaff->value;
         $this->form->modes = [ScannerMode::Checkin->value];
+        $this->form->guestGroupIds = [];
         $this->form->setDefaultScope($this->firstEventId());
         $this->ensureEntryEventIsIncludedInPool();
     }

--- a/app/Models/ProjectScanner.php
+++ b/app/Models/ProjectScanner.php
@@ -21,6 +21,7 @@ class ProjectScanner extends Model
         'project_id',
         'entry_event_id',
         'pool_event_ids',
+        'guest_group_ids',
         'requires_configuration_review',
         'name',
         'type',
@@ -44,6 +45,7 @@ class ProjectScanner extends Model
             'modes' => 'array',
             'gear_item_ids' => 'array',
             'pool_event_ids' => 'array',
+            'guest_group_ids' => 'array',
             'requires_configuration_review' => 'boolean',
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
@@ -115,9 +117,37 @@ class ProjectScanner extends Model
         return array_values(array_map('intval', $this->pool_event_ids ?? []));
     }
 
+    /** @return array<int, int> */
+    public function configuredGuestGroupIds(): array
+    {
+        return array_values(array_map('intval', $this->guest_group_ids ?? []));
+    }
+
     public function includesEvent(int $eventId): bool
     {
         return in_array($eventId, $this->configuredPoolEventIds(), true);
+    }
+
+    public function includesGuestGroup(int $guestGroupId): bool
+    {
+        return in_array($guestGroupId, $this->configuredGuestGroupIds(), true);
+    }
+
+    public function supportsVolunteerGear(): bool
+    {
+        return $this->type === ScannerType::Gear
+            || $this->type === ScannerType::VolunteerAdmin;
+    }
+
+    public function supportsGuestGear(): bool
+    {
+        return $this->type === ScannerType::Gear
+            || $this->type === ScannerType::VolunteerAdmin;
+    }
+
+    public function isGearScanner(): bool
+    {
+        return $this->type === ScannerType::Gear;
     }
 
     /**

--- a/database/factories/ProjectScannerFactory.php
+++ b/database/factories/ProjectScannerFactory.php
@@ -37,6 +37,7 @@ class ProjectScannerFactory extends Factory
             'project_id' => Project::factory(),
             'entry_event_id' => null,
             'pool_event_ids' => null,
+            'guest_group_ids' => null,
             'requires_configuration_review' => false,
             'name' => fake()->words(2, true),
             'type' => ScannerType::EntryStaff,
@@ -79,6 +80,14 @@ class ProjectScannerFactory extends Factory
         return $this->state(fn () => [
             'type' => ScannerType::VolunteerAdmin,
             'modes' => [ScannerMode::Checkin->value, ScannerMode::GearPickup->value],
+        ]);
+    }
+
+    public function gear(): static
+    {
+        return $this->state(fn () => [
+            'type' => ScannerType::Gear,
+            'modes' => [ScannerMode::GearPickup->value],
         ]);
     }
 

--- a/database/migrations/2026_04_30_120000_add_guest_group_ids_to_project_scanners_table.php
+++ b/database/migrations/2026_04_30_120000_add_guest_group_ids_to_project_scanners_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->json('guest_group_ids')->nullable()->after('pool_event_ids');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_scanners', function (Blueprint $table) {
+            $table->dropColumn('guest_group_ids');
+        });
+    }
+};

--- a/e2e/gear-scanner.spec.ts
+++ b/e2e/gear-scanner.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    viewport: { width: 430, height: 720 },
+});
+
+test('gear scanner supports cached volunteer and guest lookup without check-in actions', async ({ page }) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+            configurable: true,
+            value: async () => undefined,
+        });
+
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => new MediaStream(),
+            },
+        });
+    });
+
+    await page.goto('/s/e2e-gear-scanner-token');
+
+    await page.getByLabel('Enter 6-digit code').fill('777777');
+    await page.getByRole('button', { name: 'Authenticate' }).click();
+
+    await expect(page).toHaveURL(/\/s\/e2e-gear-scanner-token\/scan$/);
+    await expect(page.getByRole('tab', { name: 'Scanner' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Volunteers' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Guests' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Confirm Arrival' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Check In' })).toHaveCount(0);
+
+    await page.getByRole('tab', { name: 'Volunteers' }).click();
+
+    const volunteersTab = page.locator('#tabpanel-gear-volunteers');
+    const volunteerSearch = page.getByPlaceholder('Search volunteers...');
+
+    await volunteerSearch.fill('Gear');
+    await expect(volunteersTab.getByRole('button').filter({ hasText: 'Gear Pool' })).toBeVisible();
+    await volunteersTab.getByRole('button').filter({ hasText: 'Gear Pool' }).click();
+
+    await expect(volunteersTab).toContainText('gear-volunteer@example.com');
+    await expect(volunteersTab).toContainText('E2E Hoodie');
+    await expect(volunteersTab).toContainText('Size: M');
+    await expect(volunteersTab.getByRole('button', { name: 'Pick Up' })).toBeVisible();
+
+    await page.locator('[x-data]').evaluate(async (element) => {
+        const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+        if (!component) {
+            throw new Error('Scanner Alpine component not found.');
+        }
+
+        component.isOnline = false;
+        await component.reloadScannerData({ preserveUiState: true });
+    });
+
+    await expect(volunteersTab.getByText('Offline - showing cached volunteer data.')).toBeVisible();
+    await expect(volunteerSearch).toHaveValue('Gear');
+    await expect(volunteersTab.getByRole('button').filter({ hasText: 'Gear Pool' })).toBeVisible();
+
+    await page.locator('[x-data]').evaluate(async (element) => {
+        const component = (element as HTMLElement & { _x_dataStack?: Array<any> })._x_dataStack?.[0];
+
+        if (!component) {
+            throw new Error('Scanner Alpine component not found.');
+        }
+
+        component.isOnline = true;
+        await component.reloadScannerData({ preserveUiState: true });
+    });
+
+    await page.getByRole('tab', { name: 'Guests' }).click();
+
+    const guestsTab = page.locator('#tabpanel-gear-guests');
+    const guestSearch = page.getByPlaceholder('Search guests...');
+
+    await guestSearch.fill('DJ');
+    await page.waitForTimeout(400);
+    await expect(guestsTab.getByRole('button').filter({ hasText: 'DJ Tester' })).toBeVisible();
+    await guestsTab.getByRole('button').filter({ hasText: 'DJ Tester' }).click();
+
+    await expect(guestsTab).toContainText('Artists');
+    await expect(guestsTab).toContainText('DJ Tester');
+    await expect(guestsTab).toContainText('E2E Wristband');
+    await expect(guestsTab).toContainText('0 / 1 picked up');
+
+    await guestsTab.getByRole('button', { name: 'Record Pickup' }).click();
+
+    await expect(guestsTab).toContainText('1 / 1 picked up');
+    await expect(page.getByRole('button', { name: 'Check In' })).toHaveCount(0);
+});

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -98,6 +98,10 @@ vendor/bin/sail artisan tinker --execute="
   use App\Actions\GenerateTicket;
   use App\Actions\RefreshTicketJwt;
   use App\Models\Event;
+  use App\Models\GuestEntry;
+  use App\Models\GuestEntryGear;
+  use App\Models\GuestGroup;
+  use App\Models\GuestList;
   use App\Models\Organization;
   use App\Models\Project;
   use App\Models\ProjectGearItem;
@@ -476,6 +480,115 @@ vendor/bin/sail artisan tinker --execute="
       'ends_at' => now()->addHours(4),
     ]);
 
+    \App\Models\ProjectScanner::where('scanner_token', 'e2e-gear-scanner-token')->delete();
+    \App\Models\GuestList::where('name', 'E2E Gear Guest List')->delete();
+    \App\Models\Event::whereIn('name', [
+      'E2E Gear Entry Event',
+      'E2E Gear Pool Event',
+    ])->delete();
+    \App\Models\Project::where('name', 'E2E Gear Scanner Project')->delete();
+    \App\Models\Volunteer::where('email', 'gear-volunteer@example.com')->delete();
+
+    \$gearProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Gear Scanner Project',
+    ]);
+
+    \$gearEntryEvent = Event::factory()->for(\$organization)->for(\$gearProject)->published()->create([
+      'name' => 'E2E Gear Entry Event',
+      'slug' => 'e2e-gear-entry-event',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(6),
+    ]);
+
+    \$gearPoolEvent = Event::factory()->for(\$organization)->for(\$gearProject)->published()->create([
+      'name' => 'E2E Gear Pool Event',
+      'slug' => 'e2e-gear-pool-event',
+      'starts_at' => now()->subDays(14),
+      'ends_at' => now()->subDays(14)->addHours(6),
+    ]);
+
+    \$gearPoolJob = VolunteerJob::factory()->create([
+      'event_id' => \$gearPoolEvent->id,
+      'name' => 'Gear Pool Team',
+    ]);
+
+    \$gearPoolShift = Shift::factory()->create([
+      'volunteer_job_id' => \$gearPoolJob->id,
+      'shift_date' => now()->subDays(14)->toDateString(),
+      'starts_at' => now()->subDays(14)->setTime(10, 0),
+      'ends_at' => now()->subDays(14)->setTime(14, 0),
+      'display_text' => now()->subDays(14)->setTime(10, 0)->format('M d, H:i').' - '.now()->subDays(14)->setTime(14, 0)->format('H:i'),
+    ]);
+
+    \$gearVolunteer = Volunteer::factory()->verified()->for(\$gearProject)->create([
+      'first_name' => 'Gear',
+      'last_name' => 'Pool',
+      'email' => 'gear-volunteer@example.com',
+      'phone' => '+491701998877',
+    ]);
+
+    Ticket::factory()->create([
+      'project_id' => \$gearProject->id,
+      'volunteer_id' => \$gearVolunteer->id,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$gearVolunteer->id,
+      'shift_id' => \$gearPoolShift->id,
+    ]);
+
+    \$gearScanner = ProjectScanner::factory()->active()->gear()->create([
+      'project_id' => \$gearProject->id,
+      'entry_event_id' => \$gearEntryEvent->id,
+      'pool_event_ids' => [\$gearEntryEvent->id, \$gearPoolEvent->id],
+      'name' => 'E2E Gear Scanner',
+      'scanner_token' => 'e2e-gear-scanner-token',
+      'auth_code' => '777777',
+      'starts_at' => now()->subHour(),
+      'ends_at' => now()->addHours(4),
+    ]);
+
+    \$volunteerGearItem = ProjectGearItem::factory()->sized(['M'])->create([
+      'project_id' => \$gearProject->id,
+      'name' => 'E2E Hoodie',
+      'requires_size' => true,
+    ]);
+
+    VolunteerGear::factory()->create([
+      'volunteer_id' => \$gearVolunteer->id,
+      'project_gear_item_id' => \$volunteerGearItem->id,
+      'size' => 'M',
+      'quantity_entitled' => 1,
+    ]);
+
+    \$guestGearItem = ProjectGearItem::factory()->quantity(1)->create([
+      'project_id' => \$gearProject->id,
+      'name' => 'E2E Wristband',
+    ]);
+
+    \$gearGuestList = GuestList::factory()->confirmed()->create([
+      'project_id' => \$gearProject->id,
+      'scanner_id' => \$gearScanner->id,
+      'name' => 'E2E Gear Guest List',
+    ]);
+
+    \$gearGuestGroup = GuestGroup::factory()->for(\$gearGuestList)->create([
+      'label' => 'Artists',
+      'guest_count' => 1,
+    ]);
+
+    \$gearGuestEntry = GuestEntry::factory()->for(\$gearGuestGroup, 'group')->withQrToken()->create([
+      'number' => 1,
+      'name' => 'DJ Tester',
+    ]);
+
+    GuestEntryGear::factory()->create([
+      'guest_entry_id' => \$gearGuestEntry->id,
+      'project_gear_item_id' => \$guestGearItem->id,
+      'quantity' => 1,
+      'picked_up_count' => 0,
+    ]);
+
     \App\Models\ProjectScanner::whereIn('scanner_token', [
       'e2e-berlin-scheduled-token',
       'e2e-utc-scheduled-token',
@@ -686,3 +799,4 @@ echo "  VA scanner:     /s/e2e-va-shift-list-token with code 222222"
 echo "  VA all past:    /s/e2e-va-all-past-token with code 444444"
 echo "  Entry/pool:     /s/e2e-entry-pool-scanner-token with code 333333"
 echo "  Entry lookup:   /s/e2e-entry-manual-lookup-token with code 555555"
+echo "  Gear scanner:   /s/e2e-gear-scanner-token with code 777777"

--- a/resources/js/scanner/alpine-scanner.ts
+++ b/resources/js/scanner/alpine-scanner.ts
@@ -7,6 +7,7 @@
  *
  * Type-based post-scan behavior:
  * - entry_staff: arrival confirmation only
+ * - gear: volunteer + guest gear workflows
  * - volunteer_admin: shift attendance + gear pickup (gear is online-only)
  */
 import { startCamera, stopCamera } from './camera';
@@ -41,6 +42,7 @@ type ScannerState = 'idle' | 'loading' | 'scanning' | 'result' | 'duplicate' | '
 type ScannerTab = 'scanner' | 'volunteers' | 'guests' | 'shifts';
 type ScannerDataSource = 'network' | 'cache' | 'unavailable';
 type VolunteerSelectionSource = 'qr' | 'manual' | 'shift' | null;
+type GuestSelectionSource = 'qr' | 'manual' | null;
 type VolunteerDetailState = 'ready' | 'checked_in' | 'configuration_review' | 'missing_ticket' | null;
 
 interface SelectedShiftContext {
@@ -60,7 +62,7 @@ interface ScannerResult {
 
 interface ScannerAppConfig {
     scannerId: number;
-    scannerType: 'entry_staff' | 'volunteer_admin';
+    scannerType: 'entry_staff' | 'gear' | 'volunteer_admin';
     modes: string[];
     entryEventId: number | null;
     contractVersion: number;
@@ -118,7 +120,9 @@ export function scannerApp(config: ScannerAppConfig) {
         guestSearchQuery: '' as string,
         shiftSearchQuery: '' as string,
         guestResult: null as GuestEntry | null,
+        selectedGuest: null as GuestEntry | null,
         selectedVolunteerSource: null as VolunteerSelectionSource,
+        selectedGuestSource: null as GuestSelectionSource,
 
         get filteredGuestGroups(): { label: string; guestCount: number; entries: GuestEntry[] }[] {
             const groups = new Map<number, { label: string; guestCount: number; entries: GuestEntry[] }>();
@@ -151,8 +155,14 @@ export function scannerApp(config: ScannerAppConfig) {
             return query.length > 0 && query.length < 2;
         },
 
+        get shouldShowGuestSearchHint(): boolean {
+            const query = this.guestSearchQuery.trim();
+
+            return query.length > 0 && query.length < 2;
+        },
+
         get filteredVolunteers(): Volunteer[] {
-            if (this.scannerType !== 'entry_staff') {
+            if (this.scannerType === 'volunteer_admin') {
                 return [];
             }
 
@@ -202,7 +212,7 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         get hasGuestListTab(): boolean {
-            return this.scannerType === 'entry_staff';
+            return this.scannerType === 'entry_staff' || this.scannerType === 'gear';
         },
 
         get visibleShiftGroups(): ShiftGroup[] {
@@ -252,7 +262,7 @@ export function scannerApp(config: ScannerAppConfig) {
         },
 
         get canPickupGear(): boolean {
-            return config.modes.includes('gear_pickup');
+            return config.scannerType === 'gear' || config.modes.includes('gear_pickup');
         },
 
         get canMarkAttendance(): boolean {
@@ -328,9 +338,11 @@ export function scannerApp(config: ScannerAppConfig) {
                     : null;
             this.result = volunteer.ticket ? this.buildVolunteerResult(volunteer) : null;
             this.guestResult = null;
+            this.selectedGuest = null;
+            this.selectedGuestSource = null;
 
             if (options.fromQr) {
-                if (this.scannerType === 'volunteer_admin') {
+                if (this.scannerType !== 'entry_staff') {
                     this.state = 'result';
                     this.resultMessage = '';
                     this.errorMessage = '';
@@ -373,6 +385,23 @@ export function scannerApp(config: ScannerAppConfig) {
             this.guestResult = null;
         },
 
+        selectGuest(entry: GuestEntry, options: { fromQr?: boolean } = {}) {
+            this.selectedGuest = entry;
+            this.selectedGuestSource = options.fromQr ? 'qr' : 'manual';
+            this.selectedVolunteer = null;
+            this.selectedShiftContext = null;
+            this.selectedVolunteerSource = null;
+            this.result = null;
+            this.guestResult = null;
+            this.state = 'result';
+            this.resultMessage = '';
+            this.errorMessage = '';
+        },
+
+        selectGuestFromSearch(entry: GuestEntry) {
+            this.selectGuest(entry);
+        },
+
         selectVolunteerFromShift(row: ShiftGroupVolunteerRow) {
             const volunteer = this._volunteers.find((entry) => entry.id === row.volunteerId);
             if (!volunteer) {
@@ -404,6 +433,17 @@ export function scannerApp(config: ScannerAppConfig) {
             this.selectedVolunteerSource = null;
             this.result = null;
             this.guestResult = null;
+            this.selectedGuest = null;
+            this.selectedGuestSource = null;
+            this.resultMessage = '';
+            this.errorMessage = '';
+            this.state = 'scanning';
+        },
+
+        clearGuestSelection() {
+            this.selectedGuest = null;
+            this.selectedGuestSource = null;
+            this.guestResult = null;
             this.resultMessage = '';
             this.errorMessage = '';
             this.state = 'scanning';
@@ -427,10 +467,13 @@ export function scannerApp(config: ScannerAppConfig) {
             const preservedState = options.preserveUiState ? {
                 activeTab: this.activeTab,
                 volunteerSearchQuery: this.volunteerSearchQuery,
+                guestSearchQuery: this.guestSearchQuery,
                 shiftSearchQuery: this.shiftSearchQuery,
                 selectedVolunteerId: this.selectedVolunteer?.id ?? null,
+                selectedGuestId: this.selectedGuest?.id ?? null,
                 selectedShiftContext: this.selectedShiftContext,
                 selectedVolunteerSource: this.selectedVolunteerSource,
+                selectedGuestSource: this.selectedGuestSource,
             } : null;
 
             await this._loadScannerData();
@@ -443,9 +486,25 @@ export function scannerApp(config: ScannerAppConfig) {
                 ? 'scanner'
                 : preservedState.activeTab;
             this.volunteerSearchQuery = preservedState.volunteerSearchQuery;
+            this.guestSearchQuery = preservedState.guestSearchQuery;
             this.shiftSearchQuery = preservedState.shiftSearchQuery;
 
             if (!preservedState.selectedVolunteerId) {
+                if (!preservedState.selectedGuestId) {
+                    return;
+                }
+
+                const guestEntry = this._guestEntries.find((entry) => entry.id === preservedState.selectedGuestId);
+                if (!guestEntry) {
+                    this.selectedGuest = null;
+                    this.selectedGuestSource = null;
+
+                    return;
+                }
+
+                this.selectGuest(guestEntry);
+                this.selectedGuestSource = preservedState.selectedGuestSource;
+
                 return;
             }
 
@@ -876,6 +935,8 @@ export function scannerApp(config: ScannerAppConfig) {
             this.selectedVolunteer = null;
             this.selectedShiftContext = null;
             this.selectedVolunteerSource = null;
+            this.selectedGuest = null;
+            this.selectedGuestSource = null;
             this.resultMessage = '';
             this.errorMessage = '';
             this._resetInactivityTimer();
@@ -888,6 +949,14 @@ export function scannerApp(config: ScannerAppConfig) {
             this.selectedVolunteerSource = null;
             this.result = null;
             this.guestResult = entry;
+            this.selectedGuest = null;
+            this.selectedGuestSource = null;
+
+            if (this.scannerType === 'gear') {
+                this.selectGuest(entry, { fromQr: true });
+
+                return;
+            }
 
             const label = `${entry.group_label} ${entry.number}/${entry.group_guest_count}`;
 
@@ -930,7 +999,7 @@ export function scannerApp(config: ScannerAppConfig) {
 
         async _postGuestGear(guestEntryGearId: number, payload: Record<string, unknown>) {
             if (!this.isOnline) {
-                return;
+                return null;
             }
 
             try {
@@ -946,22 +1015,61 @@ export function scannerApp(config: ScannerAppConfig) {
 
                 if (!response.ok) {
                     console.error('Guest gear pickup failed:', await response.text());
+
+                    return null;
                 }
+
+                return await response.json();
             } catch (error) {
                 console.error('Guest gear pickup network error:', error);
+
+                return null;
             }
         },
 
         async selectGuestGearState(guestEntryGearId: number, state: string) {
-            await this._postGuestGear(guestEntryGearId, { status: state });
+            const response = await this._postGuestGear(guestEntryGearId, { status: state });
+            const gear = this.findGuestGear(guestEntryGearId);
+
+            if (response && gear) {
+                gear.status = state;
+            }
         },
 
         async selectGuestGearSelection(guestEntryGearId: number, selection: string) {
-            await this._postGuestGear(guestEntryGearId, { selection });
+            const response = await this._postGuestGear(guestEntryGearId, { selection });
+            const gear = this.findGuestGear(guestEntryGearId);
+
+            if (response && gear) {
+                gear.selection = selection;
+            }
         },
 
         async incrementGuestGearPickup(guestEntryGearId: number) {
-            await this._postGuestGear(guestEntryGearId, { quantity: 1 });
+            const response = await this._postGuestGear(guestEntryGearId, { quantity: 1 });
+            const gear = this.findGuestGear(guestEntryGearId);
+
+            if (response && gear) {
+                gear.picked_up_count += 1;
+            }
+        },
+
+        findGuestGear(guestEntryGearId: number) {
+            for (const entry of this._guestEntries) {
+                const gear = entry.gear.find((item) => item.id === guestEntryGearId);
+
+                if (gear) {
+                    return gear;
+                }
+            }
+
+            return null;
+        },
+
+        isGuestGearFullyPickedUp(guestEntryGearId: number): boolean {
+            const gear = this.findGuestGear(guestEntryGearId);
+
+            return gear ? gear.picked_up_count >= gear.quantity : false;
         },
 
         _resetInactivityTimer() {

--- a/resources/views/livewire/projects/scanner-management.blade.php
+++ b/resources/views/livewire/projects/scanner-management.blade.php
@@ -38,11 +38,14 @@
                 <flux:card wire:key="scanner-{{ $scanner->id }}">
                     <div class="flex items-start justify-between gap-4">
                         <div class="min-w-0 flex-1">
-                            @php
-                                $poolEventNames = collect($scanner->configuredPoolEventIds())
-                                    ->map(fn ($eventId) => $this->eventNamesById[$eventId] ?? ('#'.$eventId))
-                                    ->implode(', ');
-                            @endphp
+                             @php
+                                 $poolEventNames = collect($scanner->configuredPoolEventIds())
+                                     ->map(fn ($eventId) => $this->eventNamesById[$eventId] ?? ('#'.$eventId))
+                                     ->implode(', ');
+                                 $guestGroupNames = collect($scanner->configuredGuestGroupIds())
+                                     ->map(fn ($groupId) => $this->guestGroupLabelsById[$groupId] ?? ('#'.$groupId))
+                                     ->implode(', ');
+                             @endphp
 
                             <div class="flex items-center gap-2 mb-1">
                                 <flux:heading size="lg">{{ $scanner->name }}</flux:heading>
@@ -50,8 +53,19 @@
                                 <flux:badge size="sm" :color="match($status) { 'active' => 'emerald', 'scheduled' => 'blue', 'expired' => 'zinc' }">
                                     {{ ucfirst($status) }}
                                 </flux:badge>
-                                <flux:badge size="sm" :color="$scanner->type === \App\Enums\ScannerType::EntryStaff ? 'blue' : 'purple'">
-                                    {{ $scanner->type === \App\Enums\ScannerType::EntryStaff ? __('Entry Staff') : __('Volunteer Admin') }}
+                                <flux:badge
+                                    size="sm"
+                                    :color="match($scanner->type) {
+                                        \App\Enums\ScannerType::EntryStaff => 'blue',
+                                        \App\Enums\ScannerType::Gear => 'amber',
+                                        default => 'purple',
+                                    }"
+                                >
+                                    {{ match($scanner->type) {
+                                        \App\Enums\ScannerType::EntryStaff => __('Entry Staff'),
+                                        \App\Enums\ScannerType::Gear => __('Gear'),
+                                        default => __('Volunteer Admin'),
+                                    } }}
                                 </flux:badge>
                             </div>
                             <flux:text size="sm" class="text-zinc-500">
@@ -69,6 +83,11 @@
                                 <flux:text size="sm" class="text-zinc-500">
                                     {{ __('Pool Events: :events', ['events' => $poolEventNames !== '' ? $poolEventNames : __('Needs review')]) }}
                                 </flux:text>
+                                @if ($scanner->type === \App\Enums\ScannerType::Gear)
+                                    <flux:text size="sm" class="text-zinc-500">
+                                        {{ __('Guest Groups: :groups', ['groups' => $guestGroupNames !== '' ? $guestGroupNames : __('All confirmed guest lists')]) }}
+                                    </flux:text>
+                                @endif
                             </div>
 
                             @if ($scanner->requires_configuration_review)
@@ -173,6 +192,7 @@
                 <flux:label>{{ __('Type') }}</flux:label>
                 <flux:select wire:model.live="form.type">
                     <flux:select.option value="entry_staff">{{ __('Entry Staff') }}</flux:select.option>
+                    <flux:select.option value="gear">{{ __('Gear') }}</flux:select.option>
                     <flux:select.option value="volunteer_admin">{{ __('Volunteer Admin') }}</flux:select.option>
                 </flux:select>
                 <flux:error name="form.type" />
@@ -221,6 +241,35 @@
 
                 <flux:error name="form.poolEventIds" />
             </flux:field>
+
+            @if ($form->type === 'gear')
+                <flux:field>
+                    <flux:label>{{ __('Guest Groups') }}</flux:label>
+                    <flux:text size="sm" class="text-zinc-500">
+                        {{ __('Leave all groups unchecked to include all confirmed guest lists in the project.') }}
+                    </flux:text>
+
+                    @if ($this->guestGroups->isEmpty())
+                        <flux:text size="sm" class="text-zinc-500">
+                            {{ __('No confirmed guest groups are available yet.') }}
+                        </flux:text>
+                    @else
+                        <div class="space-y-2">
+                            @foreach ($this->guestGroups as $group)
+                                <flux:checkbox
+                                    wire:key="guest-group-{{ $group->id }}"
+                                    wire:model="form.guestGroupIds"
+                                    :value="$group->id"
+                                    :label="$group->guestList->name.' - '.$group->label"
+                                />
+                            @endforeach
+                        </div>
+                    @endif
+
+                    <flux:error name="form.guestGroupIds" />
+                    <flux:error name="form.guestGroupIds.*" />
+                </flux:field>
+            @endif
 
             <div class="grid grid-cols-2 gap-4">
                 <flux:field>

--- a/resources/views/livewire/scanner-app.blade.php
+++ b/resources/views/livewire/scanner-app.blade.php
@@ -22,8 +22,8 @@
             class="rounded-full px-2.5 py-0.5 text-xs font-medium"
             :class="scannerType === 'entry_staff'
                 ? 'bg-blue-500/20 text-blue-300'
-                : 'bg-purple-500/20 text-purple-300'"
-            x-text="scannerType === 'entry_staff' ? 'Entry Staff' : 'Volunteer Admin'"
+                : (scannerType === 'gear' ? 'bg-amber-500/20 text-amber-300' : 'bg-purple-500/20 text-purple-300')"
+            x-text="scannerType === 'entry_staff' ? 'Entry Staff' : (scannerType === 'gear' ? 'Gear' : 'Volunteer Admin')"
         ></span>
     </header>
 
@@ -341,6 +341,369 @@
                     </template>
 
                     <template x-if="filteredGuestGroups.length === 0">
+                        <p class="py-8 text-center text-sm text-zinc-500">{{ __('No guests found.') }}</p>
+                    </template>
+                </div>
+            </div>
+        @elseif ($scannerType === 'gear')
+            <div role="tablist" class="mb-4 flex border-b border-zinc-700">
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-gear-scanner"
+                    :aria-selected="activeTab === 'scanner'"
+                    aria-controls="tabpanel-gear-scanner"
+                    class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
+                    :class="activeTab === 'scanner' ? 'text-white border-b-2 border-amber-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="setActiveTab('scanner')"
+                >
+                    Scanner
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-gear-volunteers"
+                    :aria-selected="activeTab === 'volunteers'"
+                    aria-controls="tabpanel-gear-volunteers"
+                    class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
+                    :class="activeTab === 'volunteers' ? 'text-white border-b-2 border-amber-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="setActiveTab('volunteers')"
+                >
+                    Volunteers
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    id="tab-gear-guests"
+                    :aria-selected="activeTab === 'guests'"
+                    aria-controls="tabpanel-gear-guests"
+                    class="min-h-12 flex-1 px-4 py-3 text-sm font-medium transition-colors"
+                    :class="activeTab === 'guests' ? 'text-white border-b-2 border-amber-500' : 'text-zinc-400 hover:text-zinc-200'"
+                    @click="setActiveTab('guests')"
+                >
+                    Guests
+                </button>
+            </div>
+
+            <div id="tabpanel-gear-scanner" role="tabpanel" aria-labelledby="tab-gear-scanner" x-show="activeTab === 'scanner'" class="flex flex-1 flex-col items-center space-y-4">
+                <div id="scanner-viewfinder" class="relative aspect-square w-full max-w-sm overflow-hidden rounded-xl bg-black" @click="cameraPaused && resumeCamera()">
+                    <video id="scanner-video" class="h-full w-full object-cover" aria-label="{{ __('QR code camera viewfinder') }}" playsinline></video>
+                    <div
+                        x-show="cameraPaused"
+                        x-transition
+                        class="absolute inset-0 flex cursor-pointer items-center justify-center bg-black/80"
+                        x-cloak
+                    >
+                        <div class="text-center">
+                            <svg class="mx-auto mb-2 h-12 w-12 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9A2.25 2.25 0 004.5 18.75z" /></svg>
+                            <p class="text-sm font-medium text-zinc-300">{{ __('Camera paused') }}</p>
+                            <p class="mt-1 text-xs text-zinc-500">{{ __('Tap to resume') }}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div
+                    x-show="state === 'invalid'"
+                    x-transition
+                    role="alert"
+                    aria-live="assertive"
+                    class="w-full max-w-sm rounded-xl border border-red-500/30 bg-red-500/10 p-4"
+                    x-cloak
+                >
+                    <p class="text-center text-sm text-white" x-text="errorMessage"></p>
+                </div>
+
+                <div x-show="selectedVolunteer" x-cloak class="w-full max-w-sm space-y-4">
+                    <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                        <p class="text-lg font-semibold text-white" x-text="selectedVolunteer?.name"></p>
+                        <p class="text-sm text-zinc-400" x-text="selectedVolunteer?.email"></p>
+                        <p class="text-sm text-zinc-400" x-show="selectedVolunteer?.phone" x-text="selectedVolunteer?.phone"></p>
+                        <p class="text-sm text-zinc-400" x-show="selectedVolunteer && !selectedVolunteer?.phone">{{ __('No phone number') }}</p>
+                    </div>
+
+                    <template x-if="selectedVolunteer && getVolunteerGear(selectedVolunteer.id).length > 0">
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                            <h3 class="mb-3 text-sm font-semibold text-zinc-300">{{ __('Gear') }}</h3>
+                            <div class="space-y-2">
+                                <template x-for="gear in getVolunteerGear(selectedVolunteer.id)" :key="gear.id">
+                                    <div class="flex min-h-12 items-center justify-between rounded-lg bg-zinc-900 px-4 py-3">
+                                        <div class="min-w-0 flex-1">
+                                            <p class="text-sm font-medium text-white" x-text="getGearItemName(gear.project_gear_item_id)"></p>
+                                            <p x-show="gear.size" class="text-xs text-zinc-400" x-text="'{{ __('Size') }}: ' + gear.size"></p>
+                                            <p x-show="gear.quantity_entitled !== null" class="text-xs text-zinc-400" x-text="getGearPickedUpCount(gear) + ' / ' + gear.quantity_entitled + ' {{ __('picked up') }}'"></p>
+                                        </div>
+                                        <div class="ml-3 shrink-0">
+                                            <template x-if="isGearFullyPickedUp(gear)">
+                                                <span class="rounded-full bg-emerald-500/20 px-3 py-1 text-xs text-emerald-300">{{ __('Picked up') }}</span>
+                                            </template>
+                                            <template x-if="!isGearFullyPickedUp(gear) && isOnline">
+                                                <button
+                                                    type="button"
+                                                    class="min-h-10 rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 active:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                                    @click="selectGearState(gear.id, 'picked_up')"
+                                                    :disabled="isGearCooldown(gear.id)"
+                                                >
+                                                    <span x-show="!isGearCooldown(gear.id)">{{ __('Pick Up') }}</span>
+                                                    <span x-show="isGearCooldown(gear.id)" x-cloak>&#10003;</span>
+                                                </button>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    <button
+                        type="button"
+                        class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                        @click="dismiss()"
+                    >
+                        {{ __('Done') }}
+                    </button>
+                </div>
+
+                <div x-show="selectedGuest" x-cloak class="w-full max-w-sm space-y-4">
+                    <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                        <p class="text-lg font-semibold text-white" x-text="selectedGuest?.group_label"></p>
+                        <p class="text-sm text-zinc-400" x-text="selectedGuest?.name ? selectedGuest.group_label + ' - ' + selectedGuest.name : selectedGuest?.group_label"></p>
+                        <p class="text-xs text-zinc-500" x-text="selectedGuest ? '#' + selectedGuest.number + ' / ' + selectedGuest.group_guest_count : ''"></p>
+                    </div>
+
+                    <template x-if="selectedGuest?.gear?.length > 0">
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                            <h3 class="mb-3 text-sm font-semibold text-zinc-300">{{ __('Gear') }}</h3>
+                            <div class="space-y-3">
+                                <template x-for="gear in selectedGuest.gear" :key="gear.id">
+                                    <div class="rounded-lg bg-zinc-900 px-4 py-3">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div class="min-w-0 flex-1">
+                                                <p class="text-sm font-medium text-white" x-text="gear.gear_item_name"></p>
+                                                <p class="text-xs text-zinc-400" x-text="gear.picked_up_count + ' / ' + gear.quantity + ' {{ __('picked up') }}'"></p>
+                                            </div>
+                                            <template x-if="isGuestGearFullyPickedUp(gear.id)">
+                                                <span class="rounded-full bg-emerald-500/20 px-3 py-1 text-xs text-emerald-300">{{ __('Picked up') }}</span>
+                                            </template>
+                                        </div>
+
+                                        <div class="mt-3 space-y-2">
+                                            <template x-if="gear.available_sizes?.length">
+                                                <select
+                                                    class="min-h-10 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white"
+                                                    :value="gear.selection ?? ''"
+                                                    @change="selectGuestGearSelection(gear.id, $event.target.value)"
+                                                >
+                                                    <option value="">{{ __('Select size') }}</option>
+                                                    <template x-for="size in gear.available_sizes" :key="size">
+                                                        <option :value="size" x-text="size"></option>
+                                                    </template>
+                                                </select>
+                                            </template>
+
+                                            <template x-if="gear.available_states?.length">
+                                                <select
+                                                    class="min-h-10 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white"
+                                                    :value="gear.status ?? ''"
+                                                    @change="selectGuestGearState(gear.id, $event.target.value)"
+                                                >
+                                                    <option value="">{{ __('Select state') }}</option>
+                                                    <template x-for="stateOption in gear.available_states" :key="stateOption">
+                                                        <option :value="stateOption" x-text="stateOption"></option>
+                                                    </template>
+                                                </select>
+                                            </template>
+
+                                            <button
+                                                type="button"
+                                                class="min-h-10 w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 active:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                                @click="incrementGuestGearPickup(gear.id)"
+                                                :disabled="!isOnline || isGuestGearFullyPickedUp(gear.id)"
+                                            >
+                                                {{ __('Record Pickup') }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    <button
+                        type="button"
+                        class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                        @click="dismiss()"
+                    >
+                        {{ __('Done') }}
+                    </button>
+                </div>
+            </div>
+
+            <div id="tabpanel-gear-volunteers" role="tabpanel" aria-labelledby="tab-gear-volunteers" x-show="activeTab === 'volunteers'" x-cloak class="flex flex-1 flex-col space-y-4">
+                <div class="space-y-3 px-1">
+                    <input
+                        type="text"
+                        x-model.debounce.300ms="volunteerSearchQuery"
+                        placeholder="{{ __('Search volunteers...') }}"
+                        aria-label="{{ __('Search volunteers') }}"
+                        class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-base text-white placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                    />
+
+                    <template x-if="scannerDataSource === 'cache'">
+                        <div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                            Offline - showing cached volunteer data.
+                        </div>
+                    </template>
+                </div>
+
+                <template x-if="selectedVolunteer && selectedVolunteerSource === 'manual'">
+                    <div class="px-1" x-cloak>
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                            <p class="text-center text-lg font-semibold text-white" x-text="selectedVolunteer?.name"></p>
+                            <p class="mt-1 text-center text-sm text-zinc-400" x-text="selectedVolunteer?.email"></p>
+                            <div class="mt-4 space-y-2" x-show="selectedVolunteer">
+                                <template x-for="gear in getVolunteerGear(selectedVolunteer.id)" :key="gear.id">
+                                    <div class="flex min-h-12 items-center justify-between rounded-lg bg-zinc-900 px-4 py-3">
+                                        <div class="min-w-0 flex-1">
+                                            <p class="text-sm font-medium text-white" x-text="getGearItemName(gear.project_gear_item_id)"></p>
+                                            <p x-show="gear.size" class="text-xs text-zinc-400" x-text="'{{ __('Size') }}: ' + gear.size"></p>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            class="min-h-10 rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 active:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                            @click="selectGearState(gear.id, 'picked_up')"
+                                            :disabled="!isOnline || isGearFullyPickedUp(gear) || isGearCooldown(gear.id)"
+                                        >
+                                            {{ __('Pick Up') }}
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+                            <div class="mt-3 flex justify-center">
+                                <button
+                                    type="button"
+                                    class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                                    @click="clearVolunteerSelection()"
+                                >
+                                    {{ __('Close Details') }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                <div class="space-y-3 overflow-y-auto px-1">
+                    <template x-if="scannerDataSource === 'unavailable'">
+                        <p class="py-8 text-center text-sm text-zinc-500">Volunteer data is unavailable right now.</p>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && shouldShowVolunteerSearchHint">
+                        <p class="py-8 text-center text-sm text-zinc-500">Mindestens 2 Zeichen eingeben.</p>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && !shouldShowVolunteerSearchHint && volunteerSearchQuery.trim().length >= 2 && filteredVolunteers.length === 0">
+                        <p class="py-8 text-center text-sm text-zinc-500">No matching volunteers found.</p>
+                    </template>
+
+                    <template x-for="volunteer in filteredVolunteers" :key="volunteer.id">
+                        <button
+                            type="button"
+                            class="flex min-h-12 w-full items-center justify-between rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-3 text-left transition hover:bg-zinc-900"
+                            :class="selectedVolunteerSource === 'manual' && selectedVolunteer?.id === volunteer.id ? 'ring-1 ring-amber-500/60' : ''"
+                            @click="selectVolunteerFromSearch(volunteer)"
+                        >
+                            <div class="min-w-0 flex-1">
+                                <p class="text-sm font-medium text-white" x-text="volunteer.name"></p>
+                                <p class="text-xs text-zinc-400" x-text="volunteer.email"></p>
+                            </div>
+                        </button>
+                    </template>
+                </div>
+            </div>
+
+            <div id="tabpanel-gear-guests" role="tabpanel" aria-labelledby="tab-gear-guests" x-show="activeTab === 'guests'" x-cloak class="flex flex-1 flex-col space-y-4">
+                <div class="space-y-3 px-1">
+                    <input
+                        type="text"
+                        x-model.debounce.300ms="guestSearchQuery"
+                        placeholder="{{ __('Search guests...') }}"
+                        aria-label="{{ __('Search guests') }}"
+                        class="min-h-12 w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-base text-white placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                    />
+
+                    <template x-if="scannerDataSource === 'cache'">
+                        <div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                            Offline - showing cached guest data.
+                        </div>
+                    </template>
+                </div>
+
+                <template x-if="selectedGuest && selectedGuestSource === 'manual'">
+                    <div class="px-1" x-cloak>
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+                            <p class="text-center text-lg font-semibold text-white" x-text="selectedGuest?.group_label"></p>
+                            <p class="mt-1 text-center text-sm text-zinc-400" x-text="selectedGuest?.name"></p>
+                            <div class="mt-4 space-y-2" x-show="selectedGuest">
+                                <template x-for="gear in selectedGuest.gear" :key="gear.id">
+                                    <div class="rounded-lg bg-zinc-900 px-4 py-3">
+                                        <p class="text-sm font-medium text-white" x-text="gear.gear_item_name"></p>
+                                        <p class="text-xs text-zinc-400" x-text="gear.picked_up_count + ' / ' + gear.quantity + ' {{ __('picked up') }}'"></p>
+                                        <button
+                                            type="button"
+                                            class="mt-3 min-h-10 w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 active:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                            @click="incrementGuestGearPickup(gear.id)"
+                                            :disabled="!isOnline || isGuestGearFullyPickedUp(gear.id)"
+                                        >
+                                            {{ __('Record Pickup') }}
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+                            <div class="mt-3 flex justify-center">
+                                <button
+                                    type="button"
+                                    class="min-h-12 w-full rounded-lg border border-zinc-600 px-4 py-3 text-base font-medium text-zinc-300 hover:bg-zinc-700 active:bg-zinc-600"
+                                    @click="clearGuestSelection()"
+                                >
+                                    {{ __('Close Details') }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                <div class="space-y-3 overflow-y-auto px-1">
+                    <template x-if="scannerDataSource === 'unavailable'">
+                        <p class="py-8 text-center text-sm text-zinc-500">Guest data is unavailable right now.</p>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && shouldShowGuestSearchHint">
+                        <p class="py-8 text-center text-sm text-zinc-500">Mindestens 2 Zeichen eingeben.</p>
+                    </template>
+
+                    <template x-for="group in filteredGuestGroups" :key="group.label">
+                        <div class="rounded-xl border border-zinc-700 bg-zinc-800 p-3">
+                            <div class="mb-2 flex items-center justify-between">
+                                <span class="text-sm font-semibold text-white" x-text="group.label"></span>
+                                <span class="text-xs text-zinc-400" x-text="group.guestCount + ' Guests'"></span>
+                            </div>
+                            <div class="space-y-2">
+                                <template x-for="entry in group.entries" :key="entry.id">
+                                    <button
+                                        type="button"
+                                        class="flex min-h-12 w-full items-center justify-between rounded-lg bg-zinc-900 px-4 py-3 text-left"
+                                        @click="selectGuestFromSearch(entry)"
+                                    >
+                                        <div class="min-w-0 flex-1">
+                                            <span class="text-sm text-white" x-text="'#' + entry.number + (entry.name ? ' - ' + entry.name : '')"></span>
+                                        </div>
+                                        <span class="ml-3 text-xs text-zinc-400" x-text="entry.gear.length ? entry.gear.length + ' gear' : '{{ __('No gear') }}'"></span>
+                                    </button>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template x-if="scannerDataSource !== 'unavailable' && !shouldShowGuestSearchHint && filteredGuestGroups.length === 0">
                         <p class="py-8 text-center text-sm text-zinc-500">{{ __('No guests found.') }}</p>
                     </template>
                 </div>

--- a/tests/Feature/Actions/CreateProjectScannerTest.php
+++ b/tests/Feature/Actions/CreateProjectScannerTest.php
@@ -4,6 +4,8 @@ use App\Actions\CreateProjectScanner;
 use App\Enums\ScannerMode;
 use App\Enums\ScannerType;
 use App\Models\Event;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
 use App\Models\Project;
 use App\Models\ProjectScanner;
 
@@ -124,4 +126,25 @@ it('stores entry and pool events', function () {
         ->and($result->gear_item_ids)->toBe([1, 2, 3])
         ->and($result->hint_text)->toBe('Scan volunteer badges here')
         ->and($result->type)->toBe(ScannerType::VolunteerAdmin);
+});
+
+it('stores optional guest group ids for gear scanners', function () {
+    $entryEvent = Event::factory()->for($this->project)->create();
+    $guestList = GuestList::factory()->confirmed()->create(['project_id' => $this->project->id]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $action = new CreateProjectScanner;
+
+    $result = $action->execute($this->project, [
+        'name' => 'Gear Scanner',
+        'type' => ScannerType::Gear->value,
+        'modes' => [ScannerMode::GearPickup->value],
+        'entry_event_id' => $entryEvent->id,
+        'pool_event_ids' => [$entryEvent->id],
+        'guest_group_ids' => [$group->id],
+        'starts_at' => '2026-07-01 10:00:00',
+        'ends_at' => '2026-07-01 18:00:00',
+    ]);
+
+    expect($result->type)->toBe(ScannerType::Gear)
+        ->and($result->guest_group_ids)->toBe([$group->id]);
 });

--- a/tests/Feature/Actions/UpdateProjectScannerTest.php
+++ b/tests/Feature/Actions/UpdateProjectScannerTest.php
@@ -4,6 +4,8 @@ use App\Actions\UpdateProjectScanner;
 use App\Enums\ScannerMode;
 use App\Enums\ScannerType;
 use App\Models\Event;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
 use App\Models\Project;
 use App\Models\ProjectScanner;
 
@@ -132,4 +134,21 @@ it('does not modify auth_code or scanner_token', function () {
 
     expect($fresh->auth_code)->toBe($originalAuthCode)
         ->and($fresh->scanner_token)->toBe($originalToken);
+});
+
+it('updates guest group ids for gear scanners', function () {
+    $guestList = GuestList::factory()->confirmed()->create(['project_id' => $this->project->id]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $this->scanner->update([
+        'type' => ScannerType::Gear,
+        'modes' => [ScannerMode::GearPickup->value],
+    ]);
+
+    $action = new UpdateProjectScanner;
+
+    $result = $action->execute($this->scanner, [
+        'guest_group_ids' => [$group->id],
+    ]);
+
+    expect($result->guest_group_ids)->toBe([$group->id]);
 });

--- a/tests/Feature/Flows/ScannerIntegrationFlowTest.php
+++ b/tests/Feature/Flows/ScannerIntegrationFlowTest.php
@@ -12,9 +12,12 @@ use App\Models\Organization;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
+use App\Models\VolunteerJob;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
@@ -143,6 +146,17 @@ it('completes full volunteer admin flow: create scanner, auth, fetch data, gear 
 
     // Step 4: Gear pickup via API
     $volunteer = Volunteer::factory()->create(['project_id' => $project->id]);
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
     $gear = VolunteerGear::factory()->create([
         'volunteer_id' => $volunteer->id,
         'project_gear_item_id' => $gearItem->id,

--- a/tests/Feature/Http/GuestGearPickupApiTest.php
+++ b/tests/Feature/Http/GuestGearPickupApiTest.php
@@ -107,7 +107,40 @@ it('rejects gear pickup from entry staff scanner type', function () {
     ]);
 
     $response->assertForbidden()
-        ->assertJsonPath('error', 'Only volunteer admin scanners can record guest gear pickups.');
+        ->assertJsonPath('error', 'Only gear-enabled scanners can record guest gear pickups.');
+});
+
+it('rejects gear pickup for guests outside the configured gear scanner guest groups', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $allowedList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->entryStaffScanner->id,
+    ]);
+    $allowedGroup = GuestGroup::factory()->for($allowedList)->create();
+
+    $blockedList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->entryStaffScanner->id,
+    ]);
+    $blockedGroup = GuestGroup::factory()->for($blockedList)->create();
+
+    $blockedEntry = GuestEntry::factory()->for($blockedGroup, 'group')->withQrToken()->create();
+    $blockedGear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $blockedEntry->id,
+        'project_gear_item_id' => $this->gearItem->id,
+    ]);
+
+    $gearScanner->update(['guest_group_ids' => [$allowedGroup->id]]);
+
+    $this->postJson(route('scanner-api.guest-gear-pickup', $gearScanner->id), [
+        'guest_entry_gear_id' => $blockedGear->id,
+        'selection' => 'M',
+    ], [
+        'X-Scanner-Token' => $gearScanner->scanner_token,
+    ])->assertNotFound();
 });
 
 it('rejects gear pickup for entry from draft list', function () {

--- a/tests/Feature/Http/ScannerAttendanceApiTest.php
+++ b/tests/Feature/Http/ScannerAttendanceApiTest.php
@@ -71,6 +71,23 @@ it('returns 403 for entry staff scanner', function () {
     )->assertForbidden();
 });
 
+it('returns 403 for gear scanner', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
+    ]);
+
+    $this->postJson(
+        route('scanner-api.attendance', $gearScanner->id),
+        [
+            'shift_signup_id' => $this->signup->id,
+            'status' => 'on_time',
+        ],
+        ['X-Scanner-Token' => $gearScanner->scanner_token],
+    )->assertForbidden();
+});
+
 it('returns 422 for invalid status', function () {
     $this->postJson(
         route('scanner-api.attendance', $this->scanner->id),

--- a/tests/Feature/Http/ScannerDataControllerEdgeCasesTest.php
+++ b/tests/Feature/Http/ScannerDataControllerEdgeCasesTest.php
@@ -5,9 +5,12 @@ use App\Models\Event;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
+use App\Models\Shift;
+use App\Models\ShiftSignup;
 use App\Models\Ticket;
 use App\Models\Volunteer;
 use App\Models\VolunteerGear;
+use App\Models\VolunteerJob;
 use Carbon\Carbon;
 
 beforeEach(function () {
@@ -98,12 +101,23 @@ it('returns 404 when gear item belongs to different project', function () {
 it('accepts gear item belonging to same project', function () {
     $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
     $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
     $gear = VolunteerGear::factory()->create([
         'volunteer_id' => $volunteer->id,
         'project_gear_item_id' => $gearItem->id,
     ]);
 
-    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->withPoolEvents($this->event, [$this->event->id])->create([
         'project_id' => $this->project->id,
     ]);
 

--- a/tests/Feature/Http/ScannerDataControllerGuestTest.php
+++ b/tests/Feature/Http/ScannerDataControllerGuestTest.php
@@ -159,3 +159,106 @@ it('includes available_sizes and available_states in VA scanner gear data', func
     expect($gearData['available_sizes'])->toBe(['S', 'M', 'L', 'XL'])
         ->and($gearData['available_states'])->toBe(['issued', 'returned']);
 });
+
+it('filters gear scanner guest entries by configured guest groups', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $firstList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $allowedGroup = GuestGroup::factory()->for($firstList)->create(['label' => 'Allowed']);
+    $allowedEntry = GuestEntry::factory()->for($allowedGroup, 'group')->withQrToken()->create();
+
+    $secondList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $blockedGroup = GuestGroup::factory()->for($secondList)->create(['label' => 'Blocked']);
+    GuestEntry::factory()->for($blockedGroup, 'group')->withQrToken()->create();
+
+    $gearScanner->update(['guest_group_ids' => [$allowedGroup->id]]);
+
+    $response = $this->getJson(route('scanner-api.data', $gearScanner->id), [
+        'X-Scanner-Token' => $gearScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'guest_entries')
+        ->assertJsonPath('guest_entries.0.id', $allowedEntry->id)
+        ->assertJsonPath('guest_entries.0.qr_token', $allowedEntry->qr_token);
+});
+
+it('includes all confirmed guest list entries for gear scanners without guest group filters', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $firstList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $firstGroup = GuestGroup::factory()->for($firstList)->create(['label' => 'Artists']);
+    $firstEntry = GuestEntry::factory()->for($firstGroup, 'group')->withQrToken()->create();
+
+    $secondList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $secondGroup = GuestGroup::factory()->for($secondList)->create(['label' => 'Crew']);
+    $secondEntry = GuestEntry::factory()->for($secondGroup, 'group')->withQrToken()->create();
+
+    $response = $this->getJson(route('scanner-api.data', $gearScanner->id), [
+        'X-Scanner-Token' => $gearScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'guest_entries');
+
+    expect(collect($response->json('guest_entries'))->pluck('id')->all())
+        ->toEqualCanonicalizing([$firstEntry->id, $secondEntry->id]);
+});
+
+it('allows guest gear pickup for gear scanners', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create();
+    $gearItem = ProjectGearItem::factory()->for($this->project)->create();
+    $gear = GuestEntryGear::factory()->create([
+        'guest_entry_id' => $entry->id,
+        'project_gear_item_id' => $gearItem->id,
+        'quantity' => 1,
+        'picked_up_count' => 0,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.guest-gear-pickup', $gearScanner->id), [
+        'guest_entry_gear_id' => $gear->id,
+        'quantity' => 1,
+    ], [
+        'X-Scanner-Token' => $gearScanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true);
+});
+
+it('rejects guest check-in for gear scanners', function () {
+    $gearScanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->postJson(route('scanner-api.guest-checkin', $gearScanner->id), [
+        'guest_entry_id' => 1,
+    ], [
+        'X-Scanner-Token' => $gearScanner->scanner_token,
+    ])->assertForbidden();
+});

--- a/tests/Feature/Http/ScannerDataControllerTest.php
+++ b/tests/Feature/Http/ScannerDataControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\ScannerType;
+use App\Models\AttendanceRecord;
 use App\Models\Event;
 use App\Models\EventArrival;
 use App\Models\Project;
@@ -387,6 +388,34 @@ it('returns 403 when VA scanner tries to sync arrivals', function () {
     ])->assertForbidden();
 });
 
+it('returns 403 when gear scanner tries to sync arrivals', function () {
+    $scanner = ProjectScanner::factory()->active()->gear()->create([
+        'project_id' => $this->project->id,
+        'entry_event_id' => $this->event->id,
+        'pool_event_ids' => [$this->event->id],
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $ticket = Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $this->postJson(route('scanner-api.sync', $scanner->id), [
+        'contract_version' => ProjectScanner::CONTRACT_VERSION,
+        'arrivals' => [
+            [
+                'ticket_id' => $ticket->id,
+                'event_id' => $this->event->id,
+                'method' => 'qr_scan',
+                'scanned_at' => now()->toISOString(),
+            ],
+        ],
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ])->assertForbidden();
+});
+
 it('syncs arrivals to the scanner entry event instead of the client payload event', function () {
     $poolEvent = Event::factory()->for($this->project)->create();
     $scanner = ProjectScanner::factory()->active()->withPoolEvents($this->event, [$this->event->id, $poolEvent->id])->create([
@@ -421,11 +450,22 @@ it('syncs arrivals to the scanner entry event instead of the client payload even
 });
 
 it('records gear pickup for VA scanner', function () {
-    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create([
+    $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->withPoolEvents($this->event, [$this->event->id])->create([
         'project_id' => $this->project->id,
     ]);
 
     $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
     $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
     $gear = VolunteerGear::factory()->create([
         'volunteer_id' => $volunteer->id,
@@ -454,6 +494,110 @@ it('returns 403 when entry staff scanner tries gear pickup', function () {
     ], [
         'X-Scanner-Token' => $scanner->scanner_token,
     ])->assertForbidden();
+});
+
+it('records gear pickup for gear scanner', function () {
+    $scanner = ProjectScanner::factory()->active()->gear()->withPoolEvents($this->event, [$this->event->id])->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
+    $gear = VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]);
+
+    $response = $this->postJson(route('scanner-api.gear-pickup', $scanner->id), [
+        'volunteer_gear_id' => $gear->id,
+        'state' => 'picked_up',
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true);
+});
+
+it('rejects gear pickup for volunteers outside the configured pool', function () {
+    $outsideEvent = Event::factory()->for($this->project)->create();
+    $scanner = ProjectScanner::factory()->active()->gear()->withPoolEvents($this->event, [$this->event->id])->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $volunteer = Volunteer::factory()->create(['project_id' => $this->project->id]);
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $outsideEvent->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
+    $gearItem = ProjectGearItem::factory()->create(['project_id' => $this->project->id]);
+    $gear = VolunteerGear::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'project_gear_item_id' => $gearItem->id,
+    ]);
+
+    $this->postJson(route('scanner-api.gear-pickup', $scanner->id), [
+        'volunteer_gear_id' => $gear->id,
+        'state' => 'picked_up',
+    ], [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ])->assertNotFound();
+});
+
+it('omits shift attendance payload for gear scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->gear()->withPoolEvents($this->event, [$this->event->id])->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $volunteer = Volunteer::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+    Ticket::factory()->create([
+        'project_id' => $this->project->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+        'name' => 'Gear Crew',
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    $signup = ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+    AttendanceRecord::factory()->create([
+        'shift_signup_id' => $signup->id,
+    ]);
+
+    $response = $this->getJson(route('scanner-api.data', $scanner->id), [
+        'X-Scanner-Token' => $scanner->scanner_token,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonCount(0, 'attendance_records')
+        ->assertJsonPath('volunteers.0.id', $volunteer->id)
+        ->assertJsonPath('volunteers.0.shift_signups', []);
 });
 
 it('returns gear_items for volunteer admin scanner', function () {
@@ -631,6 +775,17 @@ it('rejects gear pickup when quantity exceeded via scanner API', function () {
 
     $item = ProjectGearItem::factory()->quantity(1)->for($this->project)->create();
     $volunteer = Volunteer::factory()->for($this->project)->create();
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
     $gear = VolunteerGear::factory()->withQuantity(1)->create([
         'project_gear_item_id' => $item->id,
         'volunteer_id' => $volunteer->id,
@@ -659,6 +814,17 @@ it('allows gear pickup within quantity limit via scanner API', function () {
 
     $item = ProjectGearItem::factory()->quantity(3)->for($this->project)->create();
     $volunteer = Volunteer::factory()->for($this->project)->create();
+    $job = VolunteerJob::factory()->create([
+        'event_id' => $this->event->id,
+    ]);
+    $shift = Shift::factory()->create([
+        'volunteer_job_id' => $job->id,
+    ]);
+    ShiftSignup::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'shift_id' => $shift->id,
+    ]);
+
     $gear = VolunteerGear::factory()->withQuantity(3)->create([
         'project_gear_item_id' => $item->id,
         'volunteer_id' => $volunteer->id,

--- a/tests/Feature/Livewire/ScannerAppTest.php
+++ b/tests/Feature/Livewire/ScannerAppTest.php
@@ -97,6 +97,30 @@ it('does not render entry staff volunteer lookup UI for volunteer admin scanners
         ->assertDontSee('Close Details');
 });
 
+it('renders gear scanner tabs and guest search UI', function () {
+    $scanner = ProjectScanner::factory()->active()->gear()->create();
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertSet('scannerType', ScannerType::Gear->value)
+        ->assertSee('Volunteers')
+        ->assertSee('Guests')
+        ->assertSee('Search volunteers...')
+        ->assertSee('Search guests...')
+        ->assertSeeHtml('selectGuestFromSearch(entry)')
+        ->assertSee('Record Pickup');
+});
+
+it('hides attendance and arrival actions for gear scanners', function () {
+    $scanner = ProjectScanner::factory()->active()->gear()->create();
+    session(['scanner_id' => $scanner->id]);
+
+    Livewire::test(ScannerApp::class, ['scannerToken' => $scanner->scanner_token])
+        ->assertDontSeeHtml('confirmArrival()')
+        ->assertDontSeeHtml('confirmAttendance(signup.id)')
+        ->assertDontSeeHtml('confirmGuestCheckin(entry.id)');
+});
+
 it('renders scanner and shift-list tabs for volunteer admin scanners with checkin mode', function () {
     $scanner = ProjectScanner::factory()->active()->volunteerAdmin()->create();
     session(['scanner_id' => $scanner->id]);

--- a/tests/Feature/Livewire/ScannerManagementTest.php
+++ b/tests/Feature/Livewire/ScannerManagementTest.php
@@ -6,6 +6,7 @@ use App\Enums\StaffRole;
 use App\Jobs\SendScannerLinksJob;
 use App\Livewire\Projects\ScannerManagement;
 use App\Models\Event;
+use App\Models\GuestGroup;
 use App\Models\GuestList;
 use App\Models\Organization;
 use App\Models\Project;
@@ -227,6 +228,44 @@ it('shows mode checkboxes when type is volunteer_admin', function () {
         ->set('form.type', ScannerType::VolunteerAdmin->value)
         ->assertSeeHtml('value="checkin"')
         ->assertSeeHtml('value="gear_pickup"');
+});
+
+it('shows guest group options when type is gear', function () {
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create(['label' => 'Crew']);
+
+    Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->set('form.type', ScannerType::Gear->value)
+        ->assertSee('Guest Groups')
+        ->assertSee($guestList->name.' - '.$group->label);
+});
+
+it('creates a gear scanner with guest group filters', function () {
+    $guestList = GuestList::factory()->confirmed()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $group = GuestGroup::factory()->for($guestList)->create();
+
+    Livewire::actingAs($this->organizer)
+        ->test(ScannerManagement::class, ['projectId' => $this->project->id])
+        ->set('form.name', 'Gear West')
+        ->set('form.type', ScannerType::Gear->value)
+        ->set('form.entryEventId', $this->event->id)
+        ->set('form.poolEventIds', [$this->event->id])
+        ->set('form.guestGroupIds', [$group->id])
+        ->set('form.startsAt', '2026-07-01T10:00')
+        ->set('form.endsAt', '2026-07-01T18:00')
+        ->call('createScanner')
+        ->assertHasNoErrors();
+
+    $scanner = ProjectScanner::where('project_id', $this->project->id)->where('name', 'Gear West')->first();
+
+    expect($scanner)->not->toBeNull()
+        ->and($scanner->type)->toBe(ScannerType::Gear)
+        ->and($scanner->guest_group_ids)->toBe([$group->id]);
 });
 
 it('resets modes to checkin when switching type from volunteer_admin to entry_staff', function () {

--- a/tests/Feature/Models/ProjectScannerEdgeCasesTest.php
+++ b/tests/Feature/Models/ProjectScannerEdgeCasesTest.php
@@ -106,6 +106,14 @@ it('returns configured pool event ids', function () {
     expect($scanner->configuredPoolEventIds())->toBe([$entryEvent->id, $poolEvent->id]);
 });
 
+it('returns configured guest group ids', function () {
+    $scanner = ProjectScanner::factory()->create([
+        'guest_group_ids' => ['10', 20],
+    ]);
+
+    expect($scanner->configuredGuestGroupIds())->toBe([10, 20]);
+});
+
 // --- Type casting ---
 
 it('casts type to ScannerType enum', function () {

--- a/tests/js/scanner/alpine-scanner.test.ts
+++ b/tests/js/scanner/alpine-scanner.test.ts
@@ -54,7 +54,7 @@ function makeVolunteer(overrides: Partial<Volunteer> = {}): Volunteer {
     };
 }
 
-function createApp(scannerType: 'entry_staff' | 'volunteer_admin' = 'entry_staff') {
+function createApp(scannerType: 'entry_staff' | 'gear' | 'volunteer_admin' = 'entry_staff') {
     return scannerApp({
         scannerId: 7,
         scannerType,
@@ -274,5 +274,62 @@ describe('alpine-scanner QR volunteer selection', () => {
         expect(app.state).toBe('result');
         expect(app.resultMessage).toBe('Ready to check in.');
         expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+
+    it('shows a gear scanner result for volunteer QR scans without arrival copy', () => {
+        const app = createApp('gear');
+        const volunteer = makeVolunteer();
+
+        app.selectVolunteer(volunteer, { fromQr: true });
+
+        expect(app.state).toBe('result');
+        expect(app.resultMessage).toBe('');
+        expect(app.result?.volunteerId).toBe(volunteer.id);
+    });
+});
+
+describe('alpine-scanner gear guest selection', () => {
+    it('selects a guest from search in gear mode', () => {
+        const app = createApp('gear');
+
+        app._guestEntries = [{
+            id: 11,
+            guest_group_id: 3,
+            group_label: 'Artists',
+            group_guest_count: 2,
+            number: 1,
+            name: 'DJ Test',
+            qr_token: 'guest-token',
+            checked_in_at: null,
+            gear: [],
+        }];
+
+        app.selectGuestFromSearch(app._guestEntries[0]);
+
+        expect(app.selectedGuest?.id).toBe(11);
+        expect(app.selectedGuestSource).toBe('manual');
+        expect(app.selectedVolunteer).toBeNull();
+    });
+
+    it('routes guest QR scans into gear mode guest details', () => {
+        const app = createApp('gear');
+        const entry = {
+            id: 12,
+            guest_group_id: 4,
+            group_label: 'Speakers',
+            group_guest_count: 1,
+            number: 1,
+            name: 'Keynote',
+            qr_token: 'guest-qr',
+            checked_in_at: null,
+            gear: [],
+        };
+
+        app._handleGuestQr(entry);
+
+        expect(app.selectedGuest?.id).toBe(12);
+        expect(app.selectedGuestSource).toBe('qr');
+        expect(app.guestResult).toBeNull();
+        expect(app.state).toBe('result');
     });
 });


### PR DESCRIPTION
## Summary
- add a dedicated `gear` scanner type with volunteer and guest lookup flows, guest-group filters, and a reduced scanner UI
- scope volunteer gear pickups to the configured scanner pool and keep guest gear access limited to confirmed project guest lists plus optional group filters
- cover the workflow with focused Pest, Vitest, and Playwright scanner tests, including a seeded Gear scanner E2E fixture

## Testing
- `vendor/bin/sail artisan test --compact --filter=ProjectScanner`
- `vendor/bin/sail artisan test --compact --filter=ScannerDataController`
- `vendor/bin/sail artisan test --compact --filter=ScannerManagement`
- `vendor/bin/sail artisan test --compact --filter=ScannerApp`
- `vendor/bin/sail artisan test --compact --filter=GearPickup`
- `vendor/bin/sail npm run test -- --run tests/js/scanner/alpine-scanner.test.ts tests/js/scanner/idb-store.test.ts`
- `vendor/bin/sail bin pint --dirty --format agent`
- `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/gear-scanner.spec.ts e2e/entry-staff-volunteer-lookup.spec.ts e2e/entry-staff-scanner-event-split.spec.ts e2e/va-scanner-shift-list.spec.ts e2e/va-scanner-arrival-status.spec.ts e2e/scanner-auth-timezone.spec.ts`

Closes #201