### PR TITLE
Improve invitation reliability and messaging UX

### DIFF
--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,9 +1,9 @@
 ---
 pipeline_status: complete
 current_stage: complete
-current_focus: "Issues #222 and #221 complete — portal QR refresh is current-key safe, and public signup cutoff enforcement now covers listing, reserve, final submit, and organizer-safe overrides"
-current_milestone: issue-221-signup-grace-minutes
-entry_point: implement
+current_focus: "phase-3-invitation-reliability-messaging-ux is complete; no unresolved critical/high security findings remain, and reminder-send acknowledgement timing plus frontend dependency advisories are tracked as backlog follow-ups"
+current_milestone: phase-3-invitation-reliability-messaging-ux
+entry_point: security-audit
 stages_to_run:
   - plan
   - implement
@@ -11,10 +11,13 @@ stages_to_run:
   - security-audit
 completed_stages:
   - plan
+  - implement
+  - test
+  - security-audit
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-05-07T17:30:00+02:00"
+last_updated: "2026-05-07T20:50:32+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -47,6 +50,7 @@ last_updated: "2026-05-07T17:30:00+02:00"
 | issue-201-gear-scanner-type | Gear Scanner Type | #201 dedicated gear scanner for volunteer and guest gear with pool events and guest group filters | m11-scanner, m12-guest-lists, issue-196-scanner-arrival-duplicate-status | complete |
 | issue-222-portal-jwt-refresh | Volunteer Portal JWT Refresh | #222 refresh portal QR JWTs so scanner verification no longer fails with stale signatures | m15-volunteer-portal-enhancements, m11-scanner, m19-non-expiring-magic-links | complete |
 | issue-221-signup-grace-minutes | Signup Grace Minutes | #221 event-level public signup cutoff with configurable grace minutes | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs, issue-207-signup-empty-state-notifications | complete |
+| phase-3-invitation-reliability-messaging-ux | Phase 3: Invitation Reliability & Messaging UX | #217 failed guest invitation visibility + resend, #218 sending-active guest-list wording, #220 reminder portal links, #219 guest-pass CTA button | m12-guest-lists, m13-polish, m19-non-expiring-magic-links, issue-193-guest-mail-magic-link | complete |
 
 ## Artifacts
 
@@ -78,6 +82,8 @@ last_updated: "2026-05-07T17:30:00+02:00"
 | `e2e/volunteer-portal-jwt-refresh.spec.ts` | test | issue-222 | Browser coverage for stale portal QR refresh before scanner verification | complete |
 | `.tall-pipeline/issue-221-signup-grace-minutes.md` | plan+implement+test+security | issue-221 | Issue #221 tracking for event-level signup grace minutes and booking cutoff enforcement | complete |
 | `e2e/signup-grace-minutes.spec.ts` | test | issue-221 | Browser coverage for organizer-managed signup grace minutes and public shift visibility | complete |
+| `.tall-pipeline/phase-3-invitation-reliability-messaging-ux.md` | plan+implement+test+security | phase-3-invitation-reliability-messaging-ux | Phase 3 milestone tracking with implementation, verification, and security-audit outcomes for #217, #218, #220, and #219 | complete |
+| `.tall-pipeline/phase-3-invitation-reliability-messaging-ux-security-audit.md` | security-audit | phase-3-invitation-reliability-messaging-ux | Security audit report for invitation state transitions, organizer resend recovery, reminder portal links, and guest-pass CTA surfaces | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/phase-3-invitation-reliability-messaging-ux-security-audit.md
+++ b/.tall-pipeline/phase-3-invitation-reliability-messaging-ux-security-audit.md
@@ -1,0 +1,276 @@
+# Phase 3 Invitation Reliability Messaging UX -- Security Audit Report
+
+**Milestone:** phase-3-invitation-reliability-messaging-ux
+**Audit Date:** 2026-05-07
+**Auditor:** TALL Security Audit (automated + manual)
+**Scope:** Phase 3 changes for #217, #218, #220, and #219, plus the trust boundaries they touch in guest invitation dispatch, organizer resend/recovery, reminder portal links, and guest-pass browser surfaces.
+
+---
+
+## Executive Summary
+
+The Phase 3 implementation holds its core security boundaries well. Organizer-only Livewire mutators now re-authorize inside each public method, sensitive Livewire identifiers are locked, invitation delivery timestamps are no longer mass assignable, queued invitation jobs re-bind to current state so stale jobs no-op cleanly, and guest-pass browser surfaces keep `no-store` / `noindex` protections on both valid and invalid signed-link responses.
+
+No unresolved critical or high milestone-specific findings were identified.
+
+**Overall Risk: LOW-MEDIUM**
+
+| Severity | Count |
+|---|---:|
+| Critical | 0 |
+| High | 0 |
+| Medium | 1 |
+| Low | 1 |
+| Info | 5 |
+
+**Immediate conclusion:** the milestone can advance past security audit without an implementation loop-back. Two reminder-delivery hardening items should be queued as follow-up work, but they do not block completion.
+
+---
+
+## Phase 1: Automated Scanning Results
+
+### 1.1 Dependency Audits
+
+**Composer:** `vendor/bin/sail composer audit`
+
+- No security vulnerability advisories found.
+
+**NPM:** `vendor/bin/sail npm audit --audit-level=low`
+
+- High: `axios` advisory set reported by `npm audit`
+- Moderate: `follow-redirects`
+- Moderate: `postcss`
+
+These are repo-level dependency findings, not introduced by this milestone's PHP / Livewire changes. They should still be remediated separately.
+
+**`roave/security-advisories`:** not present in `composer.json`.
+
+### 1.2 Static Analysis
+
+- PHPStan / Larastan not installed.
+- Psalm taint analysis not installed.
+
+### 1.3 Secret Detection
+
+- `gitleaks` is not installed in this workspace.
+- `.env` is ignored in `.gitignore`.
+- `git log --all --diff-filter=A -- '.env' '.env.*'` shows a historical `.env` add in the initial project commit. This audit did not inspect the historical payload, but the repository should verify no meaningful secrets were ever published and rotate anything non-disposable if needed.
+
+### 1.4 Environment / Configuration Checks
+
+`.env` reviewed for local development settings:
+
+- `APP_ENV=local`
+- `APP_DEBUG=true`
+- `SESSION_DRIVER=database`
+
+These values are acceptable for local development. Production still needs `APP_DEBUG=false` and a production-appropriate mailer.
+
+### 1.5 Header / Surface Checks
+
+- Guest-pass valid responses set `Cache-Control: no-store, private` and `X-Robots-Tag: noindex, nofollow, noarchive` in `app/Http/Controllers/GuestPassController.php:17-24`.
+- Guest-pass invalid / expired responses set the same headers in `bootstrap/app.php:42-49`.
+- No global CSP / HSTS / X-Frame-Options / Referrer-Policy middleware was found. This is a pre-existing application-level gap, not introduced by Phase 3.
+
+### 1.6 Debug Tool Exposure
+
+- No Telescope, Horizon, or Debugbar configuration was found in the current app packages / config.
+
+---
+
+## Phase 2: Manual Code Review (OWASP Top 10)
+
+### A01:2021 -- Broken Access Control
+
+#### Positive: Organizer Livewire Mutators Re-Authorize In-Method
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:108-350`
+
+All state-changing public methods call `authorizeGuestListManagement()` before mutating guest-list state. This closes the earlier post-mount permission-revocation gap and is the correct Livewire pattern.
+
+#### Positive: Authorization-Sensitive Livewire Properties Are Locked
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:34-38,57-58`
+
+`$projectId`, `$guestListId`, and `$editingEntryId` are `#[Locked]`, which prevents client-side property tampering from widening record access.
+
+#### Positive: Record Lookups Stay Scoped To The Locked Guest List / Project
+
+**Location:** `app/Livewire/Projects/GuestListShow.php:131,148,178,207,239,253,265,277,290,316`
+
+Mutating actions resolve entities through the current project / guest-list boundary instead of trusting naked IDs.
+
+### A02:2021 -- Cryptographic Failures
+
+#### Positive: Reminder Portal Links Reuse Hashed, High-Entropy Magic Tokens
+
+**Location:** `app/Actions/GenerateMagicLink.php:17-31`, `app/Actions/VerifyMagicLink.php:12-26`
+
+Reminder emails use the same 64-character random magic-link tokens already established in M19. Tokens are hashed at rest and compared by hash lookup.
+
+#### Positive: Guest-Pass Browser Links Remain Temporary Signed Routes
+
+**Location:** `app/Models/GuestEntry.php:136-144`
+
+The CTA rendering change in #219 did not widen guest-pass route semantics. The browser fallback still uses Laravel temporary signed URLs with expiry tied to the scanner window or a 7-day fallback.
+
+#### Residual Risk: Bearer-Link Replay Remains An Accepted Tradeoff
+
+**Location:** `app/Notifications/PreShiftReminder.php:47-84`, `routes/web.php:66-68`
+
+Reminder portal links and guest-pass URLs are bearer credentials. Anyone with the email can use the link until the signed URL expires or, for portal links, until the token is otherwise invalidated. This is consistent with prior milestone design and was not broadened beyond the existing portal model, but it remains an architectural replay risk.
+
+### A03:2021 -- Injection
+
+#### Positive: No SQL Injection In Phase 3 Code Paths
+
+The Phase 3 files use Eloquent query builder constraints only. No new `DB::raw`, `whereRaw`, or string-built SQL paths were introduced in the audited scope.
+
+#### Positive: No New XSS Sink On User-Controlled Content
+
+**Locations:** `resources/views/livewire/projects/guest-list-show.blade.php`, `resources/views/mail/guest-invitation.blade.php`, `resources/views/public/guest-pass.blade.php`
+
+User-facing Phase 3 strings are escaped with `{{ }}`. The only raw HTML remains QR SVG output via `{!! $entry->qrCodeSvg() !!}`, which is generated from server-side QR token input rather than user HTML.
+
+### A04:2021 -- Insecure Design
+
+#### [MEDIUM] F-1: Reminder Delivery Is Marked Sent Before Notification Success
+
+**OWASP Category:** A04:2021 -- Insecure Design
+**Location:** `app/Actions/SendPreShiftReminders.php:33-54`
+
+**Evidence:**
+
+```php
+foreach ($signups as $signup) {
+    $signup->update([$window->flagColumn() => true]);
+
+    try {
+        ['plainToken' => $plainToken] = $this->generateMagicLink->execute($signup->volunteer);
+
+        $signup->volunteer->notify(new PreShiftReminder(...));
+        $count++;
+    } catch (\Throwable $e) {
+        Log::error('Failed to send pre-shift reminder', [...]);
+    }
+}
+```
+
+**Risk:** a transient queue, database, token-generation, or mail transport failure permanently flips the `notification_24h_sent` / `notification_4h_sent` flag anyway. That suppresses future retries for the same signup and can silently drop reminder delivery. Because #220 now mints fresh portal links for every reminder send, this also creates a state mismatch between "reminder marked sent" and "no reminder actually delivered".
+
+**Remediation:** claim the signup atomically, but only persist the final sent flag after successful token generation and notification dispatch. If an early claim marker is required for concurrency control, restore it on failure inside the catch path.
+
+### A05:2021 -- Security Misconfiguration
+
+#### Positive: Guest-Pass Responses Explicitly Disable Browser / Proxy Storage
+
+**Location:** `app/Http/Controllers/GuestPassController.php:17-24`, `bootstrap/app.php:42-49`
+
+Both success and invalid-signature guest-pass surfaces carry `no-store` headers and `X-Robots-Tag`, which is the right hardening for emailed bearer links.
+
+### A06:2021 -- Vulnerable And Outdated Components
+
+#### [LOW] F-2: Frontend Dependency Advisories Are Present In `npm audit`
+
+**OWASP Category:** A06:2021 -- Vulnerable and Outdated Components
+**Location:** `package.json:12-37` and `vendor/bin/sail npm audit --audit-level=low`
+
+**Evidence:** `npm audit` reports a high advisory set on `axios` plus moderate advisories on `follow-redirects` and `postcss`.
+
+**Risk:** this is not specific to Phase 3 guest invitation / reminder code, but the repository is carrying known vulnerable frontend packages.
+
+**Remediation:** run `vendor/bin/sail npm audit fix`, verify lockfile and runtime behavior, and pin any remaining unresolved packages deliberately.
+
+### A07:2021 -- Identification And Authentication Failures
+
+#### Positive: Reminder Sends Stay Limited To Verified Volunteers
+
+**Location:** `app/Actions/SendPreShiftReminders.php:18-29`
+
+The reminder query scopes to active signups, published events, and volunteers with `email_verified_at` present.
+
+### A08:2021 -- Software And Data Integrity Failures
+
+#### Positive: Invitation Jobs Re-Bind To Current Claimed Rows And No-Op When Stale
+
+**Location:** `app/Actions/QueueGuestInvitationSiblingSet.php:71-126`, `app/Jobs/SendGuestInvitationsJob.php:29-69`
+
+The new claim-and-send flow persists exact claimed entry IDs, only updates those rows, and skips stale work once rows move or lose queued eligibility. This materially improves integrity over the older broad same-email update pattern.
+
+### A09:2021 -- Security Logging And Monitoring Failures
+
+#### Positive: Reminder Failures Are Logged With Context
+
+**Location:** `app/Actions/SendPreShiftReminders.php:46-53`
+
+Failure logs include volunteer, shift, signup, and reminder-window context without logging raw portal tokens.
+
+### A10:2021 -- Server-Side Request Forgery
+
+No SSRF-relevant outbound user-controlled URL flow was introduced in the audited Phase 3 code.
+
+### Open Redirects
+
+No user-controlled redirect target was introduced in the audited Phase 3 code.
+
+---
+
+## Phase 3: Threat Modeling
+
+### STRIDE Summary
+
+| Feature / Boundary | Spoofing | Tampering | Repudiation | Info Disclosure | DoS / Abuse | Elevation |
+|---|---|---|---|---|---|---|
+| Organizer -> `GuestListShow` Livewire mutators | Protected by auth session + per-method Gate | Locked IDs + validation reduce snapshot tampering | Session flashes / tests provide basic traceability | Invitation state is organizer-only | Organizer can intentionally queue sends, but recipient claims prevent duplicate pending/failed dispatch | No authz gap found in scoped record lookups |
+| Claim action -> `SendGuestInvitationsJob` | Job input comes from server-side dispatcher | Exact claimed IDs prevent sibling drift | Queue retries rely on worker logs | No raw QR token exposure beyond existing mail / guest pass | Stale jobs no-op cleanly; queued/failed transitions are bounded | No privilege change surface |
+| Reminder scheduler -> portal-link notification | Volunteer identity is bound by hashed magic token lookup | Token creation is server-side only | Reminder failures are logged | Portal links are bearer URLs by design | Overlap / early sent-flag persistence can duplicate or suppress delivery | No auth bypass beyond possession of the token |
+| Recipient -> guest-pass browser route | Signed URL proves integrity | Query tampering rejected by `signed` middleware | Invalid links return generic guest-safe response | `no-store` and `noindex` headers reduce passive leakage | Replay is limited to the signed URL validity window | No server-side privilege escalation |
+
+### Trust Boundaries
+
+1. **Organizer browser -> Livewire component**
+   Data crossing: entry IDs, guest names/emails, resend/edit actions.
+   Validation: `#[Locked]` on scoping IDs, explicit validation in `saveEntry()` / `updateGuestList()`, in-method `Gate::authorize()`.
+   Attacker control: all unlocked public properties and method calls.
+
+2. **Action layer -> queue jobs**
+   Data crossing: guest-list ID, recipient email, claimed entry IDs.
+   Validation: row claim happens inside DB transaction before dispatch.
+   Attacker control: indirect only through organizer-authorized mutations.
+
+3. **Email recipient -> guest-pass / portal routes**
+   Data crossing: signed guest-pass URL or plain portal bearer token.
+   Validation: `signed` middleware for guest pass, hash lookup for portal token.
+   Attacker control: possession / forwarding / replay of the link.
+
+### Abuse Cases
+
+1. As a malicious organizer, I try to tamper with Livewire IDs to resend or edit another guest list. The locked IDs and scoped queries prevent cross-list access.
+2. As a stale queue worker, I try to send to an old guest email after the organizer corrected it. The job re-checks queued state and current email, so stale work no-ops.
+3. As an attacker with access to a forwarded reminder email, I can replay the contained volunteer portal bearer link. This remains an accepted residual risk of the non-expiring magic-link model.
+
+---
+
+## Residual Risks
+
+These are not new critical / high findings, but they remain true after Phase 3:
+
+1. Reminder portal links are long-lived bearer credentials by design from M19. Forwarded or compromised emails still grant portal access until the token is otherwise invalidated.
+2. Guest-pass browser links are bearer links within their signature lifetime. They are hardened against tampering and caching, but not against intentional forwarding.
+3. The app still lacks a centralized security-header policy (CSP, HSTS, frame policy). That is broader than this milestone.
+
+---
+
+## Recommended Next Steps
+
+1. Backlog a follow-up hardening change for `SendPreShiftReminders` so sent flags are only persisted after successful notification dispatch or are rolled back on failure.
+2. Add overlap protection and/or atomic claiming for the scheduled reminder command to avoid duplicate sends and duplicate portal-token minting under concurrent runs.
+3. Triage the current `npm audit` advisories and consider adding `roave/security-advisories` plus PHPStan/Larastan in CI.
+
+---
+
+## Final Verdict
+
+- No unresolved critical or high Phase 3 findings.
+- Security-audit stage can be marked **complete**.
+- No implementation loop-back is required before milestone completion.

--- a/.tall-pipeline/phase-3-invitation-reliability-messaging-ux.md
+++ b/.tall-pipeline/phase-3-invitation-reliability-messaging-ux.md
@@ -1,0 +1,247 @@
+# Milestone: phase-3-invitation-reliability-messaging-ux — Phase 3: Invitation Reliability & Messaging UX
+
+**GitHub Issues:** #217, #218, #220, #219
+**Features:** #217, #218, #220, #219
+**Dependencies:** m12-guest-lists, m13-polish, m19-non-expiring-magic-links, issue-193-guest-mail-magic-link
+**Branch:** `phase-3-invitation-reliability-messaging-ux`
+
+## Plan
+- **Status:** complete
+- **Gate summary:** separate guest invitation dispatch from delivery, expose organizer-visible failure and resend recovery in the guest-list UI, align guest-list wording with the already-shipped always-on sending semantics, and tighten reminder and guest-pass email CTAs without broadening scope beyond the existing guest-list, reminder, and mail-template systems.
+
+### Scope
+- Keep Phase 3 scoped to the four requested issues, implemented in this order: #217, #218, #220, #219.
+- Reuse the existing guest-list grouping model of one guest invitation email per recipient address.
+- Keep guest-list internal identifiers and persisted status values stable: `confirmed`, `confirmed_at`, `ConfirmGuestList`, and `confirmGuestList()` remain unchanged.
+- Limit mail-template work to reminder defaults plus reminder notification rendering; do not migrate or rewrite existing custom event email templates.
+- Keep browser coverage focused on organizer-facing guest-list UI transitions and Mailpit-backed reminder rendering; do not add brittle browser tests for SMTP transport failures.
+
+### Invitation State Contract
+- `queued` means the grouped recipient invitation job was dispatched successfully for that recipient sibling set. It is a dispatch-time state only.
+- `sent` means the mail send call completed inside the queued job without throwing for that recipient sibling set.
+- `failed` means the grouped recipient job reached terminal failure handling after exhausting retries for that recipient sibling set.
+- Do not treat `sent` as provider-confirmed delivery, inbox placement, open, or click tracking. This milestone only models application-known dispatch, in-job send success, and terminal job failure.
+
+### Grouped Recipient Invariants
+- For grouped invitation sends, all `GuestEntry` rows in the same `GuestList` sharing the same recipient email form one recipient sibling set.
+- A recipient sibling set transitions through `queued`, `sent`, and `failed` together. Mixed per-row states inside the same sibling set are invalid for grouped sends.
+- Correcting a failed recipient email and resending operates on the failed recipient sibling set that shared the original address, not on one arbitrary row.
+- Organizer-visible resend affordances are only available for recipient sibling sets currently in terminal `failed` state.
+
+### Legacy / Backfill Interpretation
+- Pre-migration rows with only historical `invitation_sent_at` data should be interpreted as legacy-sent for organizer UI badges and should not be treated as failed or backlog by default.
+- Pre-migration rows with no invitation timestamps remain backlog/pending unless the surrounding guest-list state proves they were never eligible to send.
+- Bulk actions must remain sane against mixed legacy data: legacy-sent rows stay excluded from resend and pending-send actions unless they later enter the new terminal failed flow.
+
+### Breakdown
+
+#### 1. #217 — surface failed guest invitations and allow resend
+- **Goal:** make guest invitation delivery outcomes explicit so organizers can see failed rows, correct the address inline, and resend without leaving `GuestListShow`.
+- **Implementation areas:**
+  - `database/migrations/*guest_entries*`: add additive invitation delivery columns so dispatch, delivery success, and terminal failure are not conflated.
+  - `app/Models/GuestEntry.php`: add casts and derived helpers for backlog, queued, sent, and failed invitation states while keeping `guestPassUrl()` behavior intact.
+  - `app/Jobs/ConfirmGuestListJob.php`, `app/Jobs/SendGuestInvitationsJob.php`: stop writing sent state at dispatch time; persist `queued` when dispatch succeeds, persist `sent` only after the mail send call returns without exception inside the job, and persist `failed` only from final failure handling after retries are exhausted for the full recipient sibling set.
+  - `app/Actions/AddGuestEntry.php`, `app/Actions/UpdateGuestEntry.php`: for confirmed guest lists, queue invitations without marking them delivered; when a failed address is corrected, clear the failed state and requeue for the recipient sibling set that failed together.
+  - `app/Livewire/Projects/GuestListShow.php` and `resources/views/livewire/projects/guest-list-show.blade.php`: add visible invitation status, resend recipient-group action, failed-row recovery flow, and keep `Send Pending Invitations` limited to recipient sibling sets that are still backlog and not already queued or failed.
+- **State and retry rules:**
+  - Retryable attempts remain queued/in-flight from the organizer perspective; they must not surface as failed during intermediate retries.
+  - The organizer-visible failed badge and resend path appear only after terminal failure.
+  - Resend actions target only failed recipient sibling sets.
+  - Bulk pending send excludes recipient sibling sets already queued, already sent, or terminally failed.
+  - State persistence should be expressed as set-based updates per recipient sibling set, not row-by-row loops that can drift within a grouped send.
+- **Focused tests:**
+  - `tests/Feature/Jobs/SendGuestInvitationsJobTest.php`
+  - `tests/Feature/Jobs/ConfirmGuestListJobTest.php`
+  - `tests/Feature/Livewire/GuestListShowTest.php`
+  - `tests/Feature/GuestListLifecycleTest.php`
+  - `tests/Feature/Models/GuestEntryTest.php`
+- **Playwright:** add a new organizer-focused spec for guest-list invitation reliability that seeds deterministic failed and backlog rows, verifies failed-state visibility, inline email correction, resend, and that `Send Pending Invitations` excludes failed rows. Do not try to reproduce SMTP failure in-browser.
+
+#### 2. #218 — rename guest-list confirm flow to active sending semantics
+- **Goal:** make the guest-list UI describe the real behavior already in production: activating sending is an ongoing state, not a one-time finalization step.
+- **Implementation areas:**
+  - `app/Enums/GuestListStatus.php`: localize label output and change visible confirmed wording to active-sending semantics.
+  - `app/Livewire/Projects/GuestListShow.php`: update the post-activation flash message only.
+  - `resources/views/livewire/projects/guest-list-show.blade.php`: update the activation button and confirm dialog copy.
+  - `resources/views/livewire/projects/guest-list-index.blade.php`: consume the updated enum label output for index badges.
+  - `lang/de.json` and English locale files already used by the repo for UI strings.
+- **Focused tests:**
+  - `tests/Feature/Livewire/GuestListShowTest.php`
+  - `tests/Feature/Livewire/GuestListIndexTest.php`
+  - `tests/Feature/GuestListLifecycleTest.php` where it currently relies on old confirm wording or behavior expectations.
+- **Playwright:** cover the detail-page activation wording and the index/detail badge wording in the same organizer guest-list spec introduced for #217 instead of creating a second browser test.
+
+#### 3. #220 — add portal link to pre-shift reminder mails
+- **Goal:** let reminder recipients jump directly into their volunteer portal from both 24-hour and 4-hour reminders using the same non-expiring token pattern already used elsewhere.
+- **Implementation areas:**
+  - `app/Actions/SendPreShiftReminders.php`: generate a fresh plain magic-link token per reminder send and pass it into the notification.
+  - `app/Notifications/PreShiftReminder.php`: populate `portal_link`, render the reminder body with that URL, and add a `MailMessage::action()` CTA consistent with `SignupConfirmation` so the reminder always includes a portal link even when the custom body does not render the placeholder.
+  - `app/Services/EmailTemplateRenderer.php`: extend only the default `pre_shift_reminder_24h` and `pre_shift_reminder_4h` bodies with `{{portal_link}}`; custom templates stay body-unchanged unless they already use `{{portal_link}}`.
+- **Focused tests:**
+  - `tests/Feature/Actions/SendPreShiftRemindersTest.php`
+  - `tests/Feature/Notifications/PreShiftReminderTest.php`
+  - `tests/Feature/Services/EmailTemplateRendererTest.php`
+- **Playwright:** extend `e2e/pre-shift-reminder-relative-day.spec.ts` or add a sibling reminder-mail Mailpit spec to assert the reminder email contains the portal CTA/link for both reminder windows. Keep this as Mailpit/API-level browser coverage, not a portal-auth E2E.
+
+#### 4. #219 — render guest-pass fallback link as CTA button
+- **Goal:** upgrade the guest invitation fallback link introduced in #193 from a raw URL to a clear, localized mail CTA.
+- **Implementation areas:**
+  - `resources/views/mail/guest-invitation.blade.php`: replace the raw `<a>` with `<x-mail::button>` and localize the hint copy and button label.
+  - Guest invitation locale strings in the same translation files used for #218.
+- **Focused tests:**
+  - `tests/Feature/Mail/GuestInvitationMailTest.php`
+  - `tests/Feature/Jobs/SendGuestInvitationsJobTest.php` where mail rendering assumptions are asserted
+  - `tests/Feature/GuestListLifecycleTest.php` as a regression check on grouped invitation flow
+  - `tests/Feature/Http/GuestPassControllerTest.php` stays as the route-behavior backstop from #193
+- **Playwright:** no dedicated new browser test required if the reminder Mailpit coverage from #220 and the focused mail rendering tests stay green; this issue is primarily HTML mailable markup, not interactive app behavior.
+
+## Implement
+- **Status:** complete
+- **Tasks:**
+  - [x] Execute #217 first: additive queued/failed invitation persistence, sibling-set resend handling, organizer failed visibility, and deterministic browser coverage.
+  - [x] Review fix pass for #217: atomic pending/failed claims, exact-row success/failure updates, in-method Livewire authorization, internal-only invitation state writes, failed-set-only correction, and recovery-flow accessibility polish.
+  - [x] Finalize #217: confirmed-list email change recovery for sent/queued rows, dispatch-rollback safety, stale-job no-op behavior, reliable save feedback focus target, and no-op resend messaging.
+  - [x] Execute #218: rename visible guest-list confirm semantics to sending-active wording while keeping lifecycle identifiers stable.
+  - [x] Execute #220: fresh non-expiring reminder portal links, default reminder `{{portal_link}}` support, and consistent reminder CTA button rendering.
+  - [x] Execute #219: replace raw guest-pass fallback URLs with a localized guest-pass CTA button and cover it through focused Pest + Mailpit Playwright verification.
+  - [x] Keep #218 scoped to visible wording, localized labels via existing `__()` usage, and the existing organizer guest-list browser spec.
+  - [x] Preserve existing grouped guest invitation mail behavior and existing guest-pass route semantics.
+
+## Test
+- **Status:** complete
+- **Gate summary:** combined focused Pest coverage and both milestone Playwright specs passed for #217, #218, #220, and #219. The milestone is ready to advance to security audit with organizer resend/recovery, sending-active wording, reminder portal links, and guest-pass CTA coverage verified end to end.
+
+### Verification
+- `vendor/bin/sail artisan test --compact tests/Feature/Actions/QueueGuestInvitationSiblingSetTest.php tests/Feature/Actions/AddGuestEntryTest.php tests/Feature/Actions/UpdateGuestEntryTest.php tests/Feature/Actions/SendPreShiftRemindersTest.php tests/Feature/Jobs/SendGuestInvitationsJobTest.php tests/Feature/Jobs/ConfirmGuestListJobTest.php tests/Feature/Livewire/GuestListShowTest.php tests/Feature/Livewire/GuestListIndexTest.php tests/Feature/GuestListLifecycleTest.php tests/Feature/Models/GuestEntryTest.php tests/Feature/Notifications/PreShiftReminderTest.php tests/Feature/Services/EmailTemplateRendererTest.php tests/Feature/Mail/GuestInvitationMailTest.php tests/Feature/Http/GuestPassControllerTest.php`
+- `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/guest-list-invitation-reliability.spec.ts e2e/pre-shift-reminder-relative-day.spec.ts`
+
+### Test Results
+- Focused Pest coverage passed: 155 tests, 474 assertions.
+- Playwright coverage passed: 4 tests across `e2e/guest-list-invitation-reliability.spec.ts` and `e2e/pre-shift-reminder-relative-day.spec.ts`.
+
+### #219 Results
+- The guest invitation markdown mail now renders the browser fallback as a localized `Open Guest Pass` CTA button using Laravel's existing `<x-mail::button>` mail component instead of exposing the raw signed URL as link text.
+- The browser-fallback hint copy is now wrapped in `__()` to follow the repo's existing source-string localization convention, without introducing new route or token behavior.
+- Focused Pest coverage now asserts the localized hint text and CTA button label in `GuestInvitationMailTest`, `SendGuestInvitationsJobTest`, and `GuestListLifecycleTest`.
+- The organizer guest-list Playwright suite now also verifies a deterministic guest invitation email in Mailpit contains the CTA button and signed guest-pass browser URL, giving #219 an end-to-end verification path without changing guest-pass route behavior.
+
+### #220 Results
+- `SendPreShiftReminders` now generates a fresh non-expiring magic-link token per reminder send and passes the plain token into `PreShiftReminder`.
+- `PreShiftReminder` now renders `portal_link` with the volunteer portal URL and always appends a `Portal öffnen` CTA button, so custom reminder bodies stay unchanged unless they already use `{{portal_link}}` while still guaranteeing a portal entry point.
+- `EmailTemplateRenderer` now adds `{{portal_link}}` only to the default `pre_shift_reminder_24h` and `pre_shift_reminder_4h` bodies.
+- Focused Pest coverage now proves token generation, non-expiring token persistence, default-body portal-link rendering, custom-template opt-in placeholder rendering, and persistent CTA-button behavior.
+- Mailpit Playwright coverage now checks both 24-hour and 4-hour reminder emails for relative-day wording plus the rendered portal CTA/link without adding a portal-auth browser flow.
+
+### #217 Results
+- Focused invitation-state coverage added in `SendGuestInvitationsJobTest`, `ConfirmGuestListJobTest`, `GuestListShowTest`, `GuestListLifecycleTest`, `GuestEntryTest`, `AddGuestEntryTest`, and `UpdateGuestEntryTest`.
+- Added `QueueGuestInvitationSiblingSetTest` coverage for atomic pending/failed claim behavior and duplicate-dispatch prevention.
+- New browser coverage added in `e2e/guest-list-invitation-reliability.spec.ts` with deterministic failed, pending, and sent recipient-group fixtures.
+- Livewire review-fix coverage now includes post-mount permission revocation and exact claimed-row persistence for mixed same-email groups.
+- Final #217 coverage now also proves confirmed-list email changes from sent/queued rows requeue correctly, stale queued jobs no-op after rows move, dispatch failures restore rows out of queued state, and failed-group correction to an already-used address only reclaims the intended failed rows.
+
+### #218 Results
+- Updated guest-list status labels from raw lifecycle wording to localized sending-state wording via `GuestListStatus::label()` while keeping `confirmed` and related internals unchanged.
+- Updated the draft detail-page action button, confirm dialog copy, and post-activation flash message to describe ongoing sending semantics instead of one-time confirmation semantics.
+- Extended `GuestListShowTest`, `GuestListIndexTest`, and `e2e/guest-list-invitation-reliability.spec.ts` to cover draft and active wording on both detail and index views, including the activation dialog and success flash.
+
+## Security Audit
+- **Status:** complete
+- **Gate summary:** no unresolved critical or high findings were identified across the Phase 3 invitation-state, resend/recovery, reminder portal-link, and guest-pass CTA surfaces. The milestone can advance to complete with two non-blocking follow-up items on reminder-send acknowledgement timing and overlap hardening.
+
+### Audit Artifact
+- `.tall-pipeline/phase-3-invitation-reliability-messaging-ux-security-audit.md`
+
+### Findings Summary
+- Medium: `SendPreShiftReminders` flips reminder-sent flags before successful token generation / notification dispatch, so transient failures can suppress future reminders for that signup.
+- Low: repo-level `npm audit` still reports known frontend dependency advisories (`axios`, `follow-redirects`, `postcss`); these are not introduced by Phase 3 but remain open.
+- Info: organizer Livewire mutators re-authorize correctly, invitation-state fields are no longer mass assignable, stale invitation jobs no-op cleanly, guest-pass surfaces keep `no-store` / `noindex` headers, and reminder / guest-pass bearer-link replay remains the accepted residual risk from prior magic-link architecture.
+
+## Decisions
+
+| # | Stage | Decision | Rationale | Affects |
+|---|---|---|---|---|
+| 1 | plan | Keep grouped guest invitation delivery per recipient email and persist delivery outcomes back onto each matching `GuestEntry` | Preserves the current mail UX and minimizes scope while still making failure recovery visible per row | implement, test |
+| 2 | plan | Treat `invitation_sent_at` as actual successful delivery time going forward, and introduce separate queued and failed timestamps instead of a new enum table or raw provider error UI | The current bug comes from conflating queue dispatch with delivery; additive timestamps are the smallest forward path | implement, test, security-audit |
+| 3 | plan | `queued`, `sent`, and `failed` reflect application-known dispatch, in-job send success, and terminal job failure only; they do not imply provider-confirmed inbox delivery | Keeps the model truthful to what the app can actually observe and avoids over-promising delivery certainty in the UI | implement, test |
+| 4 | plan | Recipient sibling sets are the unit of invitation state transition, correction, resend, and batch persistence for grouped guest invitation sends | Preserves grouped-email semantics and prevents row-level drift within one recipient send | implement, test |
+| 5 | plan | `Send Pending Invitations` continues to target only backlog recipient groups and must not auto-resend failed or already queued groups | Keeps failed invitations visible instead of hiding them inside a bulk catch-all action and avoids duplicate dispatch | implement, test |
+| 6 | plan | Correcting the email of a failed recipient group clears its failed marker and immediately requeues delivery if the guest list is already sending-active | Matches organizer expectations from #217 and reuses the existing inline edit flow instead of adding a second repair UI | implement, test |
+| 7 | plan | Keep internal guest-list lifecycle identifiers (`confirmed`, `confirmed_at`, `ConfirmGuestList`, `confirmGuestList`) stable and change only visible copy | #218 is a semantics and translation fix, not an internal API rename | implement, test |
+| 8 | plan | Legacy rows with only historical `invitation_sent_at` data are interpreted as legacy-sent for badges and excluded from failed/backlog recovery actions unless they later enter the new failure flow | Prevents old rows from showing nonsensical failed/pending UI after the additive migration ships | implement, test |
+| 9 | plan | Reminder portal links use freshly generated non-expiring magic-link tokens per send, default reminder templates gain `{{portal_link}}`, and custom templates remain body-unchanged unless they already render the placeholder while the notification still appends the CTA button | Aligns reminder behavior with existing portal-link notifications and avoids mutating user-authored templates while guaranteeing a portal link is still present | implement, test, security-audit |
+| 10 | plan | Use existing repo conventions plus AGENTS and Boost guidance for this milestone plan because no repo-local `tall-foundations.md` reference exists in the project search | Prevents the milestone from blocking on a missing local reference file while keeping the plan anchored to current repo patterns | plan |
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Models | `GuestEntry`, `GuestGroup`, `GuestList`, `MagicLinkToken`, `Volunteer`, `ShiftSignup` |
+| Actions | `AddGuestEntry`, `UpdateGuestEntry`, `ConfirmGuestList`, `SendPreShiftReminders`, `GenerateMagicLink` |
+| Jobs | `ConfirmGuestListJob`, `SendGuestInvitationsJob` |
+| Livewire | `Projects\GuestListShow`, `Projects\GuestListIndex` |
+| Mail / Notifications | `GuestInvitationMail`, `PreShiftReminder`, `SignupConfirmation`, `EmailTemplateRenderer`, `resources/views/mail/guest-invitation.blade.php` |
+| Browser / Mailpit | `e2e/pre-shift-reminder-relative-day.spec.ts`, planned `e2e/guest-list-invitation-reliability.spec.ts` |
+| Prior Milestones | `m12-guest-lists`, `m13-polish`, `m19-non-expiring-magic-links`, `issue-193-guest-mail-magic-link` |
+
+## Reviews
+
+### plan — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Devil's Advocate | Row-level writes could let grouped-recipient siblings drift into contradictory invitation states or allow resend from the wrong row | high | accepted | The plan now defines the recipient sibling set as the invariant unit for queue, sent, failed, correction, resend, and set-based persistence so grouped invitation behavior cannot fragment |
+| 2 | Scalability Skeptic | Retry handling and bulk send paths could create duplicate dispatches or noisy failed badges if queued vs failed semantics stay ambiguous | medium | accepted | The plan now keeps retryable attempts in queued/in-flight state, surfaces failed only after terminal failure, excludes failed and already queued groups from bulk pending send, and prefers set-based updates over row loops |
+| 3 | Junior Developer Lens | Reminder portal-link work could be misread as permission to rewrite custom template bodies or as proof of inbox delivery once the send call succeeds | medium | accepted | The plan now spells out that `sent` is only in-job send success, not provider-confirmed delivery, and that only default reminder templates gain `{{portal_link}}` while custom bodies stay unchanged and still receive the appended CTA button |
+
+### implement-review — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Concurrency Review | Queue claims were dispatching before queued-state persistence and allowed duplicate replay of the same recipient set | high | accepted | The implementation now uses explicit pending-vs-failed claim methods that atomically claim rows before dispatch and make duplicate follow-up claims no-ops |
+| 2 | Delivery Accounting Review | Success/failure writes were broader than the actually mailed rows and could mutate unrelated same-email rows | high | accepted | The job now carries the exact claimed entry IDs and persists sent/failed state only for that claimed set, including mixed same-email cases where another row lacked a QR token |
+| 3 | Authorization Review | `GuestListShow` relied on `mount()` authorization only, so later Livewire actions could ignore revoked permissions | high | accepted | All state-changing public methods now re-authorize guest-list management and tests cover permission revocation after mount |
+| 4 | Security Review | Invitation state timestamps were mass assignable | medium | accepted | Invitation delivery timestamps are now internal-only writes on `GuestEntry` |
+| 5 | Data Integrity Review | Failed-email correction could clear unrelated sent or queued rows during state drift | medium | accepted | Failed-set correction is now scoped to the exact failed rows only and requeueing uses the explicit failed-claim path |
+| 6 | Accessibility Review | Recovery flow feedback and focus behavior were not robust for keyboard and screen-reader users | medium | accepted | The guest-list UI now adds live-region semantics, explicit labels for icon-only controls, failed-email side-effect description, and deliberate focus movement on edit/recovery interactions |
+
+### final-217-review — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Delivery Consistency Review | Confirmed-list email changes from sent or queued rows could keep the moved row blocked by stale delivery state and let stale queued jobs target the old address | high | accepted | Changed rows now clear their prior invitation state before re-claiming the new address, and jobs re-bind to current queued email/state at execution so stale jobs no-op |
+| 2 | Queue Robustness Review | Dispatch-time exceptions could leave rows stuck in queued state | high | accepted | Claiming now restores rows out of queued state if dispatch throws, preserving pending rows as pending and failed resend rows as failed |
+| 3 | UX Review | Successful inline saves could dispatch focus feedback before a stable target existed | medium | accepted | `saveEntry()` now flashes confirmation before dispatching the feedback-focus event, and browser coverage asserts the success message appears |
+| 4 | Product Edge Case Review | Correcting a failed group to an email already used elsewhere in the same guest list could unintentionally merge state across recipient sets | medium | accepted | Exact-id failed claims now requeue only the corrected failed rows, so the concern is resolved cleanly inside #217 without broadening product behavior |
+
+### implement-review-218 — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Product Copy Review | Renaming the visible confirm flow could accidentally leak into internal lifecycle names or broaden behavior beyond wording | medium | accepted | The implementation changed only user-facing button, dialog, badge, and flash copy while preserving `confirmed`, `confirmed_at`, `ConfirmGuestList`, and `confirmGuestList()` unchanged |
+| 2 | Localization Review | New status wording could bypass the repo's existing translation convention if hard-coded outside views | medium | accepted | The enum labels and flash message now use `__()` so the new wording follows the same translation-keyless convention already used across the repo |
+| 3 | Browser Coverage Review | The new activation wording could regress on the organizer UI if only covered in PHP tests | low | accepted | The existing guest-list Playwright spec now also asserts index/detail badges, activation button text, confirm dialog copy, and the post-activation flash message |
+
+### test-review-hardening — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Determinism Review | Mailpit assertions were polling the global inbox or taking the first recipient match, which could mask stale or duplicate messages | medium | accepted | The Playwright specs now poll for exactly one message per expected recipient and fail if duplicate recipient mail exists, so the checks bind to deterministic fixture mail instead of generic inbox activity |
+| 2 | Reminder UX Review | The reminder E2E only checked mail content and did not prove that a rendered portal CTA leads to a usable destination | medium | accepted | The reminder Playwright spec now extracts the portal URL from the Mailpit HTML, opens it in the browser, and asserts the volunteer portal loads with the expected volunteer context |
+| 3 | Invitation Recovery Review | The failed-address repair E2E proved row-state change but not that the repaired recipient actually received a usable invitation | medium | accepted | The guest-list Playwright spec now waits for the repaired recipient email, asserts guest-pass CTA links were rendered for both repaired rows, and opens a repaired guest-pass URL to confirm the page loads successfully |
+| 4 | Isolation Review | Extra Mailpit resets inside the individual specs or after fixture generation could further isolate tests | low | rejected | `e2e/setup.sh` already clears Mailpit before deterministic fixture mail is generated; clearing again inside this combined run would erase the seeded reminder and sent-invite evidence that the specs are intentionally validating |
+
+### security-audit — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Reminder Delivery Review | `SendPreShiftReminders` marks reminder flags as sent before notification success and does not restore them on failure | medium | backlog | A transient token-generation or mail failure can permanently suppress later reminder retries for the same signup, so the delivery acknowledgement needs to move after successful send or be rolled back on exception |
+| 2 | Dependency Hygiene Review | `npm audit` still reports known frontend advisories in `axios`, `follow-redirects`, and `postcss` | low | backlog | These findings are repo-level rather than Phase 3-specific, so they do not block the milestone but should be remediated separately |
+| 3 | Boundary Review | Organizer resend / edit actions, signed guest-pass CTAs, and reminder portal-link rendering could have widened access or leaked state | info | accepted | Manual review found per-method Livewire authorization, locked identifiers, internal-only invitation state writes, exact claimed-row job persistence, and `no-store` / `noindex` hardening intact across the new surfaces |
+
+## Feedback Loops
+
+| # | Date | Direction | Trigger | Fix | Resolution |
+|---|---|---|---|---|---|
+| 1 | 2026-05-07 | implement -> plan alignment | The pre-existing inline edit flow only updated one row, which would violate the sibling-set repair invariant for failed grouped recipients | Applied failed-email correction to the full recipient sibling set before requeueing the corrected address | resolved |
+| 2 | 2026-05-07 | implement-review -> implement | Accepted review findings identified queue claiming races, overly broad success/failure updates, missing in-method authorization, mass-assignable invitation state, and accessibility gaps | Reworked queue claiming around explicit atomic pending/failed claim paths, scoped job persistence to claimed IDs, re-authorized every mutator, removed invitation state from mass assignment, and added recovery-flow accessibility/focus handling | resolved |
+| 3 | 2026-05-07 | final-review -> implement | Final review found confirmed-list email changes could strand sent/queued rows, dispatch exceptions could leave queued rows stuck, stale jobs could still target moved rows, and same-list failed-address correction needed exact targeting | Added exact-id pending/failed claim methods, restored state on dispatch exceptions, rebound jobs to current queued email/state at execution time, flashed save confirmation before focus handoff, and targeted failed corrections by exact claimed IDs | resolved |

--- a/app/Actions/AddGuestEntry.php
+++ b/app/Actions/AddGuestEntry.php
@@ -2,7 +2,6 @@
 
 namespace App\Actions;
 
-use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
 use App\Models\GuestGroup;
 
@@ -32,8 +31,7 @@ class AddGuestEntry
             $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
 
             if ($email) {
-                SendGuestInvitationsJob::dispatch($guestList, $email);
-                $entry->update(['invitation_sent_at' => now()]);
+                app(QueueGuestInvitationSiblingSet::class)->claimPending($guestList, $email);
             }
         }
 

--- a/app/Actions/QueueGuestInvitationSiblingSet.php
+++ b/app/Actions/QueueGuestInvitationSiblingSet.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Actions;
+
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+class QueueGuestInvitationSiblingSet
+{
+    public function claimPending(GuestList $guestList, string $email): bool
+    {
+        return $this->claim(
+            guestList: $guestList,
+            email: $email,
+            claimableEntries: fn ($query) => $query
+                ->whereNotNull('qr_token')
+                ->whereNull('invitation_sent_at')
+                ->whereNull('invitation_queued_at')
+                ->whereNull('invitation_failed_at'),
+            restoreFailedState: false,
+        );
+    }
+
+    public function claimPendingEntries(GuestList $guestList, string $email, array $entryIds): bool
+    {
+        return $this->claim(
+            guestList: $guestList,
+            email: $email,
+            claimableEntries: fn ($query) => $query
+                ->whereKey($entryIds)
+                ->whereNotNull('qr_token')
+                ->whereNull('invitation_sent_at')
+                ->whereNull('invitation_queued_at')
+                ->whereNull('invitation_failed_at'),
+            restoreFailedState: false,
+        );
+    }
+
+    public function claimFailed(GuestList $guestList, string $email): bool
+    {
+        return $this->claim(
+            guestList: $guestList,
+            email: $email,
+            claimableEntries: fn ($query) => $query
+                ->whereNotNull('qr_token')
+                ->whereNull('invitation_sent_at')
+                ->whereNull('invitation_queued_at')
+                ->whereNotNull('invitation_failed_at'),
+            restoreFailedState: true,
+        );
+    }
+
+    public function claimFailedEntries(GuestList $guestList, string $email, array $entryIds): bool
+    {
+        return $this->claim(
+            guestList: $guestList,
+            email: $email,
+            claimableEntries: fn ($query) => $query
+                ->whereKey($entryIds)
+                ->whereNotNull('qr_token')
+                ->whereNull('invitation_sent_at')
+                ->whereNull('invitation_queued_at')
+                ->whereNotNull('invitation_failed_at'),
+            restoreFailedState: true,
+        );
+    }
+
+    private function claim(GuestList $guestList, string $email, callable $claimableEntries, bool $restoreFailedState): bool
+    {
+        $claimedEntryIds = DB::transaction(function () use ($guestList, $email, $claimableEntries) {
+            $candidateEntries = $guestList->entries()
+                ->select('guest_entries.id')
+                ->where('email', $email)
+                ->lockForUpdate();
+
+            $claimableEntries($candidateEntries);
+
+            $claimedEntryIds = $candidateEntries
+                ->pluck('guest_entries.id')
+                ->all();
+
+            if ($claimedEntryIds === []) {
+                return [];
+            }
+
+            GuestEntry::query()
+                ->whereKey($claimedEntryIds)
+                ->update([
+                    'invitation_sent_at' => null,
+                    'invitation_queued_at' => now(),
+                    'invitation_failed_at' => null,
+                ]);
+
+            return $claimedEntryIds;
+        });
+
+        if ($claimedEntryIds === []) {
+            return false;
+        }
+
+        try {
+            $this->dispatchClaimedJob($guestList, $email, $claimedEntryIds);
+        } catch (\Throwable $exception) {
+            GuestEntry::query()
+                ->whereKey($claimedEntryIds)
+                ->update([
+                    'invitation_queued_at' => null,
+                    'invitation_failed_at' => $restoreFailedState ? Date::now() : null,
+                ]);
+
+            throw $exception;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  int[]  $claimedEntryIds
+     */
+    protected function dispatchClaimedJob(GuestList $guestList, string $email, array $claimedEntryIds): void
+    {
+        SendGuestInvitationsJob::dispatch($guestList, $email, $claimedEntryIds);
+    }
+}

--- a/app/Actions/SendPreShiftReminders.php
+++ b/app/Actions/SendPreShiftReminders.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Facades\Log;
 
 class SendPreShiftReminders
 {
+    public function __construct(
+        private GenerateMagicLink $generateMagicLink,
+    ) {}
+
     public function execute(ReminderWindow $window): int
     {
         $signups = ShiftSignup::query()
@@ -30,10 +34,13 @@ class SendPreShiftReminders
             $signup->update([$window->flagColumn() => true]);
 
             try {
+                ['plainToken' => $plainToken] = $this->generateMagicLink->execute($signup->volunteer);
+
                 $signup->volunteer->notify(new PreShiftReminder(
                     $signup->shift->volunteerJob->event,
                     $signup->shift,
                     $window->templateType(),
+                    $plainToken,
                 ));
                 $count++;
             } catch (\Throwable $e) {

--- a/app/Actions/UpdateGuestEntry.php
+++ b/app/Actions/UpdateGuestEntry.php
@@ -2,19 +2,65 @@
 
 namespace App\Actions;
 
-use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
+use Illuminate\Support\Facades\DB;
 
 class UpdateGuestEntry
 {
     public function execute(GuestEntry $entry, array $data): GuestEntry
     {
         $originalEmail = $entry->email;
+        $guestList = $entry->group->guestList;
+        $emailWasUpdated = array_key_exists('email', $data);
+        $requestedEmail = $emailWasUpdated ? $data['email'] : $originalEmail;
+        $failedSiblingEntryIds = [];
 
-        $entry->update([
-            'name' => array_key_exists('name', $data) ? $data['name'] : $entry->name,
-            'email' => array_key_exists('email', $data) ? $data['email'] : $entry->email,
-        ]);
+        if ($guestList->isConfirmed() && $entry->isInvitationFailed() && $originalEmail !== null) {
+            $failedSiblingEntryIds = $guestList->entries()
+                ->where('email', $originalEmail)
+                ->whereNull('invitation_sent_at')
+                ->whereNull('invitation_queued_at')
+                ->whereNotNull('invitation_failed_at')
+                ->pluck('guest_entries.id')
+                ->all();
+        }
+
+        $isFailedSiblingSetCorrection = $requestedEmail !== null
+            && $requestedEmail !== $originalEmail
+            && in_array($entry->id, $failedSiblingEntryIds, true);
+
+        $changedEntryIds = [$entry->id];
+
+        DB::transaction(function () use ($entry, $data, $isFailedSiblingSetCorrection, $emailWasUpdated, $requestedEmail, $failedSiblingEntryIds, $guestList, $originalEmail, &$changedEntryIds) {
+            $entry->update([
+                'name' => array_key_exists('name', $data) ? $data['name'] : $entry->name,
+                'email' => $isFailedSiblingSetCorrection
+                    ? $entry->email
+                    : ($emailWasUpdated ? $requestedEmail : $entry->email),
+            ]);
+
+            if ($isFailedSiblingSetCorrection) {
+                GuestEntry::query()
+                    ->whereKey($failedSiblingEntryIds)
+                    ->update([
+                        'email' => $requestedEmail,
+                    ]);
+
+                $changedEntryIds = $failedSiblingEntryIds;
+
+                return;
+            }
+
+            if ($guestList->isConfirmed() && $emailWasUpdated && $requestedEmail !== null && $requestedEmail !== $originalEmail) {
+                GuestEntry::query()
+                    ->whereKey([$entry->id])
+                    ->update([
+                        'invitation_sent_at' => null,
+                        'invitation_queued_at' => null,
+                        'invitation_failed_at' => null,
+                    ]);
+            }
+        });
 
         if (isset($data['gear'])) {
             foreach ($data['gear'] as $gearData) {
@@ -28,16 +74,26 @@ class UpdateGuestEntry
             }
         }
 
+        $entry = $entry->fresh();
         $newEmail = $entry->email;
-        $guestList = $entry->group->guestList;
 
         if ($guestList->isConfirmed() && $newEmail !== null && $newEmail !== $originalEmail) {
-            if (! $entry->qr_token) {
-                $entry->update(['qr_token' => bin2hex(random_bytes(32))]);
-            }
+            $qrTokenQuery = $isFailedSiblingSetCorrection
+                ? GuestEntry::query()->whereKey($failedSiblingEntryIds)
+                : GuestEntry::query()->whereKey($changedEntryIds);
 
-            SendGuestInvitationsJob::dispatch($guestList, $newEmail);
-            $entry->update(['invitation_sent_at' => now()]);
+            $qrTokenQuery
+                ->whereNull('qr_token')
+                ->get()
+                ->each(fn (GuestEntry $sibling) => $sibling->update(['qr_token' => bin2hex(random_bytes(32))]));
+
+            $queueGuestInvitationSiblingSet = app(QueueGuestInvitationSiblingSet::class);
+
+            if ($isFailedSiblingSetCorrection) {
+                $queueGuestInvitationSiblingSet->claimFailedEntries($guestList, $newEmail, $failedSiblingEntryIds);
+            } else {
+                $queueGuestInvitationSiblingSet->claimPendingEntries($guestList, $newEmail, $changedEntryIds);
+            }
         }
 
         return $entry->fresh()->load('gear');

--- a/app/Enums/GuestListStatus.php
+++ b/app/Enums/GuestListStatus.php
@@ -10,8 +10,8 @@ enum GuestListStatus: string
     public function label(): string
     {
         return match ($this) {
-            self::Draft => 'Draft',
-            self::Confirmed => 'Confirmed',
+            self::Draft => __('Sending inactive'),
+            self::Confirmed => __('Sending active'),
         };
     }
 }

--- a/app/Jobs/ConfirmGuestListJob.php
+++ b/app/Jobs/ConfirmGuestListJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Actions\QueueGuestInvitationSiblingSet;
 use App\Models\GuestEntry;
 use App\Models\GuestList;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -47,19 +48,15 @@ class ConfirmGuestListJob implements ShouldBeUnique, ShouldQueue
             });
         });
 
-        $entries = $this->guestList->entries()
-            ->whereNotNull('email')
-            ->whereNotNull('qr_token')
-            ->get();
+        $emails = $this->guestList->entries()
+            ->pendingInvitation()
+            ->distinct()
+            ->pluck('email');
 
-        $emails = $entries->pluck('email')->unique();
+        $queueGuestInvitationSiblingSet = app(QueueGuestInvitationSiblingSet::class);
 
         foreach ($emails as $email) {
-            SendGuestInvitationsJob::dispatch($this->guestList, $email);
+            $queueGuestInvitationSiblingSet->claimPending($this->guestList, $email);
         }
-
-        $entries->each(function (GuestEntry $entry) {
-            $entry->update(['invitation_sent_at' => now()]);
-        });
     }
 }

--- a/app/Jobs/SendGuestInvitationsJob.php
+++ b/app/Jobs/SendGuestInvitationsJob.php
@@ -6,6 +6,7 @@ use App\Mail\GuestInvitationMail;
 use App\Models\GuestList;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Mail;
 
 class SendGuestInvitationsJob implements ShouldQueue
@@ -22,14 +23,19 @@ class SendGuestInvitationsJob implements ShouldQueue
     public function __construct(
         public GuestList $guestList,
         public string $email,
+        public array $guestEntryIds,
     ) {}
 
     public function handle(): void
     {
         $entries = $this->guestList->entries()
             ->with(['group.guestList.project', 'group.guestList.scanner'])
+            ->whereKey($this->guestEntryIds)
             ->where('email', $this->email)
             ->whereNotNull('qr_token')
+            ->whereNull('invitation_sent_at')
+            ->whereNotNull('invitation_queued_at')
+            ->whereNull('invitation_failed_at')
             ->get();
 
         if ($entries->isEmpty()) {
@@ -38,5 +44,27 @@ class SendGuestInvitationsJob implements ShouldQueue
 
         Mail::to($this->email)
             ->send(new GuestInvitationMail($this->guestList, $entries));
+
+        $this->guestList->entries()
+            ->whereKey($entries->modelKeys())
+            ->update([
+                'invitation_sent_at' => Date::now(),
+                'invitation_queued_at' => null,
+                'invitation_failed_at' => null,
+            ]);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        $this->guestList->entries()
+            ->whereKey($this->guestEntryIds)
+            ->where('email', $this->email)
+            ->whereNull('invitation_sent_at')
+            ->whereNotNull('invitation_queued_at')
+            ->whereNull('invitation_failed_at')
+            ->update([
+                'invitation_queued_at' => null,
+                'invitation_failed_at' => Date::now(),
+            ]);
     }
 }

--- a/app/Livewire/Projects/GuestListShow.php
+++ b/app/Livewire/Projects/GuestListShow.php
@@ -5,20 +5,22 @@ namespace App\Livewire\Projects;
 use App\Actions\AddGuestEntry;
 use App\Actions\AddGuestGroup;
 use App\Actions\ConfirmGuestList;
+use App\Actions\QueueGuestInvitationSiblingSet;
 use App\Actions\RemoveGuestEntry;
 use App\Actions\RemoveGuestGroup;
 use App\Actions\UpdateGuestEntry;
 use App\Actions\UpdateGuestList;
 use App\Enums\ScannerType;
 use App\Exceptions\DomainException;
-use App\Jobs\SendGuestInvitationsJob;
 use App\Models\GuestEntry;
 use App\Models\GuestGroup;
 use App\Models\GuestList;
 use App\Models\Project;
 use App\Models\ProjectGearItem;
 use App\Models\ProjectScanner;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Computed;
@@ -105,6 +107,8 @@ class GuestListShow extends Component
 
     public function openEditModal(): void
     {
+        $this->authorizeGuestListManagement();
+
         $guestList = $this->guestList;
 
         $this->editName = $guestList->name;
@@ -115,6 +119,8 @@ class GuestListShow extends Component
 
     public function updateGuestList(): void
     {
+        $this->authorizeGuestListManagement();
+
         $this->validate([
             'editName' => ['required', 'string', 'max:255'],
             'editScannerId' => ['required', Rule::exists('project_scanners', 'id')->where('project_id', $this->projectId)],
@@ -137,6 +143,8 @@ class GuestListShow extends Component
 
     public function confirmGuestList(): void
     {
+        $this->authorizeGuestListManagement();
+
         $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
 
         try {
@@ -144,11 +152,13 @@ class GuestListShow extends Component
             $action->execute($guestList);
         } catch (DomainException $e) {
             session()->flash('error', $e->getMessage());
+            $this->dispatch('guest-list-feedback');
 
             return;
         }
 
-        session()->flash('message', 'Guest list confirmed. QR codes are being generated.');
+        session()->flash('message', __('Guest list sending is now active. QR codes are being generated.'));
+        $this->dispatch('guest-list-feedback');
         unset($this->guestList);
     }
 
@@ -156,42 +166,71 @@ class GuestListShow extends Component
     public function pendingInvitationCount(): int
     {
         return $this->guestList->entries()
-            ->whereNotNull('email')
-            ->whereNotNull('qr_token')
-            ->whereNull('invitation_sent_at')
-            ->count();
+            ->pendingInvitation()
+            ->distinct()
+            ->count('email');
     }
 
     public function sendPendingInvitations(): void
     {
+        $this->authorizeGuestListManagement();
+
         $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
 
         if (! $guestList->isConfirmed()) {
             return;
         }
 
-        $pendingEntries = $guestList->entries()
-            ->whereNotNull('email')
-            ->whereNotNull('qr_token')
-            ->whereNull('invitation_sent_at')
-            ->get();
+        $emails = $guestList->entries()
+            ->pendingInvitation()
+            ->distinct()
+            ->pluck('email');
 
-        $emails = $pendingEntries->pluck('email')->unique();
+        $queueGuestInvitationSiblingSet = new QueueGuestInvitationSiblingSet;
+        $queuedCount = 0;
 
         foreach ($emails as $email) {
-            SendGuestInvitationsJob::dispatch($guestList, $email);
+            if ($queueGuestInvitationSiblingSet->claimPending($guestList, $email)) {
+                $queuedCount++;
+            }
         }
 
-        $pendingEntries->each(function (GuestEntry $entry) {
-            $entry->update(['invitation_sent_at' => now()]);
-        });
+        session()->flash('message', __('Invitations queued for :count recipients.', ['count' => $queuedCount]));
+        $this->dispatch('guest-list-feedback');
+        unset($this->guestList, $this->pendingInvitationCount);
+    }
 
-        session()->flash('message', __('Invitations queued for :count guests.', ['count' => $emails->count()]));
+    public function resendFailedInvitation(int $entryId): void
+    {
+        $this->authorizeGuestListManagement();
+
+        $entry = GuestEntry::whereHas('group', fn ($query) => $query->where('guest_list_id', $this->guestListId))
+            ->findOrFail($entryId);
+
+        if (! $entry->isInvitationFailed() || $entry->email === null) {
+            return;
+        }
+
+        $guestList = GuestList::where('project_id', $this->projectId)->findOrFail($this->guestListId);
+
+        $wasClaimed = (new QueueGuestInvitationSiblingSet)->claimFailed($guestList, $entry->email);
+
+        if (! $wasClaimed) {
+            session()->flash('error', __('This invitation is no longer available for resend.'));
+            $this->dispatch('guest-list-feedback');
+
+            return;
+        }
+
+        session()->flash('message', __('Invitation resend queued for :email.', ['email' => $entry->email]));
+        $this->dispatch('guest-list-feedback');
         unset($this->guestList, $this->pendingInvitationCount);
     }
 
     public function addGroup(): void
     {
+        $this->authorizeGuestListManagement();
+
         $this->validate([
             'newGroupLabel' => ['required', 'string', 'max:255'],
             'newGroupCount' => ['required', 'integer', 'min:1', 'max:100'],
@@ -209,6 +248,8 @@ class GuestListShow extends Component
 
     public function removeGroup(int $groupId): void
     {
+        $this->authorizeGuestListManagement();
+
         $group = GuestGroup::where('guest_list_id', $this->guestListId)->findOrFail($groupId);
 
         $action = new RemoveGuestGroup;
@@ -219,6 +260,8 @@ class GuestListShow extends Component
 
     public function addEntry(int $groupId): void
     {
+        $this->authorizeGuestListManagement();
+
         $group = GuestGroup::where('guest_list_id', $this->guestListId)->findOrFail($groupId);
 
         $action = new AddGuestEntry;
@@ -229,6 +272,8 @@ class GuestListShow extends Component
 
     public function removeEntry(int $entryId): void
     {
+        $this->authorizeGuestListManagement();
+
         $entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
             ->findOrFail($entryId);
 
@@ -240,6 +285,8 @@ class GuestListShow extends Component
 
     public function startEditEntry(int $entryId): void
     {
+        $this->authorizeGuestListManagement();
+
         $entry = GuestEntry::whereHas('group', fn ($q) => $q->where('guest_list_id', $this->guestListId))
             ->findOrFail($entryId);
 
@@ -247,10 +294,16 @@ class GuestListShow extends Component
         $this->entryName = $entry->name ?? '';
         $this->entryEmail = $entry->email ?? '';
         $this->entryGear = [];
+
+        $this->dispatch('guest-entry-edit-opened', inputId: $entry->isInvitationFailed()
+            ? 'entry-email-'.$entry->id
+            : 'entry-name-'.$entry->id);
     }
 
     public function saveEntry(): void
     {
+        $this->authorizeGuestListManagement();
+
         $this->validate([
             'entryName' => ['nullable', 'string', 'max:255'],
             'entryEmail' => ['nullable', 'email', 'max:255'],
@@ -272,13 +325,28 @@ class GuestListShow extends Component
 
         $this->cancelEditEntry();
         unset($this->guestList);
+        session()->flash('message', __('Guest entry updated.'));
+        $this->dispatch('guest-list-feedback');
     }
 
     public function cancelEditEntry(): void
     {
+        $this->authorizeGuestListManagement();
+
         $this->editingEntryId = null;
         $this->entryName = '';
         $this->entryEmail = '';
         $this->entryGear = [];
+    }
+
+    private function authorizeGuestListManagement(): void
+    {
+        $authenticatedUser = Auth::user();
+
+        if ($authenticatedUser instanceof User) {
+            Auth::setUser($authenticatedUser->fresh());
+        }
+
+        Gate::authorize('manageGuestLists', $this->project);
     }
 }

--- a/app/Models/GuestEntry.php
+++ b/app/Models/GuestEntry.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Services\QrCodeGenerator;
 use Database\Factories\GuestEntryFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -27,7 +28,6 @@ class GuestEntry extends Model
         'qr_token',
         'checked_in_at',
         'checked_in_by',
-        'invitation_sent_at',
     ];
 
     protected function casts(): array
@@ -36,7 +36,19 @@ class GuestEntry extends Model
             'number' => 'integer',
             'checked_in_at' => 'datetime',
             'invitation_sent_at' => 'datetime',
+            'invitation_queued_at' => 'datetime',
+            'invitation_failed_at' => 'datetime',
         ];
+    }
+
+    public function scopePendingInvitation(Builder $query): Builder
+    {
+        return $query
+            ->whereNotNull('email')
+            ->whereNotNull('qr_token')
+            ->whereNull('invitation_sent_at')
+            ->whereNull('invitation_queued_at')
+            ->whereNull('invitation_failed_at');
     }
 
     public function group(): BelongsTo
@@ -57,6 +69,53 @@ class GuestEntry extends Model
     public function isCheckedIn(): bool
     {
         return $this->checked_in_at !== null;
+    }
+
+    public function isInvitationQueued(): bool
+    {
+        return $this->invitation_queued_at !== null
+            && $this->invitation_sent_at === null
+            && $this->invitation_failed_at === null;
+    }
+
+    public function isInvitationSent(): bool
+    {
+        return $this->invitation_sent_at !== null;
+    }
+
+    public function isInvitationFailed(): bool
+    {
+        return $this->invitation_failed_at !== null;
+    }
+
+    public function isInvitationPending(): bool
+    {
+        return $this->email !== null
+            && $this->qr_token !== null
+            && ! $this->isInvitationQueued()
+            && ! $this->isInvitationSent()
+            && ! $this->isInvitationFailed();
+    }
+
+    public function invitationStatus(): string
+    {
+        if ($this->email === null || $this->qr_token === null) {
+            return 'not_ready';
+        }
+
+        if ($this->isInvitationFailed()) {
+            return 'failed';
+        }
+
+        if ($this->isInvitationSent()) {
+            return 'sent';
+        }
+
+        if ($this->isInvitationQueued()) {
+            return 'queued';
+        }
+
+        return 'pending';
     }
 
     /**

--- a/app/Notifications/PreShiftReminder.php
+++ b/app/Notifications/PreShiftReminder.php
@@ -23,6 +23,7 @@ class PreShiftReminder extends Notification implements ShouldQueue
         public Event $event,
         public Shift $shift,
         public EmailTemplateType $templateType,
+        public string $magicLinkToken,
     ) {}
 
     /**
@@ -43,6 +44,7 @@ class PreShiftReminder extends Notification implements ShouldQueue
         $cheatSheetUrl = $job->instructions
             ? route('events.jobs.cheat-sheet', ['publicToken' => $this->event->public_token, 'jobId' => $job->id])
             : '';
+        $portalUrl = route('volunteer.portal', $this->magicLinkToken);
 
         $renderer = app(EmailTemplateRenderer::class);
         $rendered = $renderer->render(
@@ -61,7 +63,7 @@ class PreShiftReminder extends Notification implements ShouldQueue
                 'shift_time' => $this->shift->displayTimeRange($timezone),
                 'event_location' => $this->event->location ? "**Ort:** {$this->event->location}" : '',
                 'cheat_sheet_url' => $cheatSheetUrl ? "[Aufgaben-Infos anzeigen]({$cheatSheetUrl})" : '',
-                'portal_link' => '', // Will be set when portal URL is available
+                'portal_link' => $portalUrl,
                 'kontakt_email' => $this->event->project?->contact_email ?? $this->event->organization->smtp_from_address ?? '',
                 'project_name' => $this->event->project?->name ?? '',
             ],
@@ -77,6 +79,8 @@ class PreShiftReminder extends Notification implements ShouldQueue
                 $mail->line($trimmed);
             }
         }
+
+        $mail->action('Portal öffnen', $portalUrl);
 
         return $this->applyOrgMailer($mail, $this->event->organization, $this->event->project);
     }

--- a/app/Services/EmailTemplateRenderer.php
+++ b/app/Services/EmailTemplateRenderer.php
@@ -20,11 +20,11 @@ class EmailTemplateRenderer
         ],
         'pre_shift_reminder_24h' => [
             'subject' => 'Erinnerung: Deine Schicht bei {{event_name}} ist {{relativer_tag}}',
-            'body' => "Hallo {{vorname}}!\n\nDies ist eine Erinnerung, dass deine Schicht bei **{{event_name}}** {{relativer_tag}} stattfindet.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis bald!",
+            'body' => "Hallo {{vorname}}!\n\nDies ist eine Erinnerung, dass deine Schicht bei **{{event_name}}** {{relativer_tag}} stattfindet.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nÖffne dein Volunteer-Portal: {{portal_link}}\n\nBis bald!",
         ],
         'pre_shift_reminder_4h' => [
             'subject' => 'Erinnerung: Deine Schicht bei {{event_name}} beginnt bald',
-            'body' => "Hallo {{vorname}}!\n\nDeine Schicht bei **{{event_name}}** beginnt {{relativer_tag}} in wenigen Stunden.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nBis gleich!",
+            'body' => "Hallo {{vorname}}!\n\nDeine Schicht bei **{{event_name}}** beginnt {{relativer_tag}} in wenigen Stunden.\n\n**Aufgabe:** {{job_name}}\n**Schicht:** {{shift_date}} {{shift_time}}\n{{event_location}}\n{{cheat_sheet_url}}\n\nÖffne dein Volunteer-Portal: {{portal_link}}\n\nBis gleich!",
         ],
         'email_verification' => [
             'subject' => 'Bestätige deine E-Mail für {{event_name}}',

--- a/database/migrations/2026_05_07_165508_add_invitation_delivery_columns_to_guest_entries_table.php
+++ b/database/migrations/2026_05_07_165508_add_invitation_delivery_columns_to_guest_entries_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('guest_entries', function (Blueprint $table) {
+            $table->timestamp('invitation_queued_at')->nullable()->after('invitation_sent_at');
+            $table->timestamp('invitation_failed_at')->nullable()->after('invitation_queued_at');
+            $table->index(['email', 'invitation_queued_at'], 'guest_entries_email_invitation_queued_at_index');
+            $table->index(['email', 'invitation_failed_at'], 'guest_entries_email_invitation_failed_at_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('guest_entries', function (Blueprint $table) {
+            $table->dropIndex('guest_entries_email_invitation_queued_at_index');
+            $table->dropIndex('guest_entries_email_invitation_failed_at_index');
+            $table->dropColumn(['invitation_queued_at', 'invitation_failed_at']);
+        });
+    }
+};

--- a/e2e/guest-list-invitation-reliability.spec.ts
+++ b/e2e/guest-list-invitation-reliability.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+type Fixtures = {
+    guestListReliabilityProjectId: number;
+    guestListReliabilityGuestListId: number;
+    guestListReliabilityDraftGuestListId: number;
+    guestListReliabilitySentInviteEmail: string;
+};
+
+type MailpitAddress = {
+    Address: string;
+};
+
+type MailpitMessage = {
+    ID: string;
+    To?: MailpitAddress[];
+};
+
+type MailpitInbox = {
+    messages?: MailpitMessage[];
+};
+
+type MailpitMessageDetails = {
+    HTML?: string;
+    Text?: string;
+};
+
+const mailpitBaseUrl = (globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+}).process?.env?.MAILPIT_BASE_URL ?? 'http://mailpit:8025';
+
+async function fetchInbox(request: APIRequestContext): Promise<MailpitInbox> {
+    const response = await request.get(`${mailpitBaseUrl}/api/v1/messages`);
+
+    return await response.json() as MailpitInbox;
+}
+
+async function fetchMessagesForRecipient(request: APIRequestContext, recipient: string): Promise<MailpitMessage[]> {
+    const inbox = await fetchInbox(request);
+
+    return (inbox.messages ?? []).filter((entry) => {
+        return entry.To?.some((address) => address.Address === recipient);
+    });
+}
+
+async function waitForSingleMessageForRecipient(request: APIRequestContext, recipient: string): Promise<MailpitMessageDetails> {
+    await expect.poll(async () => {
+        return (await fetchMessagesForRecipient(request, recipient)).length;
+    }, {
+        message: `Expected exactly one Mailpit message for ${recipient}`,
+    }).toBe(1);
+
+    const [message] = await fetchMessagesForRecipient(request, recipient);
+
+    expect(message, `Expected a Mailpit message for ${recipient}`).toBeTruthy();
+
+    const response = await request.get(`${mailpitBaseUrl}/api/v1/message/${message!.ID}`);
+
+    return await response.json() as MailpitMessageDetails;
+}
+
+function extractUrls(content: string | undefined, pattern: RegExp): string[] {
+    if (!content) {
+        return [];
+    }
+
+    const normalizedContent = content.replace(/&amp;/g, '&');
+
+    return Array.from(normalizedContent.matchAll(pattern), (match: RegExpMatchArray) => match[0]);
+}
+
+async function login(page: Page): Promise<void> {
+    await page.goto('/login');
+    await page.getByPlaceholder('email@example.com').fill('test@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await expect(page).toHaveURL(/\/admin\/dashboard$/);
+}
+
+async function loadFixtures(page: Page): Promise<Fixtures> {
+    await page.goto('/e2e-fixtures.json');
+
+    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
+}
+
+test('organizer can see failed invitation groups, resend them, and repair a failed address inline', async ({ page, request }) => {
+    const fixtures = await loadFixtures(page);
+
+    await login(page);
+    await page.goto(`/admin/projects/${fixtures.guestListReliabilityProjectId}/guest-lists/${fixtures.guestListReliabilityGuestListId}`);
+
+    await expect(page.getByRole('button', { name: 'Send Pending Invitations (1)' })).toBeVisible();
+
+    const retryRow = page.locator('tr').filter({ hasText: 'retry@example.com' }).first();
+    await expect(retryRow.getByText('Failed')).toBeVisible();
+    await retryRow.getByRole('button', { name: 'Resend' }).click();
+    await expect(page.getByText('Invitation resend queued for retry@example.com.')).toBeVisible();
+    await expect(page.locator('tr').filter({ hasText: 'retry@example.com' }).first()).toContainText(/Queued|Sent/);
+
+    const retryInvitation = await waitForSingleMessageForRecipient(request, 'retry@example.com');
+
+    expect(retryInvitation.HTML).toContain('Open Guest Pass');
+
+    const repairRow = page.locator('tr').filter({ hasText: 'repair@example.com' }).first();
+    await expect(repairRow.getByText('Failed')).toBeVisible();
+    await repairRow.getByTitle('Edit').click();
+    await expect(page.getByPlaceholder('Email')).toBeFocused();
+    await page.getByPlaceholder('Email').fill('repaired@example.com');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Guest entry updated.')).toBeVisible();
+
+    await expect(page.locator('tr').filter({ hasText: 'repaired@example.com' })).toHaveCount(2);
+    await expect(page.locator('tr').filter({ hasText: 'repaired@example.com' }).first()).toContainText(/Queued|Sent/);
+
+    const repairedInvitation = await waitForSingleMessageForRecipient(request, 'repaired@example.com');
+    const repairedGuestPassUrls = extractUrls(
+        repairedInvitation.HTML,
+        /http:\/\/localhost\/guest-pass\/\d+\?expires=\d+&signature=[A-Za-z0-9%_-]+/g,
+    );
+
+    expect(repairedInvitation.HTML).toContain('Open Guest Pass');
+    expect(repairedGuestPassUrls).toHaveLength(2);
+
+    page.once('dialog', async (dialog) => {
+        await dialog.accept();
+    });
+    await page.getByRole('button', { name: 'Send Pending Invitations (1)' }).click();
+
+    await expect(page.getByText('Invitations queued for 1 recipients.')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Send Pending Invitations/ })).toHaveCount(0);
+
+    const guestPassPage = await page.context().newPage();
+
+    await guestPassPage.goto(repairedGuestPassUrls[0]);
+    await expect(guestPassPage.getByText('Guest Pass')).toBeVisible();
+    await expect(guestPassPage.getByText('E2E Guest Invitation Reliability')).toBeVisible();
+    await expect(guestPassPage.getByText(/Repair Group [12]\/2/)).toBeVisible();
+    await expect(guestPassPage.getByText(/Repair One|Repair Two/)).toBeVisible();
+    await guestPassPage.close();
+});
+
+test('organizer sees sending-active wording on guest list badges and activation flow', async ({ page }) => {
+    const fixtures = await loadFixtures(page);
+
+    await login(page);
+    await page.goto(`/admin/projects/${fixtures.guestListReliabilityProjectId}/guest-lists`);
+
+    await expect(page.locator('div').filter({ hasText: 'E2E Guest Invitation Reliability' }).getByText('Sending active')).toBeVisible();
+    await expect(page.locator('div').filter({ hasText: 'E2E Draft Guest Invitation List' }).getByText('Sending inactive')).toBeVisible();
+
+    await page.goto(`/admin/projects/${fixtures.guestListReliabilityProjectId}/guest-lists/${fixtures.guestListReliabilityDraftGuestListId}`);
+
+    await expect(page.getByText('Sending inactive')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Activate Sending' })).toBeVisible();
+
+    page.once('dialog', async (dialog) => {
+        expect(dialog.message()).toBe('Activate sending for this guest list? QR codes will be generated for all entries, and new guests with an email address will keep receiving invitations automatically.');
+        await dialog.accept();
+    });
+
+    await page.getByRole('button', { name: 'Activate Sending' }).click();
+
+    await expect(page.getByText('Guest list sending is now active. QR codes are being generated.')).toBeVisible();
+    await expect(page.getByText('Sending active')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Activate Sending' })).toHaveCount(0);
+});
+
+test('guest invitation emails expose the browser fallback as a CTA button', async ({ page, request }) => {
+    const fixtures = await loadFixtures(page);
+
+    const invitation = await waitForSingleMessageForRecipient(request, fixtures.guestListReliabilitySentInviteEmail);
+    const guestPassUrls = extractUrls(
+        invitation.HTML,
+        /http:\/\/localhost\/guest-pass\/\d+\?expires=\d+&signature=[A-Za-z0-9%_-]+/g,
+    );
+
+    expect(invitation.Text).toContain('If the QR code is not visible in your email app, open this pass in your browser.');
+    expect(invitation.HTML).toContain('Open Guest Pass');
+    expect(guestPassUrls.length).toBeGreaterThan(0);
+});

--- a/e2e/pre-shift-reminder-relative-day.spec.ts
+++ b/e2e/pre-shift-reminder-relative-day.spec.ts
@@ -1,10 +1,11 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type APIRequestContext } from '@playwright/test';
 
 type MailpitAddress = {
     Address: string;
 };
 
 type MailpitMessage = {
+    ID: string;
     Subject?: string;
     Snippet?: string;
     To?: MailpitAddress[];
@@ -14,32 +15,84 @@ type MailpitInbox = {
     messages?: MailpitMessage[];
 };
 
+type MailpitMessageDetails = {
+    Subject?: string;
+    Text?: string;
+    HTML?: string;
+};
+
 const mailpitBaseUrl = (globalThis as typeof globalThis & {
     process?: { env?: Record<string, string | undefined> };
-}).process?.env?.MAILPIT_BASE_URL ?? 'http://localhost:8025';
+}).process?.env?.MAILPIT_BASE_URL ?? 'http://mailpit:8025';
 
-test('24-hour pre-shift reminders use today and tomorrow wording', async ({ request }) => {
-    await expect.poll(async () => {
-        const response = await request.get(`${mailpitBaseUrl}/api/v1/messages`);
-        const inbox = await response.json() as MailpitInbox;
-
-        return inbox.messages?.length ?? 0;
-    }).toBeGreaterThanOrEqual(2);
-
+async function fetchInbox(request: APIRequestContext): Promise<MailpitInbox> {
     const response = await request.get(`${mailpitBaseUrl}/api/v1/messages`);
-    const inbox = await response.json() as MailpitInbox;
 
-    const todayReminder = inbox.messages?.find((message) => {
-        return message.To?.some((recipient) => recipient.Address === 'reminder-today@example.com');
+    return await response.json() as MailpitInbox;
+}
+
+async function fetchMessagesForRecipient(request: APIRequestContext, recipient: string): Promise<MailpitMessage[]> {
+    const inbox = await fetchInbox(request);
+
+    return (inbox.messages ?? []).filter((entry) => {
+        return entry.To?.some((address) => address.Address === recipient);
     });
+}
 
-    const tomorrowReminder = inbox.messages?.find((message) => {
-        return message.To?.some((recipient) => recipient.Address === 'reminder-tomorrow@example.com');
-    });
+async function waitForSingleMessageForRecipient(request: APIRequestContext, recipient: string): Promise<MailpitMessageDetails> {
+    await expect.poll(async () => {
+        return (await fetchMessagesForRecipient(request, recipient)).length;
+    }, {
+        message: `Expected exactly one Mailpit message for ${recipient}`,
+    }).toBe(1);
 
-    expect(todayReminder?.Subject).toContain('ist heute');
-    expect(todayReminder?.Snippet).toContain('heute stattfindet');
+    const [message] = await fetchMessagesForRecipient(request, recipient);
 
-    expect(tomorrowReminder?.Subject).toContain('ist morgen');
-    expect(tomorrowReminder?.Snippet).toContain('morgen stattfindet');
+    expect(message, `Expected a Mailpit message for ${recipient}`).toBeTruthy();
+
+    const response = await request.get(`${mailpitBaseUrl}/api/v1/message/${message!.ID}`);
+
+    return await response.json() as MailpitMessageDetails;
+}
+
+function extractFirstPortalUrl(content: string | undefined): string | null {
+    if (!content) {
+        return null;
+    }
+
+    const normalizedContent = content.replace(/&amp;/g, '&');
+    const match = normalizedContent.match(/http:\/\/localhost\/my-portal\/[A-Za-z0-9]+/);
+
+    return match ? match[0] : null;
+}
+
+test('pre-shift reminders include relative-day wording and portal CTA links', async ({ page, request }) => {
+    const todayReminder = await waitForSingleMessageForRecipient(request, 'reminder-today@example.com');
+    const tomorrowReminder = await waitForSingleMessageForRecipient(request, 'reminder-tomorrow@example.com');
+    const soonReminder = await waitForSingleMessageForRecipient(request, 'reminder-soon@example.com');
+
+    expect(todayReminder.Subject).toContain('ist heute');
+    expect(todayReminder.Text).toContain('heute stattfindet');
+    expect(todayReminder.HTML).toContain('Portal öffnen');
+    expect(todayReminder.HTML).toMatch(/http:\/\/localhost\/my-portal\/[A-Za-z0-9]+/);
+
+    expect(tomorrowReminder.Subject).toContain('ist morgen');
+    expect(tomorrowReminder.Text).toContain('morgen stattfindet');
+    expect(tomorrowReminder.HTML).toContain('Portal öffnen');
+    expect(tomorrowReminder.HTML).toMatch(/http:\/\/localhost\/my-portal\/[A-Za-z0-9]+/);
+
+    expect(soonReminder.Subject).toContain('beginnt bald');
+    expect(soonReminder.Text).toContain('beginnt heute in wenigen Stunden');
+    expect(soonReminder.HTML).toContain('Portal öffnen');
+    expect(soonReminder.HTML).toMatch(/http:\/\/localhost\/my-portal\/[A-Za-z0-9]+/);
+
+    const todayPortalUrl = extractFirstPortalUrl(todayReminder.HTML);
+
+    expect(todayPortalUrl).not.toBeNull();
+
+    await page.goto(todayPortalUrl!);
+    await expect(page.getByRole('heading', { name: 'Your Portal' })).toBeVisible();
+    await expect(page.getByText('Welcome back, Heute Erinnerung')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Upcoming Shifts' })).toBeVisible();
+    await expect(page.getByText('Today Reminder Job').first()).toBeVisible();
 });

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -721,6 +721,7 @@ vendor/bin/sail artisan tinker --execute="
     \App\Models\Volunteer::whereIn('email', [
       'reminder-today@example.com',
       'reminder-tomorrow@example.com',
+      'reminder-soon@example.com',
     ])->delete();
 
     \$reminderProject = Project::factory()->for(\$organization)->create([
@@ -745,6 +746,11 @@ vendor/bin/sail artisan tinker --execute="
       'name' => 'Tomorrow Reminder Job',
     ]);
 
+    \$reminderSoonJob = VolunteerJob::factory()->create([
+      'event_id' => \$reminderEvent->id,
+      'name' => 'Soon Reminder Job',
+    ]);
+
     \$todayReminderShift = Shift::factory()->create([
       'volunteer_job_id' => \$reminderTodayJob->id,
       'shift_date' => '2026-07-01',
@@ -761,6 +767,14 @@ vendor/bin/sail artisan tinker --execute="
       'display_text' => 'Jul 02, 00:30 - 02:30',
     ]);
 
+    \$soonReminderShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reminderSoonJob->id,
+      'shift_date' => '2026-07-01',
+      'starts_at' => \Carbon\Carbon::parse('2026-07-01 10:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-07-01 12:00:00', 'UTC'),
+      'display_text' => 'Jul 01, 12:00 - 14:00',
+    ]);
+
     \$todayReminderVolunteer = Volunteer::factory()->verified()->for(\$reminderProject)->create([
       'first_name' => 'Heute',
       'last_name' => 'Erinnerung',
@@ -773,6 +787,13 @@ vendor/bin/sail artisan tinker --execute="
       'last_name' => 'Erinnerung',
       'email' => 'reminder-tomorrow@example.com',
       'phone' => '+491700000200',
+    ]);
+
+    \$soonReminderVolunteer = Volunteer::factory()->verified()->for(\$reminderProject)->create([
+      'first_name' => 'Bald',
+      'last_name' => 'Erinnerung',
+      'email' => 'reminder-soon@example.com',
+      'phone' => '+491700000300',
     ]);
 
     ShiftSignup::factory()->create([
@@ -789,7 +810,15 @@ vendor/bin/sail artisan tinker --execute="
       'notification_4h_sent' => false,
     ]);
 
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$soonReminderVolunteer->id,
+      'shift_id' => \$soonReminderShift->id,
+      'notification_24h_sent' => true,
+      'notification_4h_sent' => false,
+    ]);
+
     app(SendPreShiftReminders::class)->execute(ReminderWindow::TwentyFourHour);
+    app(SendPreShiftReminders::class)->execute(ReminderWindow::FourHour);
 
     \Carbon\Carbon::setTestNow();
 
@@ -846,6 +875,83 @@ vendor/bin/sail artisan tinker --execute="
       'capacity' => 10,
     ]);
 
+    \App\Models\Project::where('name', 'E2E Guest List Reliability Project')->delete();
+
+    \$guestListProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Guest List Reliability Project',
+    ]);
+
+    \$guestListScanner = ProjectScanner::factory()->for(\$guestListProject)->create([
+      'name' => 'E2E Guest List Reliability Scanner',
+      'type' => ScannerType::EntryStaff,
+    ]);
+
+    \$guestList = GuestList::factory()->for(\$guestListProject)->for(\$guestListScanner, 'scanner')->confirmed()->create([
+      'name' => 'E2E Guest Invitation Reliability',
+    ]);
+
+    \$draftGuestList = GuestList::factory()->for(\$guestListProject)->for(\$guestListScanner, 'scanner')->create([
+      'name' => 'E2E Draft Guest Invitation List',
+    ]);
+
+    \$repairGroup = GuestGroup::factory()->for(\$guestList)->create([
+      'label' => 'Repair Group',
+      'guest_count' => 2,
+    ]);
+
+    GuestEntry::factory()->for(\$repairGroup, 'group')->withQrToken()->create([
+      'number' => 1,
+      'name' => 'Repair One',
+      'email' => 'repair@example.com',
+      'invitation_failed_at' => now()->subMinutes(10),
+    ]);
+
+    GuestEntry::factory()->for(\$repairGroup, 'group')->withQrToken()->create([
+      'number' => 2,
+      'name' => 'Repair Two',
+      'email' => 'repair@example.com',
+      'invitation_failed_at' => now()->subMinutes(10),
+    ]);
+
+    \$retryGroup = GuestGroup::factory()->for(\$guestList)->create([
+      'label' => 'Retry Group',
+      'guest_count' => 1,
+    ]);
+
+    GuestEntry::factory()->for(\$retryGroup, 'group')->withQrToken()->create([
+      'number' => 1,
+      'name' => 'Retry Guest',
+      'email' => 'retry@example.com',
+      'invitation_failed_at' => now()->subMinutes(5),
+    ]);
+
+    \$pendingGroup = GuestGroup::factory()->for(\$guestList)->create([
+      'label' => 'Pending Group',
+      'guest_count' => 1,
+    ]);
+
+    GuestEntry::factory()->for(\$pendingGroup, 'group')->withQrToken()->create([
+      'number' => 1,
+      'name' => 'Pending Guest',
+      'email' => 'pending-invite@example.com',
+    ]);
+
+    \$sentGroup = GuestGroup::factory()->for(\$guestList)->create([
+      'label' => 'Sent Group',
+      'guest_count' => 1,
+    ]);
+
+    \$sentEntry = GuestEntry::factory()->for(\$sentGroup, 'group')->withQrToken()->create([
+      'number' => 1,
+      'name' => 'Sent Guest',
+      'email' => 'sent-invite@example.com',
+      'invitation_sent_at' => now()->subMinutes(30),
+    ]);
+
+    \Illuminate\Support\Facades\Mail::to('sent-invite@example.com')->send(
+      new \App\Mail\GuestInvitationMail(\$guestList, new \Illuminate\Database\Eloquent\Collection([\$sentEntry]))
+    );
+
     file_put_contents(base_path('public/e2e-fixtures.json'), json_encode([
       'entryPoolProjectId' => \$entryPoolProject->id,
       'entryPoolEntryEventId' => \$entryEvent->id,
@@ -865,6 +971,10 @@ vendor/bin/sail artisan tinker --execute="
       'signupGraceEventId' => \$signupGraceEvent->id,
       'signupGracePublicToken' => 'e2e-signup-grace-token',
       'signupGraceVerificationHash' => \$signupGraceVerificationHash,
+      'guestListReliabilityProjectId' => \$guestListProject->id,
+      'guestListReliabilityGuestListId' => \$guestList->id,
+      'guestListReliabilityDraftGuestListId' => \$draftGuestList->id,
+      'guestListReliabilitySentInviteEmail' => 'sent-invite@example.com',
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   });
 

--- a/resources/views/livewire/projects/guest-list-show.blade.php
+++ b/resources/views/livewire/projects/guest-list-show.blade.php
@@ -1,4 +1,9 @@
-<div class="mx-auto max-w-7xl p-6">
+<div
+    class="mx-auto max-w-7xl p-6"
+    x-data
+    x-on:guest-entry-edit-opened.window="$nextTick(() => document.getElementById($event.detail.inputId)?.focus())"
+    x-on:guest-list-feedback.window="$nextTick(() => document.getElementById('guest-list-feedback')?.focus())"
+>
     <div class="flex items-center justify-between mb-6">
         <div class="flex items-center gap-3">
             <flux:button variant="ghost" icon="arrow-left" :href="route('guest-lists.index', ['projectId' => $projectId])" wire:navigate aria-label="{{ __('Back to guest lists') }}" />
@@ -9,8 +14,8 @@
         </div>
         <div class="flex gap-2">
             @if ($this->guestList->isDraft())
-                <flux:button variant="primary" wire:click="confirmGuestList" wire:confirm="{{ __('Confirm this guest list? QR codes will be generated for all entries.') }}">
-                    {{ __('Confirm') }}
+                <flux:button variant="primary" wire:click="confirmGuestList" wire:confirm="{{ __('Activate sending for this guest list? QR codes will be generated for all entries, and new guests with an email address will keep receiving invitations automatically.') }}">
+                    {{ __('Activate Sending') }}
                 </flux:button>
             @endif
             @if ($this->guestList->isConfirmed() && $this->pendingInvitationCount > 0)
@@ -29,11 +34,11 @@
     <x-projects.layout :project="$project">
 
     @if (session('message'))
-        <flux:callout variant="success" class="mb-4">{{ session('message') }}</flux:callout>
+        <flux:callout id="guest-list-feedback" variant="success" class="mb-4" tabindex="-1" role="status" aria-live="polite" aria-atomic="true">{{ session('message') }}</flux:callout>
     @endif
 
     @if (session('error'))
-        <flux:callout variant="danger" class="mb-4">{{ session('error') }}</flux:callout>
+        <flux:callout id="guest-list-feedback" variant="danger" class="mb-4" tabindex="-1" role="alert" aria-live="assertive" aria-atomic="true">{{ session('error') }}</flux:callout>
     @endif
 
     {{-- Summary bar --}}
@@ -92,7 +97,7 @@
                             <flux:button size="sm" variant="ghost" icon="plus" wire:click="addEntry({{ $group->id }})" title="{{ __('Add entry') }}">
                                 {{ __('Add Entry') }}
                             </flux:button>
-                            <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeGroup({{ $group->id }})" wire:confirm="{{ __('Delete this group and all its entries?') }}" title="{{ __('Delete group') }}" />
+                            <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeGroup({{ $group->id }})" wire:confirm="{{ __('Delete this group and all its entries?') }}" title="{{ __('Delete group') }}" aria-label="{{ __('Delete group :label', ['label' => $group->label]) }}" />
                         </div>
                     </div>
 
@@ -106,6 +111,7 @@
                                         <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Email') }}</th>
                                         <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Gear') }}</th>
                                         <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('QR') }}</th>
+                                        <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Invitation') }}</th>
                                         <th scope="col" class="py-2 pr-4 font-medium text-zinc-500">{{ __('Status') }}</th>
                                         <th scope="col" class="sr-only py-2 font-medium text-zinc-500">{{ __('Actions') }}</th>
                                     </tr>
@@ -117,15 +123,29 @@
                                                 {{-- Inline edit mode --}}
                                                 <td class="py-2 pr-4">{{ $entry->number }}</td>
                                                 <td class="py-2 pr-4">
-                                                    <flux:input wire:model="entryName" size="sm" placeholder="{{ __('Name') }}" />
+                                                    <flux:label for="entry-name-{{ $entry->id }}" class="sr-only">{{ __('Guest name') }}</flux:label>
+                                                    <flux:input id="entry-name-{{ $entry->id }}" wire:model="entryName" size="sm" placeholder="{{ __('Name') }}" />
                                                     <flux:error name="entryName" />
                                                 </td>
                                                 <td class="py-2 pr-4">
-                                                    <flux:input wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" />
+                                                    <flux:label for="entry-email-{{ $entry->id }}" class="sr-only">{{ __('Guest email') }}</flux:label>
+                                                    <flux:input id="entry-email-{{ $entry->id }}" wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" @if ($entry->isInvitationFailed()) aria-describedby="entry-email-recovery-{{ $entry->id }}" @endif />
                                                     <flux:error name="entryEmail" />
+                                                    @if ($entry->isInvitationFailed())
+                                                        <p id="entry-email-recovery-{{ $entry->id }}" class="sr-only">{{ __('Saving a new email will resend this failed recipient group.') }}</p>
+                                                    @endif
                                                 </td>
                                                 <td class="py-2 pr-4">&mdash;</td>
                                                 <td class="py-2 pr-4">&mdash;</td>
+                                                <td class="py-2 pr-4">
+                                                    @if ($entry->isInvitationFailed())
+                                                        <p class="text-xs text-red-600 dark:text-red-400">
+                                                            {{ __('Saving a new email will resend this recipient group.') }}
+                                                        </p>
+                                                    @else
+                                                        &mdash;
+                                                    @endif
+                                                </td>
                                                 <td class="py-2 pr-4">&mdash;</td>
                                                 <td class="py-2 text-right">
                                                     <div class="flex gap-1 justify-end">
@@ -153,6 +173,24 @@
                                                     @endif
                                                 </td>
                                                 <td class="py-2 pr-4">
+                                                    @php($invitationStatus = $entry->invitationStatus())
+
+                                                    @if ($invitationStatus === 'sent')
+                                                        <flux:badge size="sm" color="emerald">{{ __('Sent') }}</flux:badge>
+                                                    @elseif ($invitationStatus === 'queued')
+                                                        <flux:badge size="sm" color="sky">{{ __('Queued') }}</flux:badge>
+                                                    @elseif ($invitationStatus === 'failed')
+                                                        <div class="space-y-1">
+                                                            <flux:badge size="sm" color="red">{{ __('Failed') }}</flux:badge>
+                                                            <p class="text-xs text-red-600 dark:text-red-400">{{ __('Fix the email or resend this recipient group.') }}</p>
+                                                        </div>
+                                                    @elseif ($invitationStatus === 'pending')
+                                                        <flux:badge size="sm" color="amber">{{ __('Pending') }}</flux:badge>
+                                                    @else
+                                                        <flux:badge size="sm" color="zinc">{{ __('No email') }}</flux:badge>
+                                                    @endif
+                                                </td>
+                                                <td class="py-2 pr-4">
                                                     @if ($entry->isCheckedIn())
                                                         <flux:badge size="sm" color="emerald">{{ __('Checked in') }}</flux:badge>
                                                     @else
@@ -161,8 +199,13 @@
                                                 </td>
                                                 <td class="py-2 text-right">
                                                     <div class="flex gap-1 justify-end">
-                                                        <flux:button size="sm" variant="ghost" icon="pencil" wire:click="startEditEntry({{ $entry->id }})" title="{{ __('Edit') }}" />
-                                                        <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeEntry({{ $entry->id }})" wire:confirm="{{ __('Remove this entry?') }}" title="{{ __('Remove') }}" />
+                                                        @if ($entry->isInvitationFailed())
+                                                            <flux:button size="sm" variant="ghost" wire:click="resendFailedInvitation({{ $entry->id }})" aria-label="{{ __('Resend failed invitation for :email', ['email' => $entry->email]) }}">
+                                                                {{ __('Resend') }}
+                                                            </flux:button>
+                                                        @endif
+                                                        <flux:button size="sm" variant="ghost" icon="pencil" wire:click="startEditEntry({{ $entry->id }})" title="{{ __('Edit') }}" aria-label="{{ __('Edit guest entry :number', ['number' => $entry->number]) }}" />
+                                                        <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeEntry({{ $entry->id }})" wire:confirm="{{ __('Remove this entry?') }}" title="{{ __('Remove') }}" aria-label="{{ __('Remove guest entry :number', ['number' => $entry->number]) }}" />
                                                     </div>
                                                 </td>
                                             @endif

--- a/resources/views/livewire/projects/guest-list-show.blade.php
+++ b/resources/views/livewire/projects/guest-list-show.blade.php
@@ -129,7 +129,11 @@
                                                 </td>
                                                 <td class="py-2 pr-4">
                                                     <flux:label for="entry-email-{{ $entry->id }}" class="sr-only">{{ __('Guest email') }}</flux:label>
-                                                    <flux:input id="entry-email-{{ $entry->id }}" wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" @if ($entry->isInvitationFailed()) aria-describedby="entry-email-recovery-{{ $entry->id }}" @endif />
+                                                    @if ($entry->isInvitationFailed())
+                                                        <flux:input id="entry-email-{{ $entry->id }}" wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" aria-describedby="entry-email-recovery-{{ $entry->id }}" />
+                                                    @else
+                                                        <flux:input id="entry-email-{{ $entry->id }}" wire:model="entryEmail" size="sm" type="email" placeholder="{{ __('Email') }}" />
+                                                    @endif
                                                     <flux:error name="entryEmail" />
                                                     @if ($entry->isInvitationFailed())
                                                         <p id="entry-email-recovery-{{ $entry->id }}" class="sr-only">{{ __('Saving a new email will resend this failed recipient group.') }}</p>

--- a/resources/views/mail/guest-invitation.blade.php
+++ b/resources/views/mail/guest-invitation.blade.php
@@ -13,9 +13,11 @@ Name: {{ $entry->name }}
 
 {!! $entry->qrCodeSvg() !!}
 
-If the QR code is not visible in your email app, open this pass in your browser.
+{{ __('If the QR code is not visible in your email app, open this pass in your browser.') }}
 
-<a href="{{ $entry->guestPassUrl() }}">{{ $entry->guestPassUrl() }}</a>
+<x-mail::button :url="$entry->guestPassUrl()">
+{{ __('Open Guest Pass') }}
+</x-mail::button>
 
 @endforeach
 

--- a/tests/Feature/Actions/AddGuestEntryTest.php
+++ b/tests/Feature/Actions/AddGuestEntryTest.php
@@ -36,6 +36,9 @@ it('adds entry to confirmed list and generates QR token and dispatches email', f
     Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
         return $job->email === 'vip@example.com';
     });
+
+    expect($entry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull();
 });
 
 it('adds entry to confirmed list without email and skips email dispatch', function () {

--- a/tests/Feature/Actions/QueueGuestInvitationSiblingSetTest.php
+++ b/tests/Feature/Actions/QueueGuestInvitationSiblingSetTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Actions\QueueGuestInvitationSiblingSet;
+use App\Jobs\SendGuestInvitationsJob;
+use App\Models\GuestEntry;
+use App\Models\GuestGroup;
+use App\Models\GuestList;
+use Illuminate\Support\Facades\Queue;
+
+it('claims a pending recipient sibling set only once before dispatching', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'pending@example.com',
+    ]);
+    GuestEntry::factory()->for($group, 'group')->create([
+        'number' => 2,
+        'email' => 'pending@example.com',
+        'qr_token' => null,
+    ]);
+
+    $action = new QueueGuestInvitationSiblingSet;
+
+    expect($action->claimPending($guestList, 'pending@example.com'))->toBeTrue()
+        ->and($action->claimPending($guestList, 'pending@example.com'))->toBeFalse();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, 1);
+
+    $entries = GuestEntry::where('email', 'pending@example.com')->orderBy('number')->get();
+
+    expect($entries[0]->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($entries[1]->fresh()->invitation_queued_at)->toBeNull();
+});
+
+it('resends only terminal failed rows for a failed recipient sibling set', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
+
+    $failedEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'shared@example.com',
+        'invitation_failed_at' => now()->subMinute(),
+    ]);
+    $sentEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 2,
+        'email' => 'shared@example.com',
+        'invitation_sent_at' => now()->subMinutes(5),
+    ]);
+    $queuedEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 3,
+        'email' => 'shared@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+
+    $action = new QueueGuestInvitationSiblingSet;
+
+    expect($action->claimFailed($guestList, 'shared@example.com'))->toBeTrue()
+        ->and($action->claimFailed($guestList, 'shared@example.com'))->toBeFalse();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function (SendGuestInvitationsJob $job) use ($failedEntry, $sentEntry, $queuedEntry) {
+        return $job->email === 'shared@example.com'
+            && $job->guestEntryIds === [$failedEntry->id]
+            && ! in_array($sentEntry->id, $job->guestEntryIds, true)
+            && ! in_array($queuedEntry->id, $job->guestEntryIds, true);
+    });
+
+    expect($failedEntry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($failedEntry->fresh()->invitation_failed_at)->toBeNull()
+        ->and($sentEntry->fresh()->invitation_sent_at)->not->toBeNull()
+        ->and($sentEntry->fresh()->invitation_queued_at)->toBeNull()
+        ->and($queuedEntry->fresh()->invitation_queued_at)->not->toBeNull();
+});
+
+it('restores pending rows when dispatch throws after claiming', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1]);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'pending@example.com',
+    ]);
+
+    $action = new class extends QueueGuestInvitationSiblingSet
+    {
+        protected function dispatchClaimedJob(GuestList $guestList, string $email, array $claimedEntryIds): void
+        {
+            throw new RuntimeException('queue connection down');
+        }
+    };
+
+    expect(fn () => $action->claimPending($guestList, 'pending@example.com'))
+        ->toThrow(RuntimeException::class);
+
+    expect($entry->fresh()->invitation_queued_at)->toBeNull()
+        ->and($entry->fresh()->invitation_failed_at)->toBeNull()
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull();
+});
+
+it('restores failed rows to failed state when dispatch throws after a resend claim', function () {
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1]);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now()->subMinute(),
+    ]);
+
+    $action = new class extends QueueGuestInvitationSiblingSet
+    {
+        protected function dispatchClaimedJob(GuestList $guestList, string $email, array $claimedEntryIds): void
+        {
+            throw new RuntimeException('queue connection down');
+        }
+    };
+
+    expect(fn () => $action->claimFailed($guestList, 'failed@example.com'))
+        ->toThrow(RuntimeException::class);
+
+    expect($entry->fresh()->invitation_queued_at)->toBeNull()
+        ->and($entry->fresh()->invitation_failed_at)->not->toBeNull();
+});

--- a/tests/Feature/Actions/SendPreShiftRemindersTest.php
+++ b/tests/Feature/Actions/SendPreShiftRemindersTest.php
@@ -4,6 +4,7 @@ use App\Actions\SendPreShiftReminders;
 use App\Enums\EventStatus;
 use App\Enums\ReminderWindow;
 use App\Models\Event;
+use App\Models\MagicLinkToken;
 use App\Models\Organization;
 use App\Models\Shift;
 use App\Models\ShiftSignup;
@@ -17,7 +18,7 @@ beforeEach(function () {
     $this->org = Organization::factory()->create();
     $this->event = Event::factory()->for($this->org)->create(['status' => EventStatus::PublishedOpen]);
     $this->job = VolunteerJob::factory()->for($this->event)->create();
-    $this->action = new SendPreShiftReminders;
+    $this->action = app(SendPreShiftReminders::class);
 });
 
 function createSignupWithShiftStartingIn(int $hours, array $overrides = []): ShiftSignup
@@ -37,7 +38,13 @@ it('sends 24h reminders for shifts starting within 24 hours', function () {
     $count = $this->action->execute(ReminderWindow::TwentyFourHour);
 
     expect($count)->toBe(1);
-    Notification::assertSentTo($signup->volunteer, PreShiftReminder::class);
+    Notification::assertSentTo($signup->volunteer, PreShiftReminder::class, function (PreShiftReminder $notification) {
+        expect($notification->magicLinkToken)->not->toBe('');
+
+        return true;
+    });
+    expect(MagicLinkToken::where('volunteer_id', $signup->volunteer_id)->count())->toBe(1)
+        ->and(MagicLinkToken::where('volunteer_id', $signup->volunteer_id)->first()->expires_at)->toBeNull();
     expect($signup->fresh()->notification_24h_sent)->toBeTrue();
 });
 
@@ -176,4 +183,28 @@ it('returns correct count', function () {
     $count = $this->action->execute(ReminderWindow::TwentyFourHour);
 
     expect($count)->toBe(2);
+});
+
+it('generates a fresh magic-link token for each reminder send', function () {
+    $signup24h = createSignupWithShiftStartingIn(20);
+    $signup4h = createSignupWithShiftStartingIn(3, [
+        'volunteer_id' => $signup24h->volunteer_id,
+    ]);
+
+    $this->action->execute(ReminderWindow::TwentyFourHour);
+    $this->action->execute(ReminderWindow::FourHour);
+
+    $tokens = [];
+
+    Notification::assertSentToTimes($signup24h->volunteer, PreShiftReminder::class, 3);
+    Notification::assertSentTo($signup24h->volunteer, PreShiftReminder::class, function (PreShiftReminder $notification) use (&$tokens) {
+        $tokens[] = $notification->magicLinkToken;
+
+        return true;
+    });
+
+    expect($tokens)->toHaveCount(3)
+        ->and(array_unique($tokens))->toHaveCount(3)
+        ->and(MagicLinkToken::where('volunteer_id', $signup24h->volunteer_id)->count())->toBe(3)
+        ->and($signup4h->fresh()->notification_4h_sent)->toBeTrue();
 });

--- a/tests/Feature/Actions/UpdateGuestEntryTest.php
+++ b/tests/Feature/Actions/UpdateGuestEntryTest.php
@@ -87,6 +87,9 @@ it('dispatches email when email is added to entry on confirmed list', function (
     Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
         return $job->email === 'newguest@example.com';
     });
+
+    expect($entry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull();
 });
 
 it('dispatches email when email is changed on confirmed list', function () {
@@ -104,6 +107,113 @@ it('dispatches email when email is changed on confirmed list', function () {
     Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
         return $job->email === 'new@example.com';
     });
+});
+
+it('resets sent state and queues a fresh invite when a confirmed sent row changes email', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'sent@example.com',
+        'invitation_sent_at' => now()->subMinute(),
+    ]);
+
+    (new UpdateGuestEntry)->execute($entry, ['email' => 'fresh@example.com']);
+
+    expect($entry->fresh()->email)->toBe('fresh@example.com')
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull()
+        ->and($entry->fresh()->invitation_queued_at)->not->toBeNull();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'fresh@example.com' && $job->guestEntryIds === [$entry->id]);
+});
+
+it('resets queued state and queues the moved row for the new email on confirmed lists', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'queued@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+
+    (new UpdateGuestEntry)->execute($entry, ['email' => 'moved@example.com']);
+
+    expect($entry->fresh()->email)->toBe('moved@example.com')
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull()
+        ->and($entry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($entry->fresh()->invitation_failed_at)->toBeNull();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'moved@example.com' && $job->guestEntryIds === [$entry->id]);
+});
+
+it('updates the full failed sibling set email before requeueing a corrected resend', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'broken@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'broken@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+
+    (new UpdateGuestEntry)->execute($entry, ['email' => 'fixed@example.com']);
+
+    expect(GuestEntry::where('guest_group_id', $group->id)->where('email', 'fixed@example.com')->count())->toBe(2)
+        ->and(GuestEntry::where('guest_group_id', $group->id)->whereNotNull('invitation_queued_at')->count())->toBe(2)
+        ->and(GuestEntry::where('guest_group_id', $group->id)->whereNotNull('invitation_failed_at')->count())->toBe(0);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'fixed@example.com');
+});
+
+it('only rewrites failed rows when correcting a failed sibling set with same-email drift present', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $failedEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'shared@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+    $sentEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'shared@example.com',
+        'invitation_sent_at' => now()->subMinute(),
+    ]);
+
+    (new UpdateGuestEntry)->execute($failedEntry, ['email' => 'fixed@example.com']);
+
+    expect($failedEntry->fresh()->email)->toBe('fixed@example.com')
+        ->and($failedEntry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($sentEntry->fresh()->email)->toBe('shared@example.com')
+        ->and($sentEntry->fresh()->invitation_sent_at)->not->toBeNull();
+});
+
+it('only requeues the corrected failed rows when the new email already exists elsewhere in the guest list', function () {
+    Queue::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create();
+    $failedEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'broken@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+    $existingSentEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'shared@example.com',
+        'invitation_sent_at' => now()->subMinute(),
+    ]);
+
+    (new UpdateGuestEntry)->execute($failedEntry, ['email' => 'shared@example.com']);
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'shared@example.com' && $job->guestEntryIds === [$failedEntry->id]);
+
+    expect($failedEntry->fresh()->email)->toBe('shared@example.com')
+        ->and($failedEntry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($existingSentEntry->fresh()->invitation_sent_at)->not->toBeNull();
 });
 
 it('does not dispatch email when email is updated on draft list', function () {

--- a/tests/Feature/GuestListLifecycleTest.php
+++ b/tests/Feature/GuestListLifecycleTest.php
@@ -66,10 +66,18 @@ it('completes full lifecycle: create list -> add groups -> add entries with gear
     // Only 1 unique email, so 1 invitation job
     Queue::assertPushed(SendGuestInvitationsJob::class, 1);
 
+    expect($guestList->entries()->where('email', 'manager@example.com')->whereNull('invitation_queued_at')->count())->toBe(0);
+
     // 6. Run the invitation job to send email
     Queue::fake();
-    (new SendGuestInvitationsJob($guestList, 'manager@example.com'))->handle();
+    (new SendGuestInvitationsJob(
+        $guestList,
+        'manager@example.com',
+        $guestList->entries()->where('email', 'manager@example.com')->pluck('guest_entries.id')->all(),
+    ))->handle();
     Mail::assertSent(GuestInvitationMail::class, function (GuestInvitationMail $mail) {
+        $mail->assertSeeInHtml(__('Open Guest Pass'));
+
         return $mail->hasTo('manager@example.com')
             && $mail->entries->count() === 1;
     });
@@ -115,6 +123,9 @@ it('post-confirm: adding entry generates QR immediately and dispatches email', f
     Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
         return $job->email === 'late@example.com';
     });
+
+    expect($newEntry->fresh()->invitation_queued_at)->not->toBeNull()
+        ->and($newEntry->fresh()->invitation_sent_at)->toBeNull();
 });
 
 it('post-confirm removal: removed entry QR becomes invalid for check-in via API', function () {

--- a/tests/Feature/Jobs/ConfirmGuestListJobTest.php
+++ b/tests/Feature/Jobs/ConfirmGuestListJobTest.php
@@ -40,8 +40,17 @@ it('dispatches one SendGuestInvitationsJob per unique email', function () {
     $job->handle();
 
     Queue::assertPushed(SendGuestInvitationsJob::class, 1);
-    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) {
-        return $job->email === 'dj@example.com';
+    $claimedEntryIds = GuestEntry::where('email', 'dj@example.com')->pluck('id')->all();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, function ($job) use ($claimedEntryIds) {
+        return $job->email === 'dj@example.com'
+            && $job->guestEntryIds === $claimedEntryIds;
+    });
+
+    GuestEntry::where('email', 'dj@example.com')->each(function (GuestEntry $entry) {
+        expect($entry->fresh()->invitation_queued_at)->not->toBeNull()
+            ->and($entry->fresh()->invitation_sent_at)->toBeNull()
+            ->and($entry->fresh()->invitation_failed_at)->toBeNull();
     });
 });
 
@@ -74,4 +83,37 @@ it('skips if guest list is not confirmed', function () {
 
     expect(GuestEntry::whereNotNull('qr_token')->count())->toBe(0);
     Queue::assertNothingPushed();
+});
+
+it('does not requeue failed or already queued recipient sibling sets during bulk confirmation dispatch', function () {
+    Queue::fake([SendGuestInvitationsJob::class]);
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
+
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'pending@example.com',
+    ]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 2,
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now()->subMinute(),
+    ]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 3,
+        'email' => 'queued@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+
+    GuestEntry::factory()->for($group, 'group')->create([
+        'number' => 4,
+        'email' => 'pending@example.com',
+        'qr_token' => null,
+    ]);
+
+    (new ConfirmGuestListJob($guestList))->handle();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, 1);
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'pending@example.com');
 });

--- a/tests/Feature/Jobs/SendGuestInvitationsJobTest.php
+++ b/tests/Feature/Jobs/SendGuestInvitationsJobTest.php
@@ -5,6 +5,7 @@ use App\Mail\GuestInvitationMail;
 use App\Models\GuestEntry;
 use App\Models\GuestGroup;
 use App\Models\GuestList;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
 
 it('sends grouped email with all QR codes for matching entries', function () {
@@ -12,16 +13,27 @@ it('sends grouped email with all QR codes for matching entries', function () {
 
     $guestList = GuestList::factory()->confirmed()->create();
     $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 3]);
-    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1, 'email' => 'dj@example.com']);
-    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 2, 'email' => 'dj@example.com']);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 1, 'email' => 'dj@example.com', 'invitation_queued_at' => now()->subMinute()]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 2, 'email' => 'dj@example.com', 'invitation_queued_at' => now()->subMinute()]);
     GuestEntry::factory()->for($group, 'group')->withQrToken()->create(['number' => 3, 'email' => null]);
 
-    $job = new SendGuestInvitationsJob($guestList, 'dj@example.com');
+    $claimedEntries = GuestEntry::where('email', 'dj@example.com')->pluck('id')->all();
+
+    $job = new SendGuestInvitationsJob($guestList, 'dj@example.com', $claimedEntries);
     $job->handle();
 
     Mail::assertSent(GuestInvitationMail::class, function (GuestInvitationMail $mail) {
+        $mail->assertSeeInHtml(__('If the QR code is not visible in your email app, open this pass in your browser.'))
+            ->assertSeeInHtml(__('Open Guest Pass'));
+
         return $mail->hasTo('dj@example.com')
             && $mail->entries->count() === 2;
+    });
+
+    GuestEntry::where('email', 'dj@example.com')->each(function (GuestEntry $entry) {
+        expect($entry->fresh()->invitation_sent_at)->not->toBeNull()
+            ->and($entry->fresh()->invitation_queued_at)->toBeNull()
+            ->and($entry->fresh()->invitation_failed_at)->toBeNull();
     });
 });
 
@@ -30,10 +42,37 @@ it('skips when no entries match the email', function () {
 
     $guestList = GuestList::factory()->confirmed()->create();
 
-    $job = new SendGuestInvitationsJob($guestList, 'nobody@example.com');
+    $job = new SendGuestInvitationsJob($guestList, 'nobody@example.com', []);
     $job->handle();
 
     Mail::assertNothingSent();
+});
+
+it('marks the full recipient sibling set as failed after retries are exhausted', function () {
+    Carbon::setTestNow(now());
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'failed@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+    GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 2,
+        'email' => 'failed@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+
+    $job = new SendGuestInvitationsJob($guestList, 'failed@example.com', GuestEntry::where('email', 'failed@example.com')->pluck('id')->all());
+    $job->failed(new RuntimeException('SMTP down'));
+
+    GuestEntry::where('email', 'failed@example.com')->each(function (GuestEntry $entry) {
+        expect($entry->fresh()->invitation_failed_at)->not->toBeNull()
+            ->and($entry->fresh()->invitation_queued_at)->toBeNull()
+            ->and($entry->fresh()->invitation_sent_at)->toBeNull();
+    });
 });
 
 it('skips entries without qr_token', function () {
@@ -41,10 +80,62 @@ it('skips entries without qr_token', function () {
 
     $guestList = GuestList::factory()->confirmed()->create();
     $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1]);
-    GuestEntry::factory()->for($group, 'group')->create(['number' => 1, 'email' => 'test@example.com', 'qr_token' => null]);
+    GuestEntry::factory()->for($group, 'group')->create(['number' => 1, 'email' => 'test@example.com', 'qr_token' => null, 'invitation_queued_at' => now()->subMinute()]);
 
-    $job = new SendGuestInvitationsJob($guestList, 'test@example.com');
+    $job = new SendGuestInvitationsJob($guestList, 'test@example.com', GuestEntry::where('email', 'test@example.com')->pluck('id')->all());
     $job->handle();
 
     Mail::assertNothingSent();
+});
+
+it('only updates the exact claimed rows when another same-email row was never eligible', function () {
+    Mail::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 2]);
+    $claimableEntry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'number' => 1,
+        'email' => 'mixed@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+    $notEligibleEntry = GuestEntry::factory()->for($group, 'group')->create([
+        'number' => 2,
+        'email' => 'mixed@example.com',
+        'qr_token' => null,
+    ]);
+
+    $job = new SendGuestInvitationsJob($guestList, 'mixed@example.com', [$claimableEntry->id]);
+    $job->handle();
+
+    expect($claimableEntry->fresh()->invitation_sent_at)->not->toBeNull()
+        ->and($claimableEntry->fresh()->invitation_queued_at)->toBeNull()
+        ->and($notEligibleEntry->fresh()->invitation_sent_at)->toBeNull()
+        ->and($notEligibleEntry->fresh()->invitation_failed_at)->toBeNull()
+        ->and($notEligibleEntry->fresh()->invitation_queued_at)->toBeNull();
+});
+
+it('does not send or mutate rows that moved to a different email after the job was queued', function () {
+    Mail::fake();
+
+    $guestList = GuestList::factory()->confirmed()->create();
+    $group = GuestGroup::factory()->for($guestList)->create(['guest_count' => 1]);
+    $entry = GuestEntry::factory()->for($group, 'group')->withQrToken()->create([
+        'email' => 'old@example.com',
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+
+    $entry->update([
+        'email' => 'new@example.com',
+        'invitation_queued_at' => null,
+    ]);
+
+    $job = new SendGuestInvitationsJob($guestList, 'old@example.com', [$entry->id]);
+    $job->handle();
+    $job->failed(new RuntimeException('stale queued job'));
+
+    Mail::assertNothingSent();
+
+    expect($entry->fresh()->email)->toBe('new@example.com')
+        ->and($entry->fresh()->invitation_sent_at)->toBeNull()
+        ->and($entry->fresh()->invitation_failed_at)->toBeNull();
 });

--- a/tests/Feature/Livewire/GuestListIndexTest.php
+++ b/tests/Feature/Livewire/GuestListIndexTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\GuestListStatus;
 use App\Enums\StaffRole;
 use App\Livewire\Projects\GuestListIndex;
 use App\Models\GuestList;
@@ -63,6 +64,29 @@ it('displays guest lists', function () {
         ->test(GuestListIndex::class, ['projectId' => $this->project->id])
         ->assertSee('Alpha List')
         ->assertSee('Beta List');
+});
+
+it('shows sending status labels for draft and active guest lists', function () {
+    GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Draft List',
+        'status' => GuestListStatus::Draft,
+    ]);
+
+    GuestList::factory()->create([
+        'project_id' => $this->project->id,
+        'scanner_id' => $this->scanner->id,
+        'name' => 'Active List',
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListIndex::class, ['projectId' => $this->project->id])
+        ->assertSee('Sending inactive')
+        ->assertSee('Sending active')
+        ->assertDontSee('Confirmed');
 });
 
 it('shows empty state when no guest lists', function () {

--- a/tests/Feature/Livewire/GuestListShowTest.php
+++ b/tests/Feature/Livewire/GuestListShowTest.php
@@ -13,6 +13,8 @@ use App\Models\Project;
 use App\Models\ProjectScanner;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 
@@ -152,6 +154,7 @@ it('confirms guest list and dispatches job', function () {
             'guestListId' => $this->guestList->id,
         ])
         ->call('confirmGuestList')
+        ->assertSee('Guest list sending is now active. QR codes are being generated.')
         ->assertHasNoErrors();
 
     $this->guestList->refresh();
@@ -159,6 +162,32 @@ it('confirms guest list and dispatches job', function () {
         ->and($this->guestList->confirmed_at)->not->toBeNull();
 
     Queue::assertPushed(ConfirmGuestListJob::class);
+});
+
+it('shows activation wording for draft guest lists', function () {
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertSee('Sending inactive')
+        ->assertSee('Activate Sending')
+        ->assertSee('Activate sending for this guest list? QR codes will be generated for all entries, and new guests with an email address will keep receiving invitations automatically.');
+});
+
+it('shows sending-active status wording for confirmed guest lists', function () {
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertSee('Sending active')
+        ->assertDontSee('Activate Sending');
 });
 
 it('rejects confirming already-confirmed list', function () {
@@ -398,6 +427,18 @@ it('dispatches invitation jobs only for unsent entries when sending pending invi
         'invitation_sent_at' => null,
     ]);
 
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'queued@example.com',
+        'invitation_queued_at' => now(),
+    ]);
+
     Livewire::actingAs($this->organizer)
         ->test(GuestListShow::class, [
             'projectId' => $this->project->id,
@@ -408,9 +449,184 @@ it('dispatches invitation jobs only for unsent entries when sending pending invi
 
     Queue::assertPushed(SendGuestInvitationsJob::class, 2); // 2 unique unsent emails
 
-    // Verify invitation_sent_at was set
     expect(GuestEntry::where('guest_group_id', $group->id)
-        ->whereNotNull('email')
-        ->whereNull('invitation_sent_at')
-        ->count())->toBe(0);
+        ->whereIn('email', ['new1@example.com', 'new2@example.com'])
+        ->whereNull('invitation_queued_at')
+        ->count())->toBe(0)
+        ->and(GuestEntry::where('guest_group_id', $group->id)
+            ->where('email', 'failed@example.com')
+            ->value('invitation_failed_at'))->not->toBeNull();
+});
+
+it('shows failed invitation state and resend action', function () {
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->assertSee('Failed')
+        ->assertSee('Resend');
+});
+
+it('resends a failed invitation sibling set', function () {
+    Queue::fake();
+
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    $entry = GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'failed@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('resendFailedInvitation', $entry->id)
+        ->assertSee('Invitation resend queued for failed@example.com.');
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'failed@example.com');
+
+    GuestEntry::where('email', 'failed@example.com')->each(function (GuestEntry $sibling) {
+        expect($sibling->fresh()->invitation_queued_at)->not->toBeNull()
+            ->and($sibling->fresh()->invitation_failed_at)->toBeNull();
+    });
+});
+
+it('shows an error instead of a false success when failed resend is no longer claimable', function () {
+    Queue::fake();
+
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    $entry = GuestEntry::factory()->create([
+        'guest_group_id' => $group->id,
+        'email' => 'failed@example.com',
+        'qr_token' => null,
+        'invitation_failed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('resendFailedInvitation', $entry->id)
+        ->assertSee('This invitation is no longer available for resend.');
+
+    Queue::assertNothingPushed();
+});
+
+it('shows a success message after saving an entry update', function () {
+    Queue::fake();
+
+    $group = GuestGroup::factory()->create([
+        'guest_list_id' => $this->guestList->id,
+    ]);
+    $entry = GuestEntry::factory()->create([
+        'guest_group_id' => $group->id,
+        'number' => 1,
+        'name' => 'Old Name',
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('startEditEntry', $entry->id)
+        ->set('entryName', 'New Name')
+        ->call('saveEntry')
+        ->assertSee('Guest entry updated.');
+});
+
+it('corrects a failed recipient sibling set email and requeues all siblings together', function () {
+    Queue::fake();
+
+    $this->guestList->update([
+        'status' => GuestListStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    $group = GuestGroup::factory()->create(['guest_list_id' => $this->guestList->id]);
+    $entry = GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'number' => 1,
+        'email' => 'broken@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+    GuestEntry::factory()->withQrToken()->create([
+        'guest_group_id' => $group->id,
+        'number' => 2,
+        'email' => 'broken@example.com',
+        'invitation_failed_at' => now(),
+    ]);
+
+    Livewire::actingAs($this->organizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $this->project->id,
+            'guestListId' => $this->guestList->id,
+        ])
+        ->call('startEditEntry', $entry->id)
+        ->set('entryEmail', 'fixed@example.com')
+        ->call('saveEntry')
+        ->assertHasNoErrors();
+
+    Queue::assertPushed(SendGuestInvitationsJob::class, fn ($job) => $job->email === 'fixed@example.com');
+
+    expect(GuestEntry::where('guest_group_id', $group->id)->where('email', 'fixed@example.com')->count())->toBe(2)
+        ->and(GuestEntry::where('guest_group_id', $group->id)->whereNotNull('invitation_queued_at')->count())->toBe(2)
+        ->and(GuestEntry::where('guest_group_id', $group->id)->whereNotNull('invitation_failed_at')->count())->toBe(0);
+});
+
+it('forbids later actions when guest-list permission is revoked after mount', function () {
+    ['user' => $projectOrganizer, 'organization' => $organization, 'project' => $project] = createUserWithProjectOrganization();
+    $scanner = ProjectScanner::factory()->create(['project_id' => $project->id]);
+    $guestList = GuestList::factory()->create([
+        'project_id' => $project->id,
+        'scanner_id' => $scanner->id,
+    ]);
+
+    app()->instance(Organization::class, $organization);
+
+    $component = Livewire::actingAs($projectOrganizer)
+        ->test(GuestListShow::class, [
+            'projectId' => $project->id,
+            'guestListId' => $guestList->id,
+        ]);
+
+    DB::table('project_user')
+        ->where('project_id', $project->id)
+        ->where('user_id', $projectOrganizer->id)
+        ->delete();
+
+    Auth::setUser($projectOrganizer->fresh());
+
+    $component->call('openEditModal')->assertForbidden();
 });

--- a/tests/Feature/Mail/GuestInvitationMailTest.php
+++ b/tests/Feature/Mail/GuestInvitationMailTest.php
@@ -64,9 +64,10 @@ it('renders a browser fallback link for each guest entry', function () {
 
     $mail = new GuestInvitationMail($this->guestList, new Collection([$entry1, $entry2]));
 
-    $mail->assertSeeInHtml('If the QR code is not visible in your email app, open this pass in your browser.')
-        ->assertSeeInHtml(e($entry1->guestPassUrl()), escape: false)
-        ->assertSeeInHtml(e($entry2->guestPassUrl()), escape: false)
+    $mail->assertSeeInHtml(__('If the QR code is not visible in your email app, open this pass in your browser.'))
+        ->assertSeeInHtml(__('Open Guest Pass'))
+        ->assertSeeInHtml('href="'.e($entry1->guestPassUrl()).'"', escape: false)
+        ->assertSeeInHtml('href="'.e($entry2->guestPassUrl()).'"', escape: false)
         ->assertSeeInHtml('<svg', escape: false);
 });
 

--- a/tests/Feature/Models/GuestEntryTest.php
+++ b/tests/Feature/Models/GuestEntryTest.php
@@ -131,3 +131,41 @@ it('falls back to a seven-day guest pass expiry when scanner end time is unavail
     expect(URL::hasValidSignature(Request::create($url)))->toBeTrue()
         ->and($query['expires'] ?? null)->toBe((string) now()->addDays(7)->timestamp);
 });
+
+it('treats legacy invitation_sent_at rows as sent', function () {
+    $entry = GuestEntry::factory()->create([
+        'email' => 'legacy@example.com',
+        'qr_token' => bin2hex(random_bytes(32)),
+        'invitation_sent_at' => now()->subMinute(),
+        'invitation_queued_at' => null,
+        'invitation_failed_at' => null,
+    ]);
+
+    expect($entry->isInvitationSent())->toBeTrue()
+        ->and($entry->invitationStatus())->toBe('sent')
+        ->and($entry->isInvitationPending())->toBeFalse();
+});
+
+it('reports queued, failed, and pending invitation states truthfully', function () {
+    $queued = GuestEntry::factory()->create([
+        'email' => 'queued@example.com',
+        'qr_token' => bin2hex(random_bytes(32)),
+        'invitation_queued_at' => now()->subMinute(),
+    ]);
+    $failed = GuestEntry::factory()->create([
+        'email' => 'failed@example.com',
+        'qr_token' => bin2hex(random_bytes(32)),
+        'invitation_failed_at' => now()->subMinute(),
+    ]);
+    $pending = GuestEntry::factory()->create([
+        'email' => 'pending@example.com',
+        'qr_token' => bin2hex(random_bytes(32)),
+    ]);
+
+    expect($queued->invitationStatus())->toBe('queued')
+        ->and($queued->isInvitationQueued())->toBeTrue()
+        ->and($failed->invitationStatus())->toBe('failed')
+        ->and($failed->isInvitationFailed())->toBeTrue()
+        ->and($pending->invitationStatus())->toBe('pending')
+        ->and($pending->isInvitationPending())->toBeTrue();
+});

--- a/tests/Feature/Notifications/PreShiftReminderTest.php
+++ b/tests/Feature/Notifications/PreShiftReminderTest.php
@@ -35,14 +35,17 @@ it('renders 24h reminder with default template', function () {
         'ends_at' => Carbon::parse('2026-04-30 16:00:00', 'UTC'),
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toContain('Summer Fest')
         ->and($mail->subject)->toContain('morgen')
         ->and(implode(' ', $mail->introLines))->toContain('morgen stattfindet')
         ->and(implode(' ', $mail->introLines))->toContain('Stage Crew')
-        ->and(implode(' ', $mail->introLines))->toContain('Central Park');
+        ->and(implode(' ', $mail->introLines))->toContain('Central Park')
+        ->and(implode(' ', $mail->introLines))->toContain(route('volunteer.portal', 'test-token'))
+        ->and($mail->actionText)->toBe('Portal öffnen')
+        ->and($mail->actionUrl)->toBe(route('volunteer.portal', 'test-token'));
 });
 
 it('renders 4h reminder with default template', function () {
@@ -52,7 +55,7 @@ it('renders 4h reminder with default template', function () {
         'ends_at' => Carbon::parse('2026-04-29 15:00:00', 'UTC'),
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder4h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder4h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toContain('Summer Fest')
@@ -68,7 +71,7 @@ it('renders 24h reminder with heute when the shift is today', function () {
         'ends_at' => Carbon::parse('2026-04-29 16:00:00', 'UTC'),
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toContain('ist heute')
@@ -83,7 +86,7 @@ it('renders 24h reminder fallback with formatted date outside today and tomorrow
         'ends_at' => Carbon::parse('2026-05-02 16:00:00', 'UTC'),
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toContain('ist am 02.05.2026')
@@ -100,7 +103,7 @@ it('uses the project timezone to determine the relative day around midnight', fu
         'ends_at' => Carbon::parse('2026-04-30 00:30:00', 'UTC'),
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toContain('morgen')
@@ -116,11 +119,28 @@ it('uses custom template when set', function () {
         'body' => 'Custom reminder for {{job_name}}',
     ]);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect($mail->subject)->toBe('Hey Alice Test, Summer Fest is tomorrow!')
-        ->and(implode(' ', $mail->introLines))->toContain('Custom reminder for Stage Crew');
+        ->and(implode(' ', $mail->introLines))->toContain('Custom reminder for Stage Crew')
+        ->and($mail->actionText)->toBe('Portal öffnen')
+        ->and($mail->actionUrl)->toBe(route('volunteer.portal', 'test-token'));
+});
+
+it('renders custom portal_link placeholder when present', function () {
+    EmailTemplate::factory()->create([
+        'event_id' => $this->event->id,
+        'type' => EmailTemplateType::PreShiftReminder24h,
+        'subject' => 'Portal {{event_name}}',
+        'body' => 'Portal: {{portal_link}}',
+    ]);
+
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'custom-token');
+    $mail = $notification->toMail($this->volunteer);
+
+    expect(implode(' ', $mail->introLines))->toContain(route('volunteer.portal', 'custom-token'))
+        ->and($mail->actionUrl)->toBe(route('volunteer.portal', 'custom-token'));
 });
 
 it('omits location when event has none', function () {
@@ -128,21 +148,21 @@ it('omits location when event has none', function () {
     $job = VolunteerJob::factory()->for($event)->create();
     $shift = Shift::factory()->for($job, 'volunteerJob')->create();
 
-    $notification = new PreShiftReminder($event, $shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($event, $shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect(implode(' ', $mail->introLines))->not->toContain('Location');
 });
 
 it('is queued', function () {
-    expect(new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h))
+    expect(new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token'))
         ->toBeInstanceOf(ShouldQueue::class);
 });
 
 it('includes cheat sheet link when job has instructions', function () {
     $this->job->update(['instructions' => 'Bring gloves and safety glasses.']);
 
-    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $this->shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     $cheatSheetUrl = route('events.jobs.cheat-sheet', [
@@ -157,7 +177,7 @@ it('omits cheat sheet link when job has no instructions', function () {
     $job = VolunteerJob::factory()->for($this->event)->create(['instructions' => null]);
     $shift = Shift::factory()->for($job, 'volunteerJob')->create();
 
-    $notification = new PreShiftReminder($this->event, $shift, EmailTemplateType::PreShiftReminder24h);
+    $notification = new PreShiftReminder($this->event, $shift, EmailTemplateType::PreShiftReminder24h, 'test-token');
     $mail = $notification->toMail($this->volunteer);
 
     expect(implode(' ', $mail->introLines))

--- a/tests/Feature/Services/EmailTemplateRendererTest.php
+++ b/tests/Feature/Services/EmailTemplateRendererTest.php
@@ -137,6 +137,7 @@ it('has German default for pre-shift reminder 24h [#81]', function () {
         ->and($defaults['subject'])->toContain('{{relativer_tag}}')
         ->and($defaults['body'])->toContain('Hallo {{vorname}}')
         ->and($defaults['body'])->toContain('{{relativer_tag}} stattfindet')
+        ->and($defaults['body'])->toContain('{{portal_link}}')
         ->and($defaults['body'])->toContain('Bis bald!');
 });
 
@@ -146,7 +147,27 @@ it('has German default for pre-shift reminder 4h [#81]', function () {
     expect($defaults['subject'])->toContain('Erinnerung')
         ->and($defaults['subject'])->toContain('bald')
         ->and($defaults['body'])->toContain('Hallo {{vorname}}')
-        ->and($defaults['body'])->toContain('{{relativer_tag}} in wenigen Stunden');
+        ->and($defaults['body'])->toContain('{{relativer_tag}} in wenigen Stunden')
+        ->and($defaults['body'])->toContain('{{portal_link}}');
+});
+
+it('does not inject portal_link into custom reminder bodies unless requested', function () {
+    EmailTemplate::factory()->create([
+        'event_id' => $this->event->id,
+        'type' => EmailTemplateType::PreShiftReminder24h,
+        'subject' => 'Custom {{event_name}}',
+        'body' => 'Nur {{job_name}}',
+    ]);
+
+    $rendered = $this->renderer->render(
+        EmailTemplateType::PreShiftReminder24h,
+        $this->event,
+        array_merge($this->variables, [
+            'portal_link' => 'https://example.com/portal/reminder',
+        ]),
+    );
+
+    expect($rendered['body'])->toBe('Nur Setup Crew');
 });
 
 it('has German default for email verification [#81]', function () {


### PR DESCRIPTION
## Summary
- add explicit guest invitation queued/failed state with organizer resend and repair flows
- rename guest-list activation language to sending-active semantics and render guest-pass fallback links as CTA buttons
- add direct portal CTA links to pre-shift reminders and extend Mailpit Playwright coverage for the repaired invitation and reminder journeys
- fix a guest-list Blade compile error that surfaced on fresh CI view compilation

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Actions/QueueGuestInvitationSiblingSetTest.php tests/Feature/Actions/AddGuestEntryTest.php tests/Feature/Actions/UpdateGuestEntryTest.php tests/Feature/Actions/SendPreShiftRemindersTest.php tests/Feature/Jobs/SendGuestInvitationsJobTest.php tests/Feature/Jobs/ConfirmGuestListJobTest.php tests/Feature/Livewire/GuestListShowTest.php tests/Feature/Livewire/GuestListIndexTest.php tests/Feature/GuestListLifecycleTest.php tests/Feature/Models/GuestEntryTest.php tests/Feature/Notifications/PreShiftReminderTest.php tests/Feature/Services/EmailTemplateRendererTest.php tests/Feature/Mail/GuestInvitationMailTest.php tests/Feature/Http/GuestPassControllerTest.php`
- `vendor/bin/sail bin pint --dirty --format agent`
- `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/guest-list-invitation-reliability.spec.ts e2e/pre-shift-reminder-relative-day.spec.ts`
- `vendor/bin/sail artisan view:clear && vendor/bin/sail php ./vendor/bin/pest tests/Feature/Livewire/GuestListShowTest.php tests/Feature/Livewire/GuestListIndexTest.php tests/Feature/GuestListLifecycleTest.php`

Fixes #217
Closes #218
Closes #220
Closes #219