### PR TITLE
Clarify signup overlap conflicts and harden re-signup flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-error.log
 /.vscode
 /.zed
 /.playwright-mcp
+/e2e/.generated/
+/test-results/

--- a/.tall-pipeline/index.md
+++ b/.tall-pipeline/index.md
@@ -1,9 +1,9 @@
 ---
 pipeline_status: complete
 current_stage: complete
-current_focus: "phase-3-invitation-reliability-messaging-ux is complete; no unresolved critical/high security findings remain, and reminder-send acknowledgement timing plus frontend dependency advisories are tracked as backlog follow-ups"
-current_milestone: phase-3-invitation-reliability-messaging-ux
-entry_point: security-audit
+current_focus: "Phase 4 signup conflict UX and coverage is complete; overlap guidance, cancelled-shift reactivation coverage, Playwright browser verification, and local-only E2E fixture handling are in place with no unresolved critical/high security findings"
+current_milestone: phase-4-signup-conflict-ux-coverage
+entry_point: plan
 stages_to_run:
   - plan
   - implement
@@ -17,7 +17,7 @@ completed_stages:
 project_summary: "Voluntify Phase 2 restructure — Projects replace EventGroups as mandatory top-level entity"
 quality_bar: "domain ~100% coverage, components 80%+, no critical/high security findings"
 started_at: "2026-04-01"
-last_updated: "2026-05-07T20:50:32+02:00"
+last_updated: "2026-05-08T07:55:01+02:00"
 ---
 
 # TALL Pipeline — Index
@@ -51,6 +51,7 @@ last_updated: "2026-05-07T20:50:32+02:00"
 | issue-222-portal-jwt-refresh | Volunteer Portal JWT Refresh | #222 refresh portal QR JWTs so scanner verification no longer fails with stale signatures | m15-volunteer-portal-enhancements, m11-scanner, m19-non-expiring-magic-links | complete |
 | issue-221-signup-grace-minutes | Signup Grace Minutes | #221 event-level public signup cutoff with configurable grace minutes | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs, issue-207-signup-empty-state-notifications | complete |
 | phase-3-invitation-reliability-messaging-ux | Phase 3: Invitation Reliability & Messaging UX | #217 failed guest invitation visibility + resend, #218 sending-active guest-list wording, #220 reminder portal links, #219 guest-pass CTA button | m12-guest-lists, m13-polish, m19-non-expiring-magic-links, issue-193-guest-mail-magic-link | complete |
+| phase-4-signup-conflict-ux-coverage | Phase 4: Signup Conflict UX & Coverage | #164 cancelled-then-re-signup overlap coverage, #163 specific overlap conflict messaging | issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs, issue-207-signup-empty-state-notifications, issue-221-signup-grace-minutes | complete |
 
 ## Artifacts
 
@@ -84,6 +85,9 @@ last_updated: "2026-05-07T20:50:32+02:00"
 | `e2e/signup-grace-minutes.spec.ts` | test | issue-221 | Browser coverage for organizer-managed signup grace minutes and public shift visibility | complete |
 | `.tall-pipeline/phase-3-invitation-reliability-messaging-ux.md` | plan+implement+test+security | phase-3-invitation-reliability-messaging-ux | Phase 3 milestone tracking with implementation, verification, and security-audit outcomes for #217, #218, #220, and #219 | complete |
 | `.tall-pipeline/phase-3-invitation-reliability-messaging-ux-security-audit.md` | security-audit | phase-3-invitation-reliability-messaging-ux | Security audit report for invitation state transitions, organizer resend recovery, reminder portal links, and guest-pass CTA surfaces | complete |
+| `.tall-pipeline/phase-4-signup-conflict-ux-coverage.md` | all | phase-4-signup-conflict-ux-coverage | Phase 4 milestone tracking for signup overlap reactivation coverage and specific conflict messaging | complete |
+| `.tall-pipeline/phase-4-signup-conflict-ux-coverage-security-audit.md` | security-audit | phase-4-signup-conflict-ux-coverage | Security audit report for overlap UX hardening, verified-token resume handling, and public E2E fixture exposure | complete |
+| `e2e/signup-conflict-ux.spec.ts` | test | phase-4-signup-conflict-ux-coverage | Browser coverage for public signup overlap messaging, returning-volunteer conflicts, and cancelled-shift reactivation outcomes | complete |
 
 ## Conceive
 - **Status:** n/a (Phase 1 design complete, Phase 2 design from PO feedback PR #89)

--- a/.tall-pipeline/phase-4-signup-conflict-ux-coverage-security-audit.md
+++ b/.tall-pipeline/phase-4-signup-conflict-ux-coverage-security-audit.md
@@ -1,0 +1,179 @@
+# Security Audit: phase-4-signup-conflict-ux-coverage
+
+## Scope
+
+- Milestone: `phase-4-signup-conflict-ux-coverage`
+- Branch: `milestone/phase-4-signup-conflict-ux-coverage`
+- Reviewed surfaces:
+  - `app/Livewire/Public/EventSignup.php`
+  - `resources/views/livewire/public/event-signup.blade.php`
+  - `tests/Feature/Public/EventSignupTest.php`
+  - `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php`
+  - `e2e/signup-conflict-ux.spec.ts`
+  - `e2e/setup.sh`
+  - `e2e/.generated/fixtures.json`
+- Trust boundaries reviewed:
+  - Browser / Livewire public properties and actions
+  - `?vt=` verification-link resume flow
+  - local-only E2E fixture generation
+
+## Verdict
+
+- Gate: **pass with deferred follow-up**
+- Critical findings: **0**
+- High findings: **0**
+- Medium findings: **1**
+- Low findings: **1**
+- Info findings: **2**
+
+Phase 4 closed the originally targeted tampering gaps around locked wizard state, renderable-shift validation, overlap-step blocking, expired verified-token rejection, and the public E2E fixture leak. The former blocker was remediated by moving generated fixture data out of the web root and having Playwright load it from disk instead. The broader `?vt=` replay model remains a deferred medium concern if a continue URL leaks during its validity window.
+
+## Method
+
+### Version-specific guidance checked
+
+- Livewire `#[Locked]` guidance for authorization-sensitive public properties
+- Laravel signed / temporary URL documentation
+- Laravel rate limiting documentation
+
+### Automated checks
+
+- `vendor/bin/sail composer audit`: no PHP advisories reported
+- `vendor/bin/sail npm audit`: repo-level advisories reported for `axios`, `follow-redirects`, and `postcss`; noted below as broader dependency hygiene, not counted against this milestone gate
+- `gitleaks detect --source . --verbose`: tool not installed locally
+- `.gitignore`: `.env` is ignored
+- `.env`: local-only settings observed (`APP_ENV=local`, `APP_DEBUG=true`)
+- No project-level security-header configuration found in the reviewed app code
+
+## Requested Surface Review
+
+### Livewire property exposure / `#[Locked]`
+
+- `EventSignup::$event`, `$state`, `$reservationExpiresAt`, `$verificationTokenId`, `$existingVolunteerId`, `$existingShiftIds`, `$existingGearSelections`, `$isReturningVolunteer`, `$verificationStartedAt`, and messaging fields are locked in `app/Livewire/Public/EventSignup.php:34-89`.
+- Server-owned state is therefore not client-mutable through Livewire snapshot tampering.
+- User-controlled fields remain mutable by design and are revalidated before use.
+
+Status: **pass**
+
+### Wizard step tampering
+
+- `reserveAndAdvance()`, `advanceToConfirmation()`, `submitSignup()`, and `resendVerification()` enforce explicit step guards via `ensureStateIs()` in `app/Livewire/Public/EventSignup.php:394-399`, `495-499`, `577-581`, and `610-614`.
+- `$state` is also `#[Locked]` at `app/Livewire/Public/EventSignup.php:37-39`, so a crafted Livewire payload cannot jump forward by mutating the public property.
+
+Status: **pass**
+
+### Selected shift tampering / hidden shift injection
+
+- `reserveAndAdvance()` validates every submitted shift ID against the current renderable list plus event-owned active shifts in `app/Livewire/Public/EventSignup.php:508-518`.
+- Existing returning-volunteer shifts can still be injected into the payload, but they are stripped back out before reservation and submit in `app/Livewire/Public/EventSignup.php:526-531` and `666-670`.
+- `SignUpVolunteerForShifts` remains the authoritative overlap and eligibility boundary, as intended.
+
+Status: **pass**
+
+### Verified email token handling, expiry, and replay windows
+
+- Expired `?vt=` resume tokens are rejected in `mount()` via `expires_at` and `verified_at` checks at `app/Livewire/Public/EventSignup.php:98-113`.
+- Final submit rechecks token verification state, expiry, project scope, and email match at `app/Livewire/Public/EventSignup.php:629-640`.
+- Tests cover expired resume and expired final-submit cases in `tests/Feature/Public/EventSignupTest.php:390-411` and `1165-1185`.
+- The broader architecture still uses a reusable bearer token in the query string for up to 30 minutes after verification (`app/Livewire/Public/EmailVerificationPage.php:37`, `app/Livewire/Public/EventSignup.php:98-113`). That remains a real replay surface if the continue URL leaks, but after the Phase 4 hardening it is a **medium** deferred concern rather than a milestone-blocking auth bypass on its own.
+
+Status: **needs follow-up**
+
+### Rate limiting scope
+
+- Initial lookup and resend throttles are event-scoped by email in `app/Livewire/Public/EventSignup.php:335-341` and `412-418`.
+- Notification signup is also event-scoped by email in `app/Livewire/Public/EventSignup.php:479-485`.
+- Reservation and final-submit throttles remain IP-only in `app/Livewire/Public/EventSignup.php:501-506` and `616-621`; this is an availability concern, not an integrity bypass.
+
+Status: **acceptable with low residual risk**
+
+### XSS / unescaped conflict copy or fixture data reaching public output
+
+- Phase 4 conflict copy is rendered through escaped Blade output in `resources/views/livewire/public/event-signup.blade.php:433-470`.
+- Conflict labels originate from job names and formatted shift labels, but there is no unescaped sink in the reviewed surface.
+- `e2e/signup-conflict-ux.spec.ts` consumes fixture JSON only inside Playwright; it does not pipe fixture content into browser HTML.
+
+Status: **pass**
+
+### Public E2E fixture exposure risk
+
+- `e2e/setup.sh` now writes fixture data to `e2e/.generated/fixtures.json`, outside the public web root.
+- The affected Playwright specs now load fixture JSON from the local filesystem through `e2e/fixtures.js` instead of fetching `/e2e-fixtures.json` over HTTP.
+- `EventSignup::mount()` still accepts `?vt=` hashes as resume credentials, but the hashes are no longer published from a publicly reachable file.
+
+Status: **pass after remediation**
+
+## Findings
+
+### [MEDIUM] `?vt=` resume links are still reusable bearer tokens within the post-verification window
+
+**OWASP Category:** A07:2021 -- Identification and Authentication Failures  
+**Location:** `app/Livewire/Public/EmailVerificationPage.php:37`, `app/Livewire/Public/EventSignup.php:98-113`, `app/Livewire/Public/EventSignup.php:629-640`
+
+**Evidence:** After email verification, the app issues a continue URL with `?vt={token_hash}`. The same hash remains reusable for resume for 30 minutes after `verified_at` as long as `expires_at` has not passed.
+
+**Risk:** If the continue URL leaks through browser history, copied URLs, screenshots, support logs, or shared devices, another person can resume the signup as that verified email during the replay window.
+
+**Remediation:** Convert the resume flow from a replayable query-string bearer token to a one-time or short-lived exchange, for example by consuming the token into a session-bound nonce before rendering the wizard.
+
+**References:**
+
+- Laravel URL validation docs
+
+### [LOW] Reservation and final-submit throttles are still global to IP instead of event-scoped
+
+**OWASP Category:** A04:2021 -- Insecure Design  
+**Location:** `app/Livewire/Public/EventSignup.php:501-506`, `app/Livewire/Public/EventSignup.php:616-621`
+
+**Evidence:** `signup-reserve:{ip}` and `signup-submit:{ip}` do not include the event identifier, unlike the email lookup and resend throttles.
+
+**Risk:** Users behind a shared NAT can throttle each other across different events. This is an availability and UX issue, not a data-integrity bypass.
+
+**Remediation:** Include the event ID in the throttle bucket if you want consistency with the Phase 4 event-scoped lookup/resend hardening.
+
+## Additional Notes
+
+### [INFO] Phase 4 hardening areas that reviewed cleanly
+
+- `#[Locked]` coverage for server-owned wizard state is appropriate in the reviewed surface.
+- Step tampering is blocked server-side with explicit guards and visible errors.
+- Hidden shift injection is blocked by renderable-shift validation plus authoritative action-level checks.
+- Conflict copy is escaped; no XSS sink was found in the reviewed milestone UI.
+
+### [INFO] Broader repo hygiene outside the milestone gate
+
+- `npm audit` reported one high (`axios`) and two moderate advisories (`follow-redirects`, `postcss`) from the frontend dependency tree.
+- `gitleaks` is not installed locally; adding it to CI would strengthen secret scanning.
+- `roave/security-advisories`, PHPStan/Larastan, and Psalm taint analysis were not present in `composer.json`.
+
+## STRIDE Summary
+
+- **Spoofing:** No current high-severity spoofing issue remains in the reviewed Phase 4 surface after the fixture exposure remediation.
+- **Tampering:** Livewire state and selected shifts are appropriately guarded in Phase 4.
+- **Repudiation:** No new audit trail gap was introduced by the reviewed change surface.
+- **Information Disclosure:** No public fixture publication remains after moving generated data to `e2e/.generated/fixtures.json`.
+- **Denial of Service:** Reserve/submit rate limits remain broader than necessary but are not blocker severity.
+- **Elevation of Privilege:** No step-jump or hidden-shift privilege escalation survived the current guards.
+
+## OWASP Top 10 Coverage
+
+- **A01 Broken Access Control:** no remaining milestone-specific finding after moving fixture data out of the web root
+- **A02 Cryptographic Failures:** no new milestone-specific finding; replay window covered separately under auth
+- **A03 Injection:** no Phase 4 XSS or injection finding in the reviewed surface
+- **A04 Insecure Design:** one low finding on global IP-scoped reserve/submit throttles
+- **A05 Security Misconfiguration:** fixture publication under `public/` contributes to the high finding
+- **A06 Vulnerable and Outdated Components:** npm advisories noted outside milestone gate
+- **A07 Identification and Authentication Failures:** one medium finding on reusable `?vt=` resume links
+- **A08 Software and Data Integrity Failures:** no new milestone-specific finding
+- **A09 Security Logging and Monitoring Failures:** no new milestone-specific finding in reviewed surface
+- **A10 SSRF:** no finding in reviewed surface
+
+## Recommended Next Steps
+
+1. Follow up on the deferred `?vt=` architecture with one-time or session-bound resume semantics.
+2. Backlog event-scoping for reserve/submit throttles if shared-IP signup environments matter.
+3. Backlog repo hygiene work: `axios` upgrade, CI secret scanning, and optional static analysis.
+
+## Executive Summary
+
+Phase 4 itself is materially safer than the pre-review version: the overlap UX additions did not introduce a Livewire tampering or XSS regression, wizard state is locked, final submit no longer trusts expired verified tokens, and the E2E setup no longer publishes live verified signup-resume hashes from the web root. No critical or high issues remain in the reviewed milestone surface. The deferred `?vt=` replay architecture still deserves follow-up, but after the Phase 4 expiry, scoping fixes, and fixture-removal remediation it is best classified as **medium**, not a release blocker by itself.

--- a/.tall-pipeline/phase-4-signup-conflict-ux-coverage.md
+++ b/.tall-pipeline/phase-4-signup-conflict-ux-coverage.md
@@ -1,0 +1,218 @@
+# Milestone: phase-4-signup-conflict-ux-coverage — Phase 4: Signup Conflict UX & Coverage
+
+**GitHub Issues:** #164, #163
+**Features:** #164, #163
+**Dependencies:** issue-168-shifts-jobs-active-state, issue-203-priority-shift-gate, issue-206-hide-fully-booked-jobs, issue-207-signup-empty-state-notifications, issue-221-signup-grace-minutes
+**Branch:** `milestone/phase-4-signup-conflict-ux-coverage`
+
+## Plan
+- **Status:** complete
+- **Gate summary:** keep Phase 4 tightly scoped to overlap UX clarity and the cancelled-then-re-signup regression backstop. Reuse the existing public preflight overlap detection in `EventSignup` and the authoritative overlap / cancelled-row reactivation rules in `SignUpVolunteerForShifts`, add only the smallest UI-facing conflict detail surface needed for #163, and finish with focused Pest plus one deterministic public-signup Playwright flow.
+
+### Scope
+- Keep Phase 4 scoped only to #164 and #163, implemented in this order: #164, then #163.
+- Reuse the current split of responsibilities: `EventSignup` stays the advisory/public UX layer, and `SignUpVolunteerForShifts` remains the final authority for overlap and cancelled-signup reactivation outcomes.
+- Do not introduce new overlap persistence, new database fields, or a new overlap service just for this milestone.
+- Keep the existing returning-volunteer rules from prior milestones intact: `existingShiftIds` are active-only, existing held shifts stay visible, and public final submit stays bound to the verified token plus the reserved shift set.
+- Keep Playwright coverage focused on the public signup flow only; organizer settings and Mailpit are out of scope for this phase.
+
+### Dependency Assumptions
+- `prefillFromVolunteer()` continues to preload only active signups into `existingShiftIds`, so cancelled historical shifts are treated as newly selected if the volunteer chooses them again.
+- `reserveAndAdvance()` continues to use `overlappingShiftIds()` as the public step gate before any reservation is created.
+- `submitSignup()` remains bound to the verified email token plus the active reserved shift set from prior milestone `#221`, so this milestone does not need a second submit-integrity mechanism.
+- Returning-volunteer visibility rules from `issue-206-hide-fully-booked-jobs` and `issue-221-signup-grace-minutes` stay intact: existing held shifts remain visible even when new public availability rules would normally hide them.
+
+### Breakdown
+
+#### 1. #164 — test cancelled-then-re-signup overlap edge case
+- **Goal:** close the coverage gap around a volunteer re-selecting a previously cancelled shift after they already hold a newer overlapping signup, without changing the authoritative reactivation behavior.
+- **Implementation areas:**
+  - `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php`: extend the existing cancelled-signup reactivation overlap coverage so both reactivation outcomes stay explicit: allowed when the volunteer's remaining active schedule does not overlap, blocked when a newer active signup now overlaps the cancelled row.
+  - `tests/Feature/Public/EventSignupTest.php`: add or tighten wizard coverage that proves a cancelled historical shift is not treated as an existing held shift in the UI, can be re-selected and completed when it no longer overlaps the volunteer's active schedule, and is blocked at the shift-selection step when an active existing shift overlaps it.
+- **Coverage intent:**
+  - Verify the current public preconditions explicitly before asserting the end-to-end flow: the cancelled shift must not appear in `existingShiftIds`, and the overlap computation must treat it as a newly selected shift.
+  - Preserve the current rule that cancelled rows can be reactivated only when they still fit the volunteer's active schedule.
+  - Prove both observable public outcomes at the wizard boundary: no warning plus successful progression for the non-overlap reactivation case, and visible conflict plus reserve-step block for the overlap case.
+  - Keep this issue test-scoped unless the new public-flow coverage exposes a real mismatch that requires a minimal production fix.
+
+#### 2. #163 — overlap warning should identify which specific shifts conflict
+- **Goal:** upgrade the public overlap warning from a generic banner plus highlighted cards to explicit conflict identification so volunteers can tell which selected shifts collide before continuing.
+- **Implementation areas:**
+  - `app/Livewire/Public/EventSignup.php`: add one shared computed conflict map per render, tentatively `overlapConflictMap`, derived from the already loaded selected and existing timed shifts. Keep `overlappingShiftIds()` as a thin derived list from that shared result so the highlight and banner semantics cannot drift.
+  - `resources/views/livewire/public/event-signup.blade.php`: render the generic warning with specific shift labels, making clear when a newly selected shift conflicts with another newly selected shift versus an already-held existing signup.
+  - `tests/Feature/Public/EventSignupTest.php`: add focused assertions for the new conflict detail text for both new-vs-new and new-vs-existing overlap cases, including cross-midnight coverage where the time comparison is easy to regress.
+- **UX rules:**
+  - Keep conflict detection client-visible only for the current shift-selection step; do not add a new modal, toast system, or multi-step detour.
+  - Identify the conflicting shifts by the same volunteer-visible label source already used in the list today: `job name`, `shift month/day`, and `displayTimeRange($tz)`, matching the existing `shiftTimeLabel` convention.
+  - For returning volunteers, the warning names both shifts for clarity but frames the newly selected shift as the actionable item because the existing held shift is locked in this step.
+  - Treat the detailed warning as advisory UX only; the final overlap source of truth remains `SignUpVolunteerForShifts` during submit.
+
+### Focused Test Strategy
+- `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php`
+  - Keep authoritative overlap coverage here, especially cancelled-row reactivation against newer active signups and cross-midnight overlap behavior.
+  - Prefer extending the existing overlap section instead of creating a new action test file.
+- `tests/Feature/Public/EventSignupTest.php`
+  - Reuse one canonical schedule shape for the cancelled-then-re-signup timeline across action and feature coverage so both layers prove the same overlap boundaries.
+  - Add public-step assertions for detailed conflict wording when two newly selected shifts overlap.
+  - Add public-step assertions for detailed conflict wording when a newly selected shift overlaps an already-held existing shift.
+  - Add a success-path regression test for cancelled-then-re-signup when the volunteer's remaining active shift does not overlap.
+  - Add a shift-step regression test for cancelled-then-re-signup when a newer active shift does overlap, proving the warning appears and the wizard cannot reserve the conflicting re-selected shift.
+- Do not add broad new Livewire or E2E infrastructure if the current feature tests can express the behavior directly.
+
+### Playwright Plan
+- Add one deterministic public-signup spec, preferably `e2e/signup-conflict-ux.spec.ts`, rather than overloading `e2e/signup-grace-minutes.spec.ts`.
+- Extend `e2e/setup.sh` and the local generated fixture file at `e2e/.generated/fixtures.json` with a dedicated overlap fixture event, verified-token hash, and volunteer state that covers isolated scenario blocks for:
+  - two newly selectable overlapping shifts for #163
+  - one returning-volunteer scenario where an active existing shift conflicts with a newly selected shift
+  - one cancelled historical signup that can be re-selected in the UI but is still blocked by the authoritative overlap rule for #164
+- Browser assertions should prove end to end that:
+  - the public shift-selection step shows the specific conflicting shift names in the warning
+  - deselecting the named conflicting shift clears the warning and allows progression
+  - the returning-volunteer conflict message names both the held shift and the newly selected shift while making the new selection the actionable one
+  - the cancelled-then-re-signup path succeeds when the re-selected cancelled shift no longer overlaps an active held shift
+  - the cancelled-then-re-signup path cannot silently complete into an overlapping schedule when a newer active held shift still conflicts
+- Keep this as a single public-flow browser spec with deterministic fixtures; no Mailpit assertions or organizer-side setup UI are needed.
+
+## Implement
+- **Status:** complete
+- **Iteration:** 1
+- **Tasks:**
+  - [x] RED: add authoritative action coverage for cancelled-row reactivation succeeding after active overlaps are gone and failing when a newer active signup still overlaps
+  - [x] RED: add public wizard coverage proving `prefillFromVolunteer()` stays active-only and cancelled historical shifts behave like new selections
+  - [x] GREEN: add one shared `overlapConflictMap` computed surface in `EventSignup` and keep `overlappingShiftIds()` as a thin derivative of it
+  - [x] GREEN: render volunteer-visible conflict details with the existing `shiftTimeLabel` convention for new-vs-new and new-vs-existing warnings
+  - [x] REFACTOR: keep `SignUpVolunteerForShifts` unchanged as the final overlap authority and reuse one canonical cancelled-re-signup timeline across the new action and feature coverage
+- **Gate summary:** `SignUpVolunteerForShifts` remains the only authoritative overlap / cancelled-row reactivation boundary, the public wizard now exposes one shared computed conflict map for both highlight and warning semantics, returning volunteers see actionable conflict copy that names the newly selected shift plus the held conflicting shift, and Phase 4 now explicitly covers both cancelled re-signup outcomes without adding persistence or new services.
+
+## Test
+- **Status:** complete
+- **Gate summary:** Phase 4 acceptance coverage is now closed across focused Pest and one deterministic public-signup Playwright spec. Authoritative overlap / reactivation enforcement remains covered by focused Pest at the action and feature layers. The browser spec proves the public preflight UX contract only: cancelled shifts reappear as selectable options, overlap warnings name specific conflicts, deselection clears conflicts and restores progression, and blocked overlap cases remain visibly blocked before confirmation.
+
+### Verification
+- Ran `vendor/bin/sail bin pint --dirty --format agent`
+- Ran `vendor/bin/sail artisan test --compact tests/Feature/Public/EventSignupTest.php tests/Feature/Actions/SignUpVolunteerForShiftsTest.php`
+- Ran `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/signup-conflict-ux.spec.ts`
+
+### Test Results
+- `vendor/bin/sail bin pint --dirty --format agent`: passed
+- `vendor/bin/sail artisan test --compact tests/Feature/Public/EventSignupTest.php tests/Feature/Actions/SignUpVolunteerForShiftsTest.php`: `124 passed (500 assertions)`
+- `bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/signup-conflict-ux.spec.ts`: `4 passed`
+
+### Story Traceability
+| Story | Acceptance Criterion | Tests | Status |
+|---|---|---|---|
+| #164 | Cancelled A + active non-overlapping B can be re-selected without warning and succeeds via reactivation | `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php` — `it('reactivates a cancelled row when the volunteers active schedule no longer overlaps', ...)`; `tests/Feature/Public/EventSignupTest.php` — `it('reactivates a cancelled historical shift when the volunteers active schedule no longer overlaps', ...)`; `e2e/signup-conflict-ux.spec.ts` — `cancelled shift can be re-selected and reactivated when the active schedule no longer overlaps` | covered |
+| #164 | Cancelled A + newer overlapping active C is recognized and blocked | `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php` — `it('skips a reactivated shift that now overlaps a newer active signup', ...)` (authoritative); `tests/Feature/Public/EventSignupTest.php` — `it('blocks re-selecting a cancelled historical shift when a newer active signup still overlaps it', ...)`; `e2e/signup-conflict-ux.spec.ts` — `cancelled shift stays blocked when a newer active signup still overlaps it` (public preflight block) | covered |
+| #164 | `prefillFromVolunteer()` excludes cancelled shift A from `existingShiftIds` | `tests/Feature/Public/EventSignupTest.php` — `it('reactivates a cancelled historical shift when the volunteers active schedule no longer overlaps', ...)`; `tests/Feature/Public/EventSignupTest.php` — `it('blocks re-selecting a cancelled historical shift when a newer active signup still overlaps it', ...)` | covered |
+| #164 | Re-selected cancelled A is treated as a new shift during overlap computation | `tests/Feature/Public/EventSignupTest.php` — `it('blocks re-selecting a cancelled historical shift when a newer active signup still overlaps it', ...)`; `tests/Feature/Public/EventSignupTest.php` — `it('reactivates a cancelled historical shift when the volunteers active schedule no longer overlaps', ...)` | covered |
+| #163 | 2+ newly selected overlapping shifts identify which shift(s) they conflict with | `tests/Feature/Public/EventSignupTest.php` — `it('blocks reserveAndAdvance when selected shifts overlap in time', ...)`; `e2e/signup-conflict-ux.spec.ts` — `newly selected overlapping shifts show specific conflict names and clear after deselection` | covered |
+| #163 | With 3+ selected shifts where only 2 conflict, only conflicting shifts are marked | `tests/Feature/Public/EventSignupTest.php` — `it('marks only the conflicting shifts when three selected shifts include one non-overlapping option', ...)` | covered |
+| #163 | A shift that conflicts with multiple others references all conflicting shifts | `tests/Feature/Public/EventSignupTest.php` — `it('references all newly selected conflicting shifts when one shift overlaps multiple others', ...)`; `tests/Feature/Public/EventSignupTest.php` — `it('uses plural existing-shift wording when one selected shift conflicts with multiple existing shifts', ...)` | covered |
+
+### Remaining Low-Risk Gaps
+- The browser spec intentionally does not assert exact localized date/time strings inside conflict copy; those exact labels remain covered in the focused feature tests.
+- The browser spec stays public-signup scoped and does not assert confirmation email delivery or organizer-side flows, which matches the milestone boundary.
+
+## Security Audit
+- **Status:** complete
+- **Gate summary:** Phase 4 passes the reviewed Livewire hardening goals for locked wizard state, step tampering resistance, renderable-shift validation, overlap-step blocking, expired verified-token rejection, and the E2E fixture publication remediation. Live signup-resume hashes are no longer written under `public/`, so the previous public credential leak is closed. The broader `?vt=` replay model remains a deferred medium concern for the security stage.
+- **Findings summary:** 0 critical, 0 high, 1 medium, 1 low, 2 info. Medium: the broader `?vt=` replay architecture remains reusable for the post-verification window if the continue URL leaks. Low: reserve/submit throttles remain IP-global rather than event-scoped.
+- **Artifact:** `.tall-pipeline/phase-4-signup-conflict-ux-coverage-security-audit.md`
+
+## Decisions
+
+| # | Stage | Decision | Rationale | Affects |
+|---|---|---|---|---|
+| 1 | plan | Implement #164 before #163 | The cancelled-row overlap invariant is already authoritative in `SignUpVolunteerForShifts`; proving that first gives the UI work a fixed behavioral target and keeps the milestone anchored to the higher-risk correctness case | implement, test |
+| 2 | plan | Keep `SignUpVolunteerForShifts` as the final overlap authority and treat any new `EventSignup` conflict detail as advisory only | Prevents UX copy improvements from becoming a second business-rules engine and avoids drift between preflight warnings and final signup enforcement | implement, test, security-audit |
+| 3 | plan | Reuse the existing overlap computation and loaded shift collections in `EventSignup` for conflict-detail rendering instead of adding new persistence or a separate overlap service | #163 is a UX clarity change, and the smallest correct path is to enrich the current computed overlap surface rather than invent new infrastructure | implement, test |
+| 4 | plan | Returning-volunteer conflict detail should name only the newly selected shift as conflicting with an already-held shift | The existing shift is locked in the UI and not actionable in this step, so the warning should guide the volunteer toward the removable choice | implement, test |
+| 5 | plan | Cover #164 through both action-level and public-flow tests, but keep production changes optional unless the new coverage exposes a real behavior gap | The issue is explicitly about edge-case coverage, and current code already suggests the intended rule exists in the action | implement, test |
+| 6 | plan | Use a dedicated public-signup Playwright spec with deterministic fixtures for both issues | The overlap UX is a public wizard concern and is clearer to verify in one focused browser flow than by extending the unrelated organizer grace-minutes spec | test |
+| 7 | implement | Store overlap warning details as a map keyed by each newly selected shift, with existing conflicting shifts represented only inside that new shift's conflict list | This keeps the UI actionable for returning volunteers, lets `overlappingShiftIds()` derive directly from the same source, and avoids separate list/highlight overlap logic | implement, test |
+| 8 | implement | Reuse the same cancelled/overlapping/non-overlapping August 15 timeline in both action and public tests | A shared schedule shape makes the reactivation expectations easier to compare across the advisory wizard layer and the authoritative signup action | implement, test |
+
+## Cross-Milestone Interface
+
+| Category | Items |
+|---|---|
+| Livewire | `EventSignup::jobs()`, `EventSignup::overlappingShiftIds()`, `EventSignup::reserveAndAdvance()`, `EventSignup::submitSignup()`, `EventSignup::prefillFromVolunteer()` |
+| Actions | `SignUpVolunteerForShifts` remains the authoritative overlap and cancelled-signup reactivation boundary; `ProcessVolunteerSignup` continues to reach it from the public wizard |
+| Views | `resources/views/livewire/public/event-signup.blade.php` overlap badges and warning copy |
+| Tests | `tests/Feature/Public/EventSignupTest.php`, `tests/Feature/Actions/SignUpVolunteerForShiftsTest.php` |
+| E2E | planned `e2e/signup-conflict-ux.spec.ts`; `e2e/setup.sh`; `e2e/.generated/fixtures.json` |
+| Prior Milestones | `issue-168-shifts-jobs-active-state`, `issue-203-priority-shift-gate`, `issue-206-hide-fully-booked-jobs`, `issue-207-signup-empty-state-notifications`, `issue-221-signup-grace-minutes` |
+
+## Reviews
+
+### plan — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Devil's Advocate | UI conflict-detail messaging could drift from the authoritative overlap rules once exact conflicts become user-visible | high | accepted | The plan now requires one shared computed conflict map in `EventSignup`, keeps `overlappingShiftIds()` as a thin derivative, and explicitly validates covered semantics against the submit-path authority |
+| 2 | Devil's Advocate | #164 outcome expectations were ambiguous about whether cancelled re-selection should succeed, fail, or be blocked in the wizard | high | accepted | The plan now names both expected public outcomes explicitly: successful reactivation when schedules no longer overlap, and shift-step conflict blocking when an active held shift still overlaps |
+| 3 | Scalability Skeptic | Repeating overlap computations and test timelines across layers could create render-time waste and cross-test drift | high | accepted | The plan now uses one computed conflict map per render and calls for one canonical cancelled-re-signup schedule shape reused across action and feature coverage |
+| 4 | Junior Developer Lens | The new conflict-detail surface lacked a naming and label-format contract, making implementation and assertions guessy | medium | accepted | The plan now expects a shared `overlapConflictMap`-style surface and anchors labels to the existing `shiftTimeLabel` convention already visible in the UI |
+| 5 | Scalability Skeptic | One browser spec covering three overlap cases could become brittle if scenarios are not isolated clearly | medium | accepted | The plan keeps one focused public-signup spec but now requires isolated scenario blocks inside deterministic fixture data so each path remains diagnosable |
+| 6 | Devil's Advocate | Phase 4 depended on prior signup contracts that were not stated explicitly, making regressions harder to attribute | medium | accepted | Added a `Dependency Assumptions` section covering active-only preload, reserve-step gating, reserved-shift submit integrity, and returning-volunteer visibility contracts from earlier milestones |
+
+### implement-review — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Security Paranoid | The public `state` property could be mutated to call reserve/details/submit methods out of order | high | accepted | Locked `state` and added explicit server-side step guards for `reserveAndAdvance()`, `advanceToConfirmation()`, and `submitSignup()` |
+| 2 | Security Paranoid | Shift validation accepted event-owned active IDs that were not actually renderable in the current wizard state | medium | accepted | Reservation validation now requires submitted shift IDs to be in the current renderable public/returning-volunteer-visible shift list as well as event-owned |
+| 3 | Accessibility Specialist | The conflict warning was not announced as a live update and conflicting checkboxes were not tied to their specific warning text | high | accepted | Added alert/live-region semantics to the warning block and `aria-describedby` links from conflicting selected checkboxes to per-shift conflict text |
+| 4 | Accessibility Specialist | Conflict wording became unclear when one selected shift overlapped multiple other shifts, especially with existing-shift phrasing | medium | accepted | Added grouped conflict phrasing that distinguishes existing held shifts from other selected shifts and uses singular/plural wording for both |
+
+### implement-review-rerun — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Privacy Reviewer | `restartSignup()` still preserved volunteer-facing personal data, so restart was not actually fresh | medium | accepted | `restartSignup()` now clears first name, last name, email, and phone in addition to reservation and lookup state |
+| 2 | Accessibility Specialist | The conflict description wiring reused the same DOM ID for the hidden checkbox description and visible alert item | high | accepted | Split the IDs into deterministic hidden `shift-conflict-description-*` nodes and visible `shift-conflict-message-*` nodes while keeping `aria-describedby` on the hidden description only |
+| 3 | Security Paranoid | `resendVerification()` lacked a step guard, fresh email validation, event-scoped throttles, and binding to an active token | medium | accepted | Resend now requires the pending-verification step, revalidates the email, scopes throttles by event, and requires a live unexpired token for the current event/project/email |
+| 4 | Security Paranoid | The broader `?vt=` verification-link architecture still needs hardening | medium | deferred | Explicitly left out of this pass per milestone instruction so it can be addressed as a separate security-stage concern |
+| 5 | Accessibility Specialist | The shift picker lacked group-level association with current warning/error text | low | accepted | Added group semantics tying the shift picker to overlap, warning, and validation messages without redesigning the layout |
+
+### implement-review-final-local-pass — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Security Paranoid | The initial email lookup throttle was still global to the email instead of event-scoped | medium | accepted | Scoped the submit-email lookup throttle to the current event to match the resend hardening |
+| 2 | Security Paranoid | Expired verification tokens could still be trusted in local resume or final submit paths | medium | accepted | Expired `?vt=` tokens no longer resume the wizard and expired verified tokens no longer pass final submit validation |
+| 3 | UX Reviewer | Clicking Continue with known overlap conflicts still failed silently from the volunteer’s perspective | medium | accepted | `reserveAndAdvance()` now adds a visible validation error when overlap conflicts already exist |
+| 4 | UX Reviewer | Step-guard failures were server-enforced but not visible in the template | medium | accepted | Added a visible `state` error surface so server-side guard failures are shown to the volunteer |
+| 5 | Accessibility Specialist | The step-transition live-region label map did not cover all server-driven terminal/interstitial states | medium | accepted | Added minimal labels for `PendingVerification`, `Complete`, and `Expired` without changing the broader flow |
+
+### test-review — 2026-05-07
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | QA Skeptic | Cancelled historical shifts were covered logically, but not yet shown as visibly selectable instead of locked/already-held | medium | accepted | Tightened feature coverage to assert the cancelled shift renders as a selectable checkbox without the locked/disabled state while the true active shift remains held |
+| 2 | QA Skeptic | Returning-volunteer browser coverage stopped at the conflict warning and did not prove recovery after removing the new conflicting shift | medium | accepted | The Playwright flow now removes the conflicting new shift, proves the warning clears and progression resumes, then reintroduces the conflict to verify the visible block |
+| 3 | QA Skeptic | The 3-shift scenario only proved internal Livewire overlap structures, not the visible warning contract | medium | accepted | Added visible-warning assertions showing only the two conflicting shifts appear in the rendered conflict copy while the non-conflicting third shift is omitted |
+| 4 | QA Skeptic | Browser/feature blocked re-selection coverage should assert the visible failure contract, not just lack of advancement | medium | accepted | Tightened both layers to assert the volunteer-visible overlap-block message and absence of confirmation progression |
+| 5 | QA Skeptic | Reactivation-success coverage did not prove the cancelled row was reactivated instead of duplicated | medium | accepted | Added database assertions that exactly one active signup row exists for the re-selected cancelled shift after success |
+| 6 | QA Skeptic | `force: true` checkbox usage weakened confidence in real user actionability | low | accepted | Removed forced checkbox interaction from the Playwright spec after confirming normal interaction succeeds reliably |
+| 7 | QA Skeptic | Browser wording could overclaim submit-path authority for blocked reactivation | medium | accepted | Updated the Test gate summary and traceability matrix so Playwright is described as proving public preflight blocking only, with submit authority attributed to focused Pest |
+| 8 | QA Skeptic | Browser-level exact full-label ambiguity still looked underspecified | low | deferred | Exact localized full-label formatting is already covered at the feature-test layer; duplicating that exact contract in Playwright would add brittleness without improving the public-flow confidence target for this milestone |
+
+### security-audit-review — 2026-05-08
+
+| # | Perspective | Concern | Severity | Resolution | Rationale |
+|---|---|---|---|---|---|
+| 1 | Security Paranoid | `?vt=` resume links remain reusable bearer credentials during the post-verification window | medium | deferred | The public fixture leak is fixed and no critical/high finding remains, but the broader session-binding / one-time-use redesign is outside Phase 4 scope and stays documented in the audit artifact |
+| 2 | Scalability Skeptic | Pending-verification polling still issues one token lookup every 3 seconds per open tab for up to 10 minutes | medium | deferred | This is a residual availability concern rather than a Phase 4 integrity bypass, so it is recorded for later optimization instead of blocking the milestone |
+| 3 | Scalability Skeptic | Reserve / submit throttles remain IP-scoped instead of event-scoped | low | deferred | The milestone already event-scoped lookup and resend throttles; reserve / submit scoping remains a non-blocking availability improvement noted in the audit artifact |
+| 4 | Scalability Skeptic | The E2E harness still uses one destructive setup and one shared generated fixture file for all runs | low | rejected | This is test-harness operational debt, not a production security issue in the shipped Phase 4 surface, so it does not affect the milestone security gate |
+
+## Feedback Loops
+
+| # | Date | Direction | Trigger | Fix | Resolution |
+|---|---|---|---|---|---|
+| 1 | 2026-05-07 | harden | Accepted implementation-review findings for step-boundary hardening, renderable-shift validation, and conflict accessibility semantics | Locked the server-owned wizard state, added explicit step guards, narrowed reservation validation to renderable shift IDs, and linked live conflict text to the conflicting inputs with clearer grouped wording | Fixed in the implement stage; focused Pest coverage added, Playwright and security follow-up still pending |
+| 2 | 2026-05-07 | harden | Second implementation-review fix pass covering fresh restart semantics, unique conflict-description IDs, resend verification hardening, and shift-group associations | Cleared volunteer-facing fields on restart, split visible/hidden conflict IDs, bound resend to the pending verification flow with event-scoped throttles and active-token checks, and linked the shift group to its current warning/error surfaces | Fixed in the implement stage; the broader `?vt=` architecture remains intentionally deferred to a later security concern |
+| 3 | 2026-05-07 | harden | Final local review pass highlighted event-scoped lookup throttling, expired-token trust, silent overlap blocking, missing visible state-guard errors, and incomplete step announcements | Scoped lookup throttles by event, rejected expired verified tokens in resume/submit, surfaced overlap-block and state-guard errors in the UI, and added live-region labels for pending, complete, and expired states | Fixed in the implement stage; only the broader `?vt=` replay architecture remains intentionally deferred to security audit |
+| 4 | 2026-05-07 | tighten | Accepted test-review follow-up for selectable cancelled-shift UX, visible 3-shift conflict scope, blocked-flow messaging, reactivation non-duplication, and browser recovery after deselection | Tightened feature assertions for fresh cancelled-shift rendering, visible conflict-copy scope, explicit overlap-block messaging, and non-duplicated reactivation; updated Playwright to use normal checkbox interaction, prove recovery after unselecting a conflicting new shift, and describe blocked browser coverage as preflight-only | Fixed in the test stage; exact localized full-label verification remains intentionally concentrated in feature tests to avoid brittle browser assertions |
+| 5 | 2026-05-07 | remediate | Security audit high finding on publicly exposed E2E fixtures | Moved generated Playwright fixtures from `public/e2e-fixtures.json` to local-only `e2e/.generated/fixtures.json`, switched affected specs to load fixtures from disk, and ignored the generated directory | Fixed in the security remediation pass; the broader `?vt=` replay model remains intentionally deferred |

--- a/app/Livewire/Public/EventSignup.php
+++ b/app/Livewire/Public/EventSignup.php
@@ -13,6 +13,7 @@ use App\Enums\WizardState;
 use App\Exceptions\DomainException;
 use App\Models\EmailVerificationToken;
 use App\Models\Event;
+use App\Models\Shift;
 use App\Models\ShiftReservation;
 use App\Models\Volunteer;
 use App\Services\HintTextResolver;
@@ -33,6 +34,7 @@ class EventSignup extends Component
     #[Locked]
     public Event $event;
 
+    #[Locked]
     public WizardState $state = WizardState::EmailEntry;
 
     /** @var array<int> */
@@ -100,6 +102,7 @@ class EventSignup extends Component
                 ->where('event_id', $this->event->id)
                 ->whereNotNull('verified_at')
                 ->where('verified_at', '>', now()->subMinutes(30))
+                ->where('expires_at', '>', now())
                 ->first();
 
             if ($token) {
@@ -188,6 +191,20 @@ class EventSignup extends Component
             ->all();
     }
 
+    /**
+     * @return array<int>
+     */
+    #[Computed]
+    public function renderableShiftIds(): array
+    {
+        return $this->jobs
+            ->flatMap(fn ($job) => $job->shifts)
+            ->pluck('id')
+            ->map(fn ($shiftId) => (int) $shiftId)
+            ->values()
+            ->all();
+    }
+
     #[Computed]
     public function hintSignupEmail(): ?string
     {
@@ -226,6 +243,67 @@ class EventSignup extends Component
     }
 
     /**
+     * Returns the selected new shifts keyed to their specific conflicts.
+     *
+     * @return array<int, array{shift_id: int, shift_label: string, conflicts: array<int, array{shift_id: int, shift_label: string, is_existing: bool}>}>
+     */
+    #[Computed]
+    public function overlapConflictMap(): array
+    {
+        if (count($this->selectedShiftIds) < 2) {
+            return [];
+        }
+
+        $selectedShiftIds = array_map('intval', $this->selectedShiftIds);
+        $newShiftIds = array_values(array_diff($selectedShiftIds, $this->existingShiftIds));
+
+        if ($newShiftIds === []) {
+            return [];
+        }
+
+        $shiftContexts = $this->shiftContextMap();
+
+        $newShifts = collect($newShiftIds)
+            ->map(fn (int $shiftId) => $shiftContexts[$shiftId] ?? null)
+            ->filter(fn (?array $context) => $context !== null
+                && $context['shift']->starts_at !== null
+                && $context['shift']->ends_at !== null)
+            ->values();
+
+        $existingShifts = collect($this->existingShiftIds)
+            ->map(fn (int $shiftId) => $shiftContexts[$shiftId] ?? null)
+            ->filter(fn (?array $context) => $context !== null
+                && $context['shift']->starts_at !== null
+                && $context['shift']->ends_at !== null)
+            ->values();
+
+        $conflicts = [];
+
+        for ($i = 0; $i < $newShifts->count(); $i++) {
+            for ($j = $i + 1; $j < $newShifts->count(); $j++) {
+                if (! $this->shiftsOverlap($newShifts[$i]['shift'], $newShifts[$j]['shift'])) {
+                    continue;
+                }
+
+                $this->addOverlapConflict($conflicts, $newShifts[$i], $newShifts[$j], false);
+                $this->addOverlapConflict($conflicts, $newShifts[$j], $newShifts[$i], false);
+            }
+        }
+
+        foreach ($newShifts as $newShift) {
+            foreach ($existingShifts as $existingShift) {
+                if (! $this->shiftsOverlap($newShift['shift'], $existingShift['shift'])) {
+                    continue;
+                }
+
+                $this->addOverlapConflict($conflicts, $newShift, $existingShift, true);
+            }
+        }
+
+        return $conflicts;
+    }
+
+    /**
      * Returns the IDs of selected shifts that overlap with at least one other
      * selected shift.
      *
@@ -234,52 +312,7 @@ class EventSignup extends Component
     #[Computed]
     public function overlappingShiftIds(): array
     {
-        if (count($this->selectedShiftIds) < 2) {
-            return [];
-        }
-
-        $intIds = array_map('intval', $this->selectedShiftIds);
-
-        $newOnly = array_diff($intIds, $this->existingShiftIds);
-        if (count($newOnly) < 1) {
-            return [];
-        }
-
-        $allShifts = $this->jobs->flatMap(fn ($job) => $job->shifts);
-
-        $newShifts = $allShifts
-            ->filter(fn ($s) => in_array((int) $s->id, $newOnly, true)
-                && $s->starts_at !== null && $s->ends_at !== null)
-            ->values();
-
-        $existingShifts = $allShifts
-            ->filter(fn ($s) => in_array((int) $s->id, $this->existingShiftIds, true)
-                && $s->starts_at !== null && $s->ends_at !== null)
-            ->values();
-
-        $conflicting = [];
-
-        // New vs new
-        for ($i = 0; $i < $newShifts->count(); $i++) {
-            for ($j = $i + 1; $j < $newShifts->count(); $j++) {
-                if ($newShifts[$i]->starts_at < $newShifts[$j]->ends_at
-                    && $newShifts[$i]->ends_at > $newShifts[$j]->starts_at) {
-                    $conflicting[] = $newShifts[$i]->id;
-                    $conflicting[] = $newShifts[$j]->id;
-                }
-            }
-        }
-
-        // New vs existing — only flag the new shift (existing is locked in the UI)
-        foreach ($newShifts as $new) {
-            foreach ($existingShifts as $existing) {
-                if ($new->starts_at < $existing->ends_at && $new->ends_at > $existing->starts_at) {
-                    $conflicting[] = $new->id;
-                }
-            }
-        }
-
-        return array_values(array_unique($conflicting));
+        return array_map('intval', array_keys($this->overlapConflictMap));
     }
 
     /**
@@ -299,7 +332,7 @@ class EventSignup extends Component
         }
         RateLimiter::hit($ipKey, 60);
 
-        $emailKey = 'signup-lookup-email:'.strtolower(trim($this->volunteerEmail));
+        $emailKey = 'signup-lookup-email:'.$this->event->id.':'.strtolower(trim($this->volunteerEmail));
         if (RateLimiter::tooManyAttempts($emailKey, 3)) {
             $this->addError('volunteerEmail', __('Too many attempts for this email. Please wait a few minutes.'));
 
@@ -360,7 +393,23 @@ class EventSignup extends Component
      */
     public function resendVerification(): void
     {
-        $emailKey = 'email-verification-resend:'.strtolower(trim($this->volunteerEmail));
+        if (! $this->ensureStateIs(WizardState::PendingVerification)) {
+            return;
+        }
+
+        $this->validate([
+            'volunteerEmail' => ['required', 'email', 'max:255'],
+        ]);
+
+        $token = $this->currentPendingVerificationToken();
+
+        if (! $token) {
+            $this->addError('volunteerEmail', __('Your verification attempt is no longer active. Please start again.'));
+
+            return;
+        }
+
+        $emailKey = 'email-verification-resend:'.$this->event->id.':'.strtolower(trim($this->volunteerEmail));
         if (RateLimiter::tooManyAttempts($emailKey, 3)) {
             $this->addError('volunteerEmail', __('Too many resend attempts. Please wait before trying again.'));
 
@@ -445,6 +494,10 @@ class EventSignup extends Component
      */
     public function reserveAndAdvance(): void
     {
+        if (! $this->ensureStateIs(WizardState::SelectingShifts)) {
+            return;
+        }
+
         if (RateLimiter::tooManyAttempts('signup-reserve:'.request()->ip(), 15)) {
             $this->addError('selectedShiftIds', __('Too many attempts. Please wait a moment before trying again.'));
 
@@ -456,6 +509,7 @@ class EventSignup extends Component
             'selectedShiftIds' => ['required', 'array', 'min:1'],
             'selectedShiftIds.*' => [
                 'integer',
+                Rule::in($this->renderableShiftIds),
                 Rule::exists('shifts', 'id')->where(fn ($q) => $q->whereIn(
                     'volunteer_job_id',
                     $this->event->volunteerJobs()->active()->select('id'),
@@ -464,6 +518,8 @@ class EventSignup extends Component
         ]);
 
         if (count($this->overlappingShiftIds) > 0) {
+            $this->addError('selectedShiftIds', __('Some selected shifts overlap in time. Review the conflict details below before continuing.'));
+
             return;
         }
 
@@ -499,7 +555,7 @@ class EventSignup extends Component
         }
 
         $this->selectedShiftIds = array_merge($this->existingShiftIds, $result->reservedShiftIds());
-        unset($this->overlappingShiftIds, $this->selectedJobIds, $this->gearItems, $this->hasGearOrFields);
+        unset($this->overlapConflictMap, $this->overlappingShiftIds, $this->selectedJobIds, $this->gearItems, $this->hasGearOrFields);
         $this->reservationExpiresAt = $result->expiresAt->toISOString();
 
         if (count($result->unavailable) > 0) {
@@ -520,6 +576,10 @@ class EventSignup extends Component
      */
     public function advanceToConfirmation(): void
     {
+        if (! $this->ensureStateIs(WizardState::GearAndFields)) {
+            return;
+        }
+
         if (! ShiftReservation::forSession(session()->getId())->active()->exists()) {
             $this->handleReservationExpired();
 
@@ -549,6 +609,10 @@ class EventSignup extends Component
      */
     public function submitSignup(): void
     {
+        if (! $this->ensureStateIs(WizardState::Confirming)) {
+            return;
+        }
+
         if (RateLimiter::tooManyAttempts('signup-submit:'.request()->ip(), 5)) {
             $this->addError('volunteerEmail', __('Too many signup attempts. Please wait a few minutes before trying again.'));
 
@@ -568,7 +632,7 @@ class EventSignup extends Component
 
         $verifiedEmail = $verificationToken?->volunteer?->email ?? $verificationToken?->email;
 
-        if (! $verificationToken?->isVerified() || $verificationToken->project_id !== $this->event->project_id || $verifiedEmail === null || strcasecmp($this->volunteerEmail, $verifiedEmail) !== 0) {
+        if (! $verificationToken?->isVerified() || $verificationToken->expires_at->isPast() || $verificationToken->project_id !== $this->event->project_id || $verifiedEmail === null || strcasecmp($this->volunteerEmail, $verifiedEmail) !== 0) {
             $this->addError('volunteerEmail', __('Your verified email no longer matches the submitted email. Please verify your email again before completing your signup.'));
             $this->restartSignup();
 
@@ -684,6 +748,10 @@ class EventSignup extends Component
         $this->state = WizardState::EmailEntry;
         $this->selectedShiftIds = [];
         $this->reservationExpiresAt = '';
+        $this->volunteerFirstName = '';
+        $this->volunteerLastName = '';
+        $this->volunteerEmail = '';
+        $this->volunteerPhone = '';
         $this->warningMessage = '';
         $this->lookupMessage = '';
         $this->notificationSubscriptionEmail = '';
@@ -696,7 +764,63 @@ class EventSignup extends Component
         $this->customFieldResponses = [];
         $this->isReturningVolunteer = false;
         $this->verificationStartedAt = null;
-        unset($this->jobs, $this->overlappingShiftIds, $this->selectedJobIds, $this->gearItems, $this->hasGearOrFields);
+        unset($this->jobs, $this->overlapConflictMap, $this->overlappingShiftIds, $this->selectedJobIds, $this->gearItems, $this->hasGearOrFields);
+    }
+
+    /**
+     * @return array<int, array{shift: Shift, label: string}>
+     */
+    private function shiftContextMap(): array
+    {
+        $timezone = $this->event->project->timezone ?? 'UTC';
+        $contexts = [];
+
+        foreach ($this->jobs as $job) {
+            foreach ($job->shifts as $shift) {
+                $contexts[(int) $shift->id] = [
+                    'shift' => $shift,
+                    'label' => $job->name.' — '.$shift->shift_date->setTimezone($timezone)->format('M d').' '.$shift->displayTimeRange($timezone),
+                ];
+            }
+        }
+
+        return $contexts;
+    }
+
+    private function shiftsOverlap(Shift $firstShift, Shift $secondShift): bool
+    {
+        return $firstShift->starts_at < $secondShift->ends_at
+            && $firstShift->ends_at > $secondShift->starts_at;
+    }
+
+    /**
+     * @param  array<int, array{shift_id: int, shift_label: string, conflicts: array<int, array{shift_id: int, shift_label: string, is_existing: bool}>}>  $conflicts
+     * @param  array{shift: Shift, label: string}  $selectedShift
+     * @param  array{shift: Shift, label: string}  $conflictingShift
+     */
+    private function addOverlapConflict(array &$conflicts, array $selectedShift, array $conflictingShift, bool $isExisting): void
+    {
+        $selectedShiftId = (int) $selectedShift['shift']->id;
+        $conflictingShiftId = (int) $conflictingShift['shift']->id;
+
+        $conflicts[$selectedShiftId] ??= [
+            'shift_id' => $selectedShiftId,
+            'shift_label' => $selectedShift['label'],
+            'conflicts' => [],
+        ];
+
+        $alreadyRecorded = collect($conflicts[$selectedShiftId]['conflicts'])
+            ->contains(fn (array $conflict) => $conflict['shift_id'] === $conflictingShiftId);
+
+        if ($alreadyRecorded) {
+            return;
+        }
+
+        $conflicts[$selectedShiftId]['conflicts'][] = [
+            'shift_id' => $conflictingShiftId,
+            'shift_label' => $conflictingShift['label'],
+            'is_existing' => $isExisting,
+        ];
     }
 
     private function validateGearAndCustomFields(): void
@@ -742,6 +866,43 @@ class EventSignup extends Component
         ]);
     }
 
+    /**
+     * @param  array{shift_id: int, shift_label: string, conflicts: array<int, array{shift_id: int, shift_label: string, is_existing: bool}>}  $conflict
+     */
+    public function overlapConflictMessage(array $conflict): string
+    {
+        $existingLabels = collect($conflict['conflicts'])
+            ->filter(fn (array $item) => $item['is_existing'])
+            ->pluck('shift_label')
+            ->values()
+            ->all();
+
+        $selectedLabels = collect($conflict['conflicts'])
+            ->reject(fn (array $item) => $item['is_existing'])
+            ->pluck('shift_label')
+            ->values()
+            ->all();
+
+        $segments = [];
+
+        if ($existingLabels !== []) {
+            $segments[] = count($existingLabels) === 1
+                ? __('your existing shift :shifts', ['shifts' => $this->implodeLabels($existingLabels)])
+                : __('your existing shifts :shifts', ['shifts' => $this->implodeLabels($existingLabels)]);
+        }
+
+        if ($selectedLabels !== []) {
+            $segments[] = count($selectedLabels) === 1
+                ? __('the selected shift :shifts', ['shifts' => $this->implodeLabels($selectedLabels)])
+                : __('the selected shifts :shifts', ['shifts' => $this->implodeLabels($selectedLabels)]);
+        }
+
+        return __('Deselect :shift because it overlaps :conflicts.', [
+            'shift' => $conflict['shift_label'],
+            'conflicts' => $this->implodeLabels($segments),
+        ]);
+    }
+
     private function prefillFromVolunteer(?Volunteer $volunteer): void
     {
         if (! $volunteer) {
@@ -776,5 +937,57 @@ class EventSignup extends Component
         if (! empty($this->existingShiftIds) || ! empty($this->existingGearSelections)) {
             $this->lookupMessage = __('Details pre-filled from your previous signup.');
         }
+    }
+
+    private function ensureStateIs(WizardState $expectedState): bool
+    {
+        if ($this->state === $expectedState) {
+            return true;
+        }
+
+        $this->addError('state', __('Please continue from the current signup step.'));
+
+        return false;
+    }
+
+    private function currentPendingVerificationToken(): ?EmailVerificationToken
+    {
+        if ($this->verificationTokenId === null) {
+            return null;
+        }
+
+        $token = EmailVerificationToken::find($this->verificationTokenId);
+
+        if (! $token) {
+            return null;
+        }
+
+        if ($token->event_id !== $this->event->id || $token->project_id !== $this->event->project_id) {
+            return null;
+        }
+
+        if ($token->isVerified() || $token->expires_at->isPast()) {
+            return null;
+        }
+
+        if (strcasecmp($token->email ?? '', $this->volunteerEmail) !== 0) {
+            return null;
+        }
+
+        return $token;
+    }
+
+    /**
+     * @param  array<int, string>  $labels
+     */
+    private function implodeLabels(array $labels): string
+    {
+        if (count($labels) <= 1) {
+            return $labels[0] ?? '';
+        }
+
+        $lastLabel = array_pop($labels);
+
+        return implode(', ', $labels).' '.__('and').' '.$lastLabel;
     }
 }

--- a/e2e/entry-staff-scanner-event-split.spec.ts
+++ b/e2e/entry-staff-scanner-event-split.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { loadFixtures } from './fixtures.js';
+
 test('organizer configures an entry staff scanner with separate entry and pool events', async ({ page }) => {
     await page.goto('/login');
     await page.getByPlaceholder('email@example.com').fill('test@example.com');
@@ -8,13 +10,11 @@ test('organizer configures an entry staff scanner with separate entry and pool e
 
     await expect(page).toHaveURL(/\/admin\/dashboard$/);
 
-    await page.goto('/e2e-fixtures.json');
-
-    const fixtures = JSON.parse(await page.locator('body').innerText()) as {
+    const fixtures = await loadFixtures<{
         entryPoolProjectId: number;
         entryPoolEntryEventId: number;
         entryPoolPoolEventId: number;
-    };
+    }>();
 
     await page.goto(`/admin/projects/${fixtures.entryPoolProjectId}/scanners`);
     await expect(page.getByRole('button', { name: 'New Scanner' })).toBeVisible();

--- a/e2e/fixtures.d.ts
+++ b/e2e/fixtures.d.ts
@@ -1,0 +1,1 @@
+export declare function loadFixtures<T>(): Promise<T>;

--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -1,0 +1,7 @@
+import { readFile } from 'node:fs/promises';
+
+const fixtureFile = new URL('./.generated/fixtures.json', import.meta.url);
+
+export async function loadFixtures() {
+    return JSON.parse(await readFile(fixtureFile, 'utf8'));
+}

--- a/e2e/guest-list-invitation-reliability.spec.ts
+++ b/e2e/guest-list-invitation-reliability.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
 
+import { loadFixtures } from './fixtures.js';
+
 type Fixtures = {
     guestListReliabilityProjectId: number;
     guestListReliabilityGuestListId: number;
@@ -77,14 +79,8 @@ async function login(page: Page): Promise<void> {
     await expect(page).toHaveURL(/\/admin\/dashboard$/);
 }
 
-async function loadFixtures(page: Page): Promise<Fixtures> {
-    await page.goto('/e2e-fixtures.json');
-
-    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
-}
-
 test('organizer can see failed invitation groups, resend them, and repair a failed address inline', async ({ page, request }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await login(page);
     await page.goto(`/admin/projects/${fixtures.guestListReliabilityProjectId}/guest-lists/${fixtures.guestListReliabilityGuestListId}`);
@@ -140,7 +136,7 @@ test('organizer can see failed invitation groups, resend them, and repair a fail
 });
 
 test('organizer sees sending-active wording on guest list badges and activation flow', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await login(page);
     await page.goto(`/admin/projects/${fixtures.guestListReliabilityProjectId}/guest-lists`);
@@ -166,7 +162,7 @@ test('organizer sees sending-active wording on guest list badges and activation 
 });
 
 test('guest invitation emails expose the browser fallback as a CTA button', async ({ page, request }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     const invitation = await waitForSingleMessageForRecipient(request, fixtures.guestListReliabilitySentInviteEmail);
     const guestPassUrls = extractUrls(

--- a/e2e/pending-deletion-retention.spec.ts
+++ b/e2e/pending-deletion-retention.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { loadFixtures } from './fixtures.js';
+
 type Fixtures = {
     deletionProjectId: number;
     deletionEventId: number;
@@ -17,14 +19,8 @@ async function login(page: Page): Promise<void> {
     await expect(page).toHaveURL(/\/admin\/dashboard$/);
 }
 
-async function loadFixtures(page: Page): Promise<Fixtures> {
-    await page.goto('/e2e-fixtures.json');
-
-    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
-}
-
 test('event deletion UI uses the 7-day retention copy', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await login(page);
     await page.goto(`/admin/events/${fixtures.deletionEventId}`);
@@ -38,7 +34,7 @@ test('event deletion UI uses the 7-day retention copy', async ({ page }) => {
 });
 
 test('project deletion UI uses the 7-day retention copy', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await login(page);
     await page.goto(`/admin/projects/${fixtures.deletionProjectId}`);

--- a/e2e/scanner-auth-timezone.spec.ts
+++ b/e2e/scanner-auth-timezone.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { loadFixtures } from './fixtures.js';
+
 type Fixtures = {
     scannerAuthBerlinToken: string;
     scannerAuthBerlinStartLabel: string;
@@ -7,14 +9,8 @@ type Fixtures = {
     scannerAuthUtcStartLabel: string;
 };
 
-async function loadFixtures(page: Page): Promise<Fixtures> {
-    await page.goto('/e2e-fixtures.json');
-
-    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
-}
-
 test('scheduled scanner auth shows the project timezone start time', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await page.goto(`/s/${fixtures.scannerAuthBerlinToken}`);
 
@@ -23,7 +19,7 @@ test('scheduled scanner auth shows the project timezone start time', async ({ pa
 });
 
 test('scheduled scanner auth falls back to UTC when the project timezone is empty', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     await page.goto(`/s/${fixtures.scannerAuthUtcToken}`);
 

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -875,6 +875,217 @@ vendor/bin/sail artisan tinker --execute="
       'capacity' => 10,
     ]);
 
+    \App\Models\Event::where('name', 'E2E Signup Conflict Event')->delete();
+    \App\Models\Project::where('name', 'E2E Signup Conflict Project')->delete();
+
+    \$signupConflictProject = Project::factory()->for(\$organization)->create([
+      'name' => 'E2E Signup Conflict Project',
+      'timezone' => 'UTC',
+    ]);
+
+    \$signupConflictEvent = Event::factory()->for(\$organization)->for(\$signupConflictProject)->published()->create([
+      'name' => 'E2E Signup Conflict Event',
+      'slug' => 'e2e-signup-conflict-event',
+      'starts_at' => now()->addDays(30),
+      'ends_at' => now()->addDays(30)->addHours(12),
+    ]);
+
+    \$signupConflictEvent->forceFill([
+      'public_token' => 'e2e-signup-conflict-token',
+    ])->save();
+
+    \$createVerifiedSignupToken = function (?Volunteer \$volunteer, string \$email, string \$plainTextToken) use (\$signupConflictEvent, \$signupConflictProject): string {
+      \$tokenHash = \App\ValueObjects\HashedToken::fromPlaintext(\$plainTextToken)->hash;
+
+      \App\Models\EmailVerificationToken::where('token_hash', \$tokenHash)->delete();
+
+      \App\Models\EmailVerificationToken::create([
+        'volunteer_id' => \$volunteer?->id,
+        'event_id' => \$signupConflictEvent->id,
+        'project_id' => \$signupConflictProject->id,
+        'email' => \$email,
+        'token_hash' => \$tokenHash,
+        'expires_at' => now()->addHour(),
+        'verified_at' => now(),
+      ]);
+
+      return \$tokenHash;
+    };
+
+    \$conflictNewVolunteer = Volunteer::factory()->verified()->for(\$signupConflictProject)->create([
+      'first_name' => 'Nina',
+      'last_name' => 'Overlap',
+      'email' => 'signup-conflict-new@example.com',
+      'phone' => '+15550002101',
+    ]);
+
+    \$returningConflictVolunteer = Volunteer::factory()->verified()->for(\$signupConflictProject)->create([
+      'first_name' => 'Elli',
+      'last_name' => 'Existing',
+      'email' => 'signup-conflict-existing@example.com',
+      'phone' => '+15550002102',
+    ]);
+
+    \$reactivateSuccessVolunteer = Volunteer::factory()->verified()->for(\$signupConflictProject)->create([
+      'first_name' => 'Rita',
+      'last_name' => 'Return',
+      'email' => 'signup-conflict-reactivate-ok@example.com',
+      'phone' => '+15550002103',
+    ]);
+
+    \$reactivateBlockedVolunteer = Volunteer::factory()->verified()->for(\$signupConflictProject)->create([
+      'first_name' => 'Blake',
+      'last_name' => 'Blocked',
+      'email' => 'signup-conflict-reactivate-blocked@example.com',
+      'phone' => '+15550002104',
+    ]);
+
+    \$newVsNewJobA = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Morning Setup',
+    ]);
+    \$newVsNewJobB = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Registration Desk',
+    ]);
+    \$newVsNewJobC = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Closing Support',
+    ]);
+
+    Shift::factory()->create([
+      'volunteer_job_id' => \$newVsNewJobA->id,
+      'shift_date' => '2026-09-10',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-10 09:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-10 12:00:00', 'UTC'),
+      'display_text' => 'Sep 10, 09:00 - 12:00',
+      'capacity' => 10,
+    ]);
+    Shift::factory()->create([
+      'volunteer_job_id' => \$newVsNewJobB->id,
+      'shift_date' => '2026-09-10',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-10 11:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-10 14:00:00', 'UTC'),
+      'display_text' => 'Sep 10, 11:00 - 14:00',
+      'capacity' => 10,
+    ]);
+    Shift::factory()->create([
+      'volunteer_job_id' => \$newVsNewJobC->id,
+      'shift_date' => '2026-09-10',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-10 15:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-10 18:00:00', 'UTC'),
+      'display_text' => 'Sep 10, 15:00 - 18:00',
+      'capacity' => 10,
+    ]);
+
+    \$heldJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Held Check-In',
+    ]);
+    \$newConflictJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Crowd Support',
+    ]);
+
+    \$heldShift = Shift::factory()->create([
+      'volunteer_job_id' => \$heldJob->id,
+      'shift_date' => '2026-09-11',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-11 10:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-11 14:00:00', 'UTC'),
+      'display_text' => 'Sep 11, 10:00 - 14:00',
+      'capacity' => 10,
+    ]);
+    \$newConflictShift = Shift::factory()->create([
+      'volunteer_job_id' => \$newConflictJob->id,
+      'shift_date' => '2026-09-11',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-11 12:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-11 15:00:00', 'UTC'),
+      'display_text' => 'Sep 11, 12:00 - 15:00',
+      'capacity' => 10,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$returningConflictVolunteer->id,
+      'shift_id' => \$heldShift->id,
+    ]);
+
+    \$reactivateSuccessCancelledJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Warehouse Morning',
+    ]);
+    \$reactivateSuccessActiveJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Welcome Tent',
+    ]);
+
+    \$reactivateSuccessCancelledShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reactivateSuccessCancelledJob->id,
+      'shift_date' => '2026-09-12',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-12 10:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-12 14:00:00', 'UTC'),
+      'display_text' => 'Sep 12, 10:00 - 14:00',
+      'capacity' => 10,
+    ]);
+    \$reactivateSuccessActiveShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reactivateSuccessActiveJob->id,
+      'shift_date' => '2026-09-12',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-12 15:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-12 18:00:00', 'UTC'),
+      'display_text' => 'Sep 12, 15:00 - 18:00',
+      'capacity' => 10,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$reactivateSuccessVolunteer->id,
+      'shift_id' => \$reactivateSuccessActiveShift->id,
+    ]);
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$reactivateSuccessVolunteer->id,
+      'shift_id' => \$reactivateSuccessCancelledShift->id,
+      'cancelled_at' => now()->subDay(),
+    ]);
+
+    \$reactivateBlockedCancelledJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Check-In Revisit',
+    ]);
+    \$reactivateBlockedActiveJob = VolunteerJob::factory()->create([
+      'event_id' => \$signupConflictEvent->id,
+      'name' => 'Main Stage Help',
+    ]);
+
+    \$reactivateBlockedCancelledShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reactivateBlockedCancelledJob->id,
+      'shift_date' => '2026-09-13',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-13 10:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-13 14:00:00', 'UTC'),
+      'display_text' => 'Sep 13, 10:00 - 14:00',
+      'capacity' => 10,
+    ]);
+    \$reactivateBlockedActiveShift = Shift::factory()->create([
+      'volunteer_job_id' => \$reactivateBlockedActiveJob->id,
+      'shift_date' => '2026-09-13',
+      'starts_at' => \Carbon\Carbon::parse('2026-09-13 11:00:00', 'UTC'),
+      'ends_at' => \Carbon\Carbon::parse('2026-09-13 16:00:00', 'UTC'),
+      'display_text' => 'Sep 13, 11:00 - 16:00',
+      'capacity' => 10,
+    ]);
+
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$reactivateBlockedVolunteer->id,
+      'shift_id' => \$reactivateBlockedActiveShift->id,
+    ]);
+    ShiftSignup::factory()->create([
+      'volunteer_id' => \$reactivateBlockedVolunteer->id,
+      'shift_id' => \$reactivateBlockedCancelledShift->id,
+      'cancelled_at' => now()->subDay(),
+    ]);
+
+    \$signupConflictNewVolunteerHash = \$createVerifiedSignupToken(\$conflictNewVolunteer, \$conflictNewVolunteer->email, 'e2e-signup-conflict-new-vt');
+    \$signupConflictReturningConflictHash = \$createVerifiedSignupToken(\$returningConflictVolunteer, \$returningConflictVolunteer->email, 'e2e-signup-conflict-existing-vt');
+    \$signupConflictReactivateSuccessHash = \$createVerifiedSignupToken(\$reactivateSuccessVolunteer, \$reactivateSuccessVolunteer->email, 'e2e-signup-conflict-reactivate-ok-vt');
+    \$signupConflictReactivateBlockedHash = \$createVerifiedSignupToken(\$reactivateBlockedVolunteer, \$reactivateBlockedVolunteer->email, 'e2e-signup-conflict-reactivate-blocked-vt');
+
     \App\Models\Project::where('name', 'E2E Guest List Reliability Project')->delete();
 
     \$guestListProject = Project::factory()->for(\$organization)->create([
@@ -952,7 +1163,11 @@ vendor/bin/sail artisan tinker --execute="
       new \App\Mail\GuestInvitationMail(\$guestList, new \Illuminate\Database\Eloquent\Collection([\$sentEntry]))
     );
 
-    file_put_contents(base_path('public/e2e-fixtures.json'), json_encode([
+    if (! is_dir(base_path('e2e/.generated'))) {
+      mkdir(base_path('e2e/.generated'), 0777, true);
+    }
+
+    file_put_contents(base_path('e2e/.generated/fixtures.json'), json_encode([
       'entryPoolProjectId' => \$entryPoolProject->id,
       'entryPoolEntryEventId' => \$entryEvent->id,
       'entryPoolPoolEventId' => \$poolEvent->id,
@@ -971,6 +1186,11 @@ vendor/bin/sail artisan tinker --execute="
       'signupGraceEventId' => \$signupGraceEvent->id,
       'signupGracePublicToken' => 'e2e-signup-grace-token',
       'signupGraceVerificationHash' => \$signupGraceVerificationHash,
+      'signupConflictPublicToken' => 'e2e-signup-conflict-token',
+      'signupConflictNewVolunteerHash' => \$signupConflictNewVolunteerHash,
+      'signupConflictReturningConflictHash' => \$signupConflictReturningConflictHash,
+      'signupConflictReactivateSuccessHash' => \$signupConflictReactivateSuccessHash,
+      'signupConflictReactivateBlockedHash' => \$signupConflictReactivateBlockedHash,
       'guestListReliabilityProjectId' => \$guestListProject->id,
       'guestListReliabilityGuestListId' => \$guestList->id,
       'guestListReliabilityDraftGuestListId' => \$draftGuestList->id,

--- a/e2e/signup-conflict-ux.spec.ts
+++ b/e2e/signup-conflict-ux.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import { loadFixtures } from './fixtures.js';
+
+type Fixtures = {
+    signupConflictPublicToken: string;
+    signupConflictNewVolunteerHash: string;
+    signupConflictReturningConflictHash: string;
+    signupConflictReactivateSuccessHash: string;
+    signupConflictReactivateBlockedHash: string;
+};
+
+function publicSignupUrl(publicToken: string, verificationHash: string): string {
+    return `/events/${publicToken}?vt=${verificationHash}`;
+}
+
+async function continueToShiftSelection(page: Page, url: string): Promise<void> {
+    await page.goto(url);
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByRole('heading', { name: 'Choose Your Shifts' })).toBeVisible();
+}
+
+function jobCard(page: Page, jobName: string): Locator {
+    return page
+        .locator('div[wire\\:key^="job-"]')
+        .filter({ has: page.locator('h3', { hasText: jobName }) });
+}
+
+function shiftCheckbox(page: Page, jobName: string): Locator {
+    return jobCard(page, jobName).locator('input[type="checkbox"]').first();
+}
+
+test('newly selected overlapping shifts show specific conflict names and clear after deselection', async ({ page }) => {
+    const fixtures = await loadFixtures<Fixtures>();
+
+    await continueToShiftSelection(
+        page,
+        publicSignupUrl(fixtures.signupConflictPublicToken, fixtures.signupConflictNewVolunteerHash),
+    );
+
+    await shiftCheckbox(page, 'Morning Setup').check();
+    await shiftCheckbox(page, 'Registration Desk').check();
+
+    const conflictWarning = page.locator('#shift-selection-conflicts');
+
+    await expect(conflictWarning).toBeVisible();
+    await expect(conflictWarning).toContainText('Morning Setup');
+    await expect(conflictWarning).toContainText('Registration Desk');
+
+    await shiftCheckbox(page, 'Registration Desk').uncheck();
+
+    await expect(conflictWarning).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Confirm Your Signup' })).toBeVisible();
+    await expect(page.locator('div').filter({ hasText: 'Selected Shifts' }).getByText('Morning Setup:')).toBeVisible();
+});
+
+test('returning volunteer conflict copy names the held shift and only flags the new selection', async ({ page }) => {
+    const fixtures = await loadFixtures<Fixtures>();
+
+    await continueToShiftSelection(
+        page,
+        publicSignupUrl(fixtures.signupConflictPublicToken, fixtures.signupConflictReturningConflictHash),
+    );
+
+    const heldShift = jobCard(page, 'Held Check-In');
+    await expect(heldShift).toContainText('Already signed up');
+
+    await shiftCheckbox(page, 'Crowd Support').check();
+
+    const conflictItems = page.locator('#shift-selection-conflicts li');
+    await expect(conflictItems).toHaveCount(1);
+    await expect(conflictItems.first()).toContainText('Crowd Support');
+    await expect(conflictItems.first()).toContainText('Held Check-In');
+
+    await shiftCheckbox(page, 'Crowd Support').uncheck();
+    await shiftCheckbox(page, 'Closing Support').check();
+
+    await expect(page.locator('#shift-selection-conflicts')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Confirm Your Signup' })).toBeVisible();
+    await expect(page.locator('div').filter({ hasText: 'Selected Shifts' }).getByText('(already signed up)')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Back' }).click();
+    await expect(page.getByRole('heading', { name: 'Choose Your Shifts' })).toBeVisible();
+
+    await shiftCheckbox(page, 'Crowd Support').check();
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(page.getByText('Some selected shifts overlap in time. Review the conflict details below before continuing.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Choose Your Shifts' })).toBeVisible();
+});
+
+test('cancelled shift can be re-selected and reactivated when the active schedule no longer overlaps', async ({ page }) => {
+    const fixtures = await loadFixtures<Fixtures>();
+
+    await continueToShiftSelection(
+        page,
+        publicSignupUrl(fixtures.signupConflictPublicToken, fixtures.signupConflictReactivateSuccessHash),
+    );
+
+    const activeShift = jobCard(page, 'Welcome Tent');
+    await expect(activeShift).toContainText('Already signed up');
+
+    await shiftCheckbox(page, 'Warehouse Morning').check();
+    await expect(page.locator('#shift-selection-conflicts')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByRole('heading', { name: 'Confirm Your Signup' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await expect(page.getByRole('heading', { name: "You're signed up!" })).toBeVisible();
+});
+
+test('cancelled shift stays blocked when a newer active signup still overlaps it', async ({ page }) => {
+    const fixtures = await loadFixtures<Fixtures>();
+
+    await continueToShiftSelection(
+        page,
+        publicSignupUrl(fixtures.signupConflictPublicToken, fixtures.signupConflictReactivateBlockedHash),
+    );
+
+    const activeShift = jobCard(page, 'Main Stage Help');
+    await expect(activeShift).toContainText('Already signed up');
+
+    await shiftCheckbox(page, 'Check-In Revisit').check();
+
+    const conflictItems = page.locator('#shift-selection-conflicts li');
+    await expect(conflictItems).toHaveCount(1);
+    await expect(conflictItems.first()).toContainText('Check-In Revisit');
+    await expect(conflictItems.first()).toContainText('Main Stage Help');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(page.getByText('Some selected shifts overlap in time. Review the conflict details below before continuing.')).toBeVisible();
+    await expect(page.locator('#shift-selection-conflicts')).toContainText('Check-In Revisit');
+    await expect(page.locator('#shift-selection-conflicts')).toContainText('Main Stage Help');
+    await expect(page.getByRole('heading', { name: 'Choose Your Shifts' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Confirm Your Signup' })).toHaveCount(0);
+});

--- a/e2e/signup-grace-minutes.spec.ts
+++ b/e2e/signup-grace-minutes.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import { loadFixtures } from './fixtures.js';
+
 type Fixtures = {
     signupGraceEventId: number;
     signupGracePublicToken: string;
@@ -14,14 +16,8 @@ async function login(page: Page): Promise<void> {
     await expect(page).toHaveURL(/\/admin\/dashboard$/);
 }
 
-async function loadFixtures(page: Page): Promise<Fixtures> {
-    await page.goto('/e2e-fixtures.json');
-
-    return JSON.parse(await page.locator('body').innerText()) as Fixtures;
-}
-
 test('organizer updates signup grace minutes and the public signup list reacts immediately', async ({ page }) => {
-    const fixtures = await loadFixtures(page);
+    const fixtures = await loadFixtures<Fixtures>();
 
     const publicSignupUrl = `/events/${fixtures.signupGracePublicToken}?vt=${fixtures.signupGraceVerificationHash}`;
 

--- a/resources/views/livewire/public/event-signup.blade.php
+++ b/resources/views/livewire/public/event-signup.blade.php
@@ -10,10 +10,13 @@
             init() {
                 const labels = {
                     '{{ \App\Enums\WizardState::EmailEntry->value }}': '{{ __('Step 1: Enter Your Email') }}',
+                    '{{ \App\Enums\WizardState::PendingVerification->value }}': '{{ __('Email verification in progress') }}',
                     '{{ \App\Enums\WizardState::PersonalInfo->value }}': '{{ __('Step 2: Your Information') }}',
                     '{{ \App\Enums\WizardState::SelectingShifts->value }}': '{{ __('Step 3: Choose Your Shifts') }}',
                     '{{ \App\Enums\WizardState::GearAndFields->value }}': '{{ __('Step 4: Details') }}',
                     '{{ \App\Enums\WizardState::Confirming->value }}': '{{ __('Step 5: Confirm Your Signup') }}',
+                    '{{ \App\Enums\WizardState::Complete->value }}': '{{ __('Signup complete') }}',
+                    '{{ \App\Enums\WizardState::Expired->value }}': '{{ __('Reservation expired') }}',
                 };
                 this.$watch(() => $wire.state, (state) => {
                     this.announcement = labels[state] || '';
@@ -192,12 +195,18 @@
         </nav>
 
         @if ($warningMessage && $state === \App\Enums\WizardState::SelectingShifts)
-            <div class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(245,158,11,0.1); border: 1px solid rgba(245,158,11,0.2); color: #fbbf24;">
+            <div id="shift-selection-warning" class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(245,158,11,0.1); border: 1px solid rgba(245,158,11,0.2); color: #fbbf24;">
                 {{ $warningMessage }}
             </div>
         @endif
 
         @error('selectedShiftIds')
+            <div id="shift-selection-error" class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(230,57,70,0.1); border: 1px solid rgba(230,57,70,0.2); color: #fca5a5;">
+                {{ $message }}
+            </div>
+        @enderror
+
+        @error('state')
             <div class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(230,57,70,0.1); border: 1px solid rgba(230,57,70,0.2); color: #fca5a5;">
                 {{ $message }}
             </div>
@@ -279,6 +288,13 @@
 
         {{-- Step 2: Select Shifts --}}
         <div x-show="$wire.state === '{{ \App\Enums\WizardState::SelectingShifts->value }}'" x-cloak>
+            @php
+                $shiftGroupDescribedBy = collect([
+                    $warningMessage ? 'shift-selection-warning' : null,
+                    $errors->has('selectedShiftIds') ? 'shift-selection-error' : null,
+                    $this->overlapConflictMap !== [] ? 'shift-selection-conflicts' : null,
+                ])->filter()->implode(' ');
+            @endphp
             <div class="space-y-6 mb-8">
                 <div>
                     <h2 class="font-bebas text-white text-2xl" style="letter-spacing: 0.04em;" id="step-heading-{{ \App\Enums\WizardState::SelectingShifts->value }}" tabindex="-1">{{ __('Choose Your Shifts') }}</h2>
@@ -338,6 +354,7 @@
                         </div>
                     </div>
                 @else
+                    <div role="group" aria-labelledby="step-heading-{{ \App\Enums\WizardState::SelectingShifts->value }}" @if ($shiftGroupDescribedBy !== '') aria-describedby="{{ $shiftGroupDescribedBy }}" @endif>
                     @foreach ($this->jobs as $job)
                         <div class="rounded-lg overflow-hidden" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);" wire:key="job-{{ $job->id }}">
                             <div class="p-4" style="background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);">
@@ -356,15 +373,19 @@
 
                             <div class="p-4 space-y-3">
                                 @foreach ($job->shifts as $shift)
-                                    @php
-                                        $spotsLeft = $shift->spotsRemaining();
-                                        $isFull = $spotsLeft === 0;
-                                        $isSelected = in_array($shift->id, $selectedShiftIds);
-                                        $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
-                                        $isExisting = in_array($shift->id, $existingShiftIds);
-                                        $isLockedByPriorityGate = $this->priorityGateStatus['is_closed'] && ! $shift->is_priority && ! $isExisting;
-                                        $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
-                                    @endphp
+                                     @php
+                                         $spotsLeft = $shift->spotsRemaining();
+                                         $isFull = $spotsLeft === 0;
+                                         $isSelected = in_array($shift->id, $selectedShiftIds);
+                                         $isConflicting = in_array($shift->id, $this->overlappingShiftIds);
+                                         $isExisting = in_array($shift->id, $existingShiftIds);
+                                         $isLockedByPriorityGate = $this->priorityGateStatus['is_closed'] && ! $shift->is_priority && ! $isExisting;
+                                         $shiftTimeLabel = $job->name.' — '.$shift->shift_date->setTimezone($tz)->format('M d').' '.$shift->displayTimeRange($tz);
+                                         $shiftConflict = $this->overlapConflictMap[$shift->id] ?? null;
+                                         $describedBy = collect([
+                                             $shiftConflict !== null && $isSelected ? 'shift-conflict-description-'.$shift->id : null,
+                                         ])->filter()->implode(' ');
+                                      @endphp
                                     <label
                                         class="flex items-center justify-between p-3 rounded-lg transition-all duration-200"
                                         style="border: 2px solid {{ $isExisting ? 'rgba(59,130,246,0.3)' : ($isSelected && $isConflicting ? 'var(--yellow)' : ($isSelected ? 'var(--brand)' : 'rgba(255,255,255,0.08)')) }};
@@ -373,15 +394,16 @@
                                         wire:key="shift-{{ $shift->id }}"
                                     >
                                         <div class="flex items-center gap-3">
-                                            <input type="checkbox" value="{{ $shift->id }}"
-                                                wire:model.live="selectedShiftIds"
-                                                @disabled($isFull || $isExisting || $isLockedByPriorityGate)
-                                                @checked($isExisting)
-                                                @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
-                                                @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
-                                                @if ($isLockedByPriorityGate) aria-label="{{ $shiftTimeLabel }} — {{ __('Locked until priority shifts are filled') }}" @endif
-                                                class="accent-emerald-600"
-                                            />
+                                             <input type="checkbox" value="{{ $shift->id }}"
+                                                 wire:model.live="selectedShiftIds"
+                                                 @disabled($isFull || $isExisting || $isLockedByPriorityGate)
+                                                 @checked($isExisting)
+                                                 @if ($describedBy !== '') aria-describedby="{{ $describedBy }}" @endif
+                                                 @if ($isFull) aria-label="{{ $shiftTimeLabel }} — {{ __('Full, no spots available') }}" @endif
+                                                 @if ($isExisting) aria-label="{{ $shiftTimeLabel }} — {{ __('Already signed up') }}" @endif
+                                                 @if ($isLockedByPriorityGate) aria-label="{{ $shiftTimeLabel }} — {{ __('Locked until priority shifts are filled') }}" @endif
+                                                 class="accent-emerald-600"
+                                             />
                                             <div>
                                                 <span class="text-sm font-medium text-white">
                                                     {{ $shift->shift_date->setTimezone($tz)->format('M d') }} — {{ $shift->displayTimeRange($tz) }}
@@ -405,11 +427,17 @@
                                                     <span class="block text-sm" style="color: #a1a1aa;">
                                                         {{ $spotsLeft }} {{ __('spots remaining') }}
                                                     </span>
-                                                @endif
-                                            </div>
-                                        </div>
-                                        @if ($isExisting)
-                                            <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
+                                                 @endif
+                                             </div>
+
+                                              @if ($shiftConflict !== null && $isSelected)
+                                                  <span id="shift-conflict-description-{{ $shift->id }}" class="sr-only">
+                                                      {{ $this->overlapConflictMessage($shiftConflict) }}
+                                                  </span>
+                                              @endif
+                                         </div>
+                                         @if ($isExisting)
+                                             <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(59,130,246,0.15); color: #93c5fd;">{{ __('Signed Up') }}</span>
                                         @elseif ($isLockedByPriorityGate)
                                             <span class="text-xs font-semibold px-2 py-0.5 rounded" style="background: rgba(161,161,170,0.15); color: #d4d4d8;">{{ __('Locked') }}</span>
                                         @elseif ($isFull)
@@ -424,12 +452,21 @@
                             </div>
                         </div>
                     @endforeach
+                    </div>
                 @endif
             </div>
 
-            @if (count($this->overlappingShiftIds) > 0)
-                <div class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(245,158,11,0.1); border: 1px solid rgba(245,158,11,0.2); color: #fbbf24;">
-                    {{ __('Some selected shifts overlap in time. Deselect the highlighted shifts before continuing.') }}
+            @if ($this->overlapConflictMap !== [])
+                <div id="shift-selection-conflicts" role="alert" aria-live="assertive" aria-atomic="true" class="rounded-lg p-3 mb-4 text-sm" style="background: rgba(245,158,11,0.1); border: 1px solid rgba(245,158,11,0.2); color: #fbbf24;">
+                    <p class="font-medium text-white">{{ __('Some selected shifts overlap in time.') }}</p>
+
+                    <ul class="mt-2 space-y-1">
+                        @foreach ($this->overlapConflictMap as $conflict)
+                            <li id="shift-conflict-message-{{ $conflict['shift_id'] }}">
+                                {{ $this->overlapConflictMessage($conflict) }}
+                            </li>
+                        @endforeach
+                    </ul>
                 </div>
             @endif
 

--- a/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
+++ b/tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
@@ -17,6 +17,17 @@ use Carbon\Carbon;
 use Illuminate\Notifications\Action;
 use Illuminate\Support\Facades\Notification;
 
+function phaseFourCancelledResignupTimeline(): array
+{
+    $cancelledStart = Carbon::parse('2026-08-15 10:00:00');
+
+    return [
+        'cancelled' => [$cancelledStart, $cancelledStart->copy()->addHours(2)],
+        'overlapping_active' => [$cancelledStart->copy()->addHour(), $cancelledStart->copy()->addHours(3)],
+        'non_overlapping_active' => [$cancelledStart->copy()->addHours(3), $cancelledStart->copy()->addHours(5)],
+    ];
+}
+
 beforeEach(function () {
     Notification::fake();
 
@@ -314,8 +325,27 @@ it('cancelled signups do not count toward capacity', function () {
         ->and($result->newSignups)->toHaveCount(1);
 });
 
-it('re-signup reactivates a cancelled row', function () {
+it('reactivates a cancelled row when the volunteers active schedule no longer overlaps', function () {
     $volunteer = Volunteer::factory()->for($this->project)->create();
+    $timeline = phaseFourCancelledResignupTimeline();
+
+    $this->shift1->update([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['cancelled'][0],
+        'ends_at' => $timeline['cancelled'][1],
+    ]);
+
+    $activeShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['non_overlapping_active'][0],
+        'ends_at' => $timeline['non_overlapping_active'][1],
+        'capacity' => 5,
+    ]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $activeShift->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+
     $signup = ShiftSignup::factory()->create([
         'shift_id' => $this->shift1->id,
         'volunteer_id' => $volunteer->id,
@@ -330,6 +360,7 @@ it('re-signup reactivates a cancelled row', function () {
 
     expect($result->hasNewSignups())->toBeTrue()
         ->and($result->newSignups)->toHaveCount(1)
+        ->and($result->skippedOverlap)->toBeEmpty()
         ->and($signup->fresh()->cancelled_at)->toBeNull();
 });
 
@@ -455,24 +486,24 @@ it('allows adjacent non-overlapping shifts', function () {
         ->and($result->skippedOverlap)->toBeEmpty();
 });
 
-it('skips a reactivated shift that now overlaps a newer signup', function () {
+it('skips a reactivated shift that now overlaps a newer active signup', function () {
     $volunteer = Volunteer::factory()->for($this->project)->create();
+    $timeline = phaseFourCancelledResignupTimeline();
 
     $shiftA = Shift::factory()->for($this->job, 'volunteerJob')->create([
-        'shift_date' => '2026-06-01',
-        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
-        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['cancelled'][0],
+        'ends_at' => $timeline['cancelled'][1],
         'capacity' => 5,
     ]);
     $shiftB = Shift::factory()->for($this->job, 'volunteerJob')->create([
-        'shift_date' => '2026-06-01',
-        'starts_at' => Carbon::parse('2026-06-01 11:00:00'),
-        'ends_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['overlapping_active'][0],
+        'ends_at' => $timeline['overlapping_active'][1],
         'capacity' => 5,
     ]);
 
-    // Volunteer has a cancelled signup for A and an active signup for B
-    ShiftSignup::factory()->create([
+    $cancelledSignup = ShiftSignup::factory()->create([
         'shift_id' => $shiftA->id,
         'volunteer_id' => $volunteer->id,
         'cancelled_at' => now(),
@@ -491,7 +522,8 @@ it('skips a reactivated shift that now overlaps a newer signup', function () {
 
     expect($result->hasNewSignups())->toBeFalse()
         ->and($result->skippedOverlap)->toHaveCount(1)
-        ->and($result->skippedOverlap[0]->id)->toBe($shiftA->id);
+        ->and($result->skippedOverlap[0]->id)->toBe($shiftA->id)
+        ->and($cancelledSignup->fresh()->cancelled_at)->not->toBeNull();
 });
 
 // --- Cross-day overlap tests ---

--- a/tests/Feature/Livewire/EventSignupTest.php
+++ b/tests/Feature/Livewire/EventSignupTest.php
@@ -24,6 +24,20 @@ function simulateLivewireVerification($component, string $email)
     return $component->call('checkVerification');
 }
 
+function startLivewireSignupWizard(string $publicToken, string $email = 'test@example.com')
+{
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $publicToken])
+        ->set('volunteerEmail', $email)
+        ->call('submitEmail');
+
+    simulateLivewireVerification($component, $email);
+
+    return $component
+        ->set('volunteerFirstName', 'Test')
+        ->set('volunteerLastName', 'Person')
+        ->call('advanceToShifts');
+}
+
 beforeEach(function () {
     Notification::fake();
     $this->org = Organization::factory()->create();
@@ -38,12 +52,7 @@ it('renders custom fields on step 2 of the wizard', function () {
     CustomRegistrationField::factory()->select(['Vegan', 'None'])->for($this->event)->create(['label' => 'Diet', 'sort_order' => 2]);
     CustomRegistrationField::factory()->checkbox()->for($this->event)->create(['label' => 'Photo Release', 'sort_order' => 3]);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -65,12 +74,7 @@ it('does not render deleted custom fields', function () {
 it('validates required custom fields on step 2', function () {
     $field = CustomRegistrationField::factory()->required()->for($this->event)->create(['label' => 'Required Field']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -132,12 +136,7 @@ it('completes signup with custom fields for verified volunteer', function () {
 it('renders placeholder option in custom field select dropdown', function () {
     CustomRegistrationField::factory()->select(['Vegan', 'Vegetarian', 'None'])->for($this->event)->create(['label' => 'Diet Preference']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -147,12 +146,7 @@ it('renders placeholder option in custom field select dropdown', function () {
 it('renders placeholder option in gear size select dropdown', function () {
     ProjectGearItem::factory()->sized(['S', 'M', 'L'])->for($this->project)->create(['name' => 'T-Shirt']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -174,12 +168,7 @@ it('renders without error when gear item has requires_size true but available_si
 it('validates multi-choice custom field with array values', function () {
     $field = CustomRegistrationField::factory()->select(['Red', 'Blue', 'Green'])->allowMultiple()->for($this->event)->create(['label' => 'Favorite Colors']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)
@@ -192,12 +181,7 @@ it('validates multi-choice custom field with array values', function () {
 it('advances to confirmation when gear items exist but none require size validation', function () {
     ProjectGearItem::factory()->for($this->project)->create(['name' => 'Badge']);
 
-    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
-        ->set('state', WizardState::PersonalInfo)
-        ->set('volunteerFirstName', 'Test')
-        ->set('volunteerLastName', 'Person')
-        ->set('volunteerEmail', 'test@example.com')
-        ->call('advanceToShifts')
+    startLivewireSignupWizard($this->event->public_token)
         ->set('selectedShiftIds', [$this->shift->id])
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::GearAndFields)

--- a/tests/Feature/Public/EventSignupTest.php
+++ b/tests/Feature/Public/EventSignupTest.php
@@ -37,6 +37,22 @@ function simulateVerification(Testable $component, string $email): Testable
     return $component->call('checkVerification');
 }
 
+function eventSignupPhaseFourTimeline(): array
+{
+    $cancelledStart = Carbon::parse('2026-08-15 10:00:00');
+
+    return [
+        'cancelled' => [$cancelledStart, $cancelledStart->copy()->addHours(2)],
+        'overlapping_active' => [$cancelledStart->copy()->addHour(), $cancelledStart->copy()->addHours(3)],
+        'non_overlapping_active' => [$cancelledStart->copy()->addHours(3), $cancelledStart->copy()->addHours(5)],
+    ];
+}
+
+function eventSignupShiftTimeLabel(VolunteerJob $job, Shift $shift, string $timezone): string
+{
+    return $job->name.' — '.$shift->shift_date->setTimezone($timezone)->format('M d').' '.$shift->displayTimeRange($timezone);
+}
+
 beforeEach(function () {
     Notification::fake();
 
@@ -371,6 +387,29 @@ it('prefills data for returning verified volunteer only after verification', fun
         ->assertSet('state', WizardState::PersonalInfo);
 });
 
+it('does not resume personal info from an expired verified vt token', function () {
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'expired-vt@example.com',
+        'first_name' => 'Expired',
+        'last_name' => 'Resume',
+    ]);
+
+    $token = EmailVerificationToken::factory()->create([
+        'volunteer_id' => $volunteer->id,
+        'event_id' => $this->event->id,
+        'project_id' => $this->project->id,
+        'email' => $volunteer->email,
+        'verified_at' => now()->subMinutes(5),
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    Livewire::withQueryParams(['vt' => $token->token_hash])
+        ->test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->assertSet('state', WizardState::EmailEntry)
+        ->assertSet('verificationTokenId', null)
+        ->assertSet('volunteerEmail', '');
+});
+
 it('shows identical response for known and unknown emails', function () {
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'known@example.com']);
 
@@ -388,6 +427,31 @@ it('shows identical response for known and unknown emails', function () {
         ->and($unknown->get('volunteerFirstName'))->toBe('')
         ->and($known->get('isReturningVolunteer'))->toBeFalse()
         ->and($unknown->get('isReturningVolunteer'))->toBeFalse();
+});
+
+it('scopes the initial email lookup throttle to the current event', function () {
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'scoped-lookup@example.com')
+        ->call('submitEmail')
+        ->assertHasNoErrors();
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'scoped-lookup@example.com')
+        ->call('submitEmail')
+        ->assertHasNoErrors();
+
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'scoped-lookup@example.com')
+        ->call('submitEmail')
+        ->assertHasNoErrors();
+
+    Livewire::test(EventSignup::class, ['publicToken' => $otherEvent->public_token])
+        ->set('volunteerEmail', 'scoped-lookup@example.com')
+        ->call('submitEmail')
+        ->assertHasNoErrors('volunteerEmail')
+        ->assertSet('state', WizardState::PendingVerification);
 });
 
 it('completes full wizard for verified volunteer with verification step', function () {
@@ -411,6 +475,60 @@ it('completes full wizard for verified volunteer with verification step', functi
         ->call('submitSignup')
         ->assertHasNoErrors()
         ->assertSet('state', WizardState::Complete);
+});
+
+it('resendVerification requires the pending verification step', function () {
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'resend-step@example.com')
+        ->call('resendVerification')
+        ->assertHasErrors(['state'])
+        ->assertSet('state', WizardState::EmailEntry);
+});
+
+it('resendVerification validates the current email again', function () {
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'valid@example.com')
+        ->call('submitEmail')
+        ->assertSet('state', WizardState::PendingVerification);
+
+    $component->set('volunteerEmail', 'not-an-email')
+        ->call('resendVerification')
+        ->assertHasErrors(['volunteerEmail']);
+});
+
+it('resendVerification requires an active verification token', function () {
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'expired-resend@example.com')
+        ->call('submitEmail')
+        ->assertSet('state', WizardState::PendingVerification);
+
+    EmailVerificationToken::find($component->get('verificationTokenId'))?->update([
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    $component->call('resendVerification')
+        ->assertHasErrors(['volunteerEmail']);
+});
+
+it('scopes resend verification throttling to the current event', function () {
+    $otherEvent = Event::factory()->for($this->org)->for($this->project)->published()->create();
+
+    $firstComponent = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'scoped-resend@example.com')
+        ->call('submitEmail')
+        ->assertSet('state', WizardState::PendingVerification);
+
+    $firstComponent->call('resendVerification')
+        ->call('resendVerification')
+        ->call('resendVerification')
+        ->assertHasNoErrors();
+
+    $secondComponent = Livewire::test(EventSignup::class, ['publicToken' => $otherEvent->public_token])
+        ->set('volunteerEmail', 'scoped-resend@example.com')
+        ->call('submitEmail')
+        ->assertSet('state', WizardState::PendingVerification)
+        ->call('resendVerification')
+        ->assertHasNoErrors('volunteerEmail');
 });
 
 // --- Step 1: Shift selection & reservation ---
@@ -526,6 +644,44 @@ it('rejects inactive shifts during reservation even if submitted directly', func
         ->assertSet('state', WizardState::SelectingShifts);
 });
 
+it('rejects reserveAndAdvance outside the shift-selection step', function () {
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'wrong-step-reserve@example.com', 'first_name' => 'Wrong', 'last_name' => 'Step']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'wrong-step-reserve@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'wrong-step-reserve@example.com');
+
+    $component->call('reserveAndAdvance')
+        ->assertHasErrors(['state'])
+        ->assertSee(__('Please continue from the current signup step.'))
+        ->assertSet('state', WizardState::PersonalInfo);
+
+    expect(ShiftReservation::count())->toBe(0);
+});
+
+it('rejects hidden shift ids that are not renderable in the current public shift list', function () {
+    $hiddenJob = VolunteerJob::factory()->for($this->event)->create(['name' => 'Hidden']);
+    $hiddenShift = Shift::factory()->for($hiddenJob, 'volunteerJob')->create(['capacity' => 1]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $hiddenShift->id,
+        'volunteer_id' => Volunteer::factory()->for($this->project),
+    ]);
+
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'hidden-injection@example.com', 'first_name' => 'Hidden', 'last_name' => 'Injection']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'hidden-injection@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'hidden-injection@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$hiddenShift->id])
+        ->call('reserveAndAdvance')
+        ->assertHasErrors(['selectedShiftIds.0' => ['in']])
+        ->assertSet('state', WizardState::SelectingShifts);
+});
+
 it('blocks reserveAndAdvance when selected shifts overlap in time', function () {
     $shiftA = Shift::factory()->for($this->job, 'volunteerJob')->create([
         'shift_date' => '2026-06-01',
@@ -542,6 +698,10 @@ it('blocks reserveAndAdvance when selected shifts overlap in time', function () 
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
+    $timezone = $this->project->timezone ?? 'UTC';
+    $shiftALabel = eventSignupShiftTimeLabel($this->job, $shiftA, $timezone);
+    $shiftBLabel = eventSignupShiftTimeLabel($this->job, $shiftB, $timezone);
+
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
         ->call('submitEmail');
@@ -550,7 +710,14 @@ it('blocks reserveAndAdvance when selected shifts overlap in time', function () 
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->assertSee(__('Some selected shifts overlap in time'))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftALabel, 'conflicts' => __('the selected shift :shifts', ['shifts' => $shiftBLabel])]))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftBLabel, 'conflicts' => __('the selected shift :shifts', ['shifts' => $shiftALabel])]))
+        ->assertSeeHtml('role="alert" aria-live="assertive" aria-atomic="true"')
+        ->assertSeeHtml('id="shift-conflict-description-'.$shiftA->id.'"')
+        ->assertSeeHtml('aria-describedby="shift-conflict-description-'.$shiftA->id.'"')
         ->call('reserveAndAdvance')
+        ->assertHasErrors(['selectedShiftIds'])
+        ->assertSee(__('Some selected shifts overlap in time. Review the conflict details below before continuing.'))
         ->assertSet('state', WizardState::SelectingShifts);
 
     expect(ShiftReservation::count())->toBe(0);
@@ -586,6 +753,116 @@ it('allows reserveAndAdvance after deselecting one conflicting shift', function 
         ->assertSet('state', WizardState::Confirming);
 
     expect(ShiftReservation::where('shift_id', $shiftA->id)->count())->toBe(1);
+});
+
+it('marks only the conflicting shifts when three selected shifts include one non-overlapping option', function () {
+    $shiftA = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'capacity' => 10,
+    ]);
+    $shiftB = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'capacity' => 10,
+    ]);
+    $shiftC = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 14:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 16:00:00'),
+        'capacity' => 10,
+    ]);
+
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'three-shifts@example.com', 'first_name' => 'Three', 'last_name' => 'Shifts']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'three-shifts@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'three-shifts@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$shiftA->id, $shiftB->id, $shiftC->id])
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => eventSignupShiftTimeLabel($this->job, $shiftA, $timezone = $this->project->timezone ?? 'UTC'), 'conflicts' => __('the selected shift :shifts', ['shifts' => eventSignupShiftTimeLabel($this->job, $shiftB, $timezone)])]))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => eventSignupShiftTimeLabel($this->job, $shiftB, $timezone), 'conflicts' => __('the selected shift :shifts', ['shifts' => eventSignupShiftTimeLabel($this->job, $shiftA, $timezone)])]))
+        ->assertDontSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => eventSignupShiftTimeLabel($this->job, $shiftC, $timezone), 'conflicts' => __('the selected shift :shifts', ['shifts' => eventSignupShiftTimeLabel($this->job, $shiftA, $timezone)])]));
+
+    expect(array_keys($component->instance()->overlapConflictMap))
+        ->toEqualCanonicalizing([$shiftA->id, $shiftB->id])
+        ->and($component->instance()->overlappingShiftIds)
+        ->toEqualCanonicalizing([$shiftA->id, $shiftB->id]);
+});
+
+it('references all newly selected conflicting shifts when one shift overlaps multiple others', function () {
+    $shiftA = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'capacity' => 10,
+    ]);
+    $shiftB = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:30:00'),
+        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'capacity' => 10,
+    ]);
+    $shiftC = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 11:30:00'),
+        'ends_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'capacity' => 10,
+    ]);
+
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'multi-conflict@example.com', 'first_name' => 'Multi', 'last_name' => 'Conflict']);
+
+    $timezone = $this->project->timezone ?? 'UTC';
+    $shiftALabel = eventSignupShiftTimeLabel($this->job, $shiftA, $timezone);
+    $shiftBLabel = eventSignupShiftTimeLabel($this->job, $shiftB, $timezone);
+    $shiftCLabel = eventSignupShiftTimeLabel($this->job, $shiftC, $timezone);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'multi-conflict@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'multi-conflict@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$shiftA->id, $shiftB->id, $shiftC->id])
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftBLabel, 'conflicts' => __('the selected shifts :shifts', ['shifts' => $shiftALabel.' and '.$shiftCLabel])]))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftALabel, 'conflicts' => __('the selected shift :shifts', ['shifts' => $shiftBLabel])]))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftCLabel, 'conflicts' => __('the selected shift :shifts', ['shifts' => $shiftBLabel])]));
+});
+
+it('uses unique ids for visible and hidden conflict descriptions and associates the shift group with its messages', function () {
+    $shiftA = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 10:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 12:00:00'),
+        'capacity' => 10,
+    ]);
+    $shiftB = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-06-01',
+        'starts_at' => Carbon::parse('2026-06-01 11:00:00'),
+        'ends_at' => Carbon::parse('2026-06-01 13:00:00'),
+        'capacity' => 10,
+    ]);
+
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'ids@example.com', 'first_name' => 'Ids', 'last_name' => 'Check']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'ids@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'ids@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
+        ->assertSeeHtml('id="shift-conflict-description-'.$shiftA->id.'"')
+        ->assertSeeHtml('id="shift-conflict-message-'.$shiftA->id.'"')
+        ->assertSeeHtml('aria-describedby="shift-conflict-description-'.$shiftA->id.'"')
+        ->assertSeeHtml('role="group"')
+        ->assertSeeHtml('aria-labelledby="step-heading-selecting_shifts"')
+        ->assertSeeHtml('aria-describedby="shift-selection-conflicts"')
+        ->assertDontSeeHtml('aria-describedby="shift-conflict-message-'.$shiftA->id.'"');
 });
 
 it('allows selecting adjacent shifts that meet exactly at midnight', function () {
@@ -635,6 +912,10 @@ it('blocks reserveAndAdvance when overnight shift overlaps next-day shift', func
 
     Volunteer::factory()->for($this->project)->verified()->create(['email' => 'test@example.com', 'first_name' => 'Test', 'last_name' => 'Person']);
 
+    $timezone = $this->project->timezone ?? 'UTC';
+    $shiftALabel = eventSignupShiftTimeLabel($this->job, $shiftA, $timezone);
+    $shiftBLabel = eventSignupShiftTimeLabel($this->job, $shiftB, $timezone);
+
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'test@example.com')
         ->call('submitEmail');
@@ -643,6 +924,7 @@ it('blocks reserveAndAdvance when overnight shift overlaps next-day shift', func
         ->set('selectedShiftIds', [$shiftA->id, $shiftB->id])
         ->assertSee(__('Conflict'))
         ->assertSee(__('Some selected shifts overlap in time'))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $shiftALabel, 'conflicts' => __('the selected shift :shifts', ['shifts' => $shiftBLabel])]))
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::SelectingShifts);
 
@@ -719,6 +1001,21 @@ it('validates size is required for size-required gear items on step 2', function
         ->assertSet('state', WizardState::GearAndFields)
         ->call('advanceToConfirmation')
         ->assertHasErrors(['gearSelections.'.$tshirt->id]);
+});
+
+it('rejects advanceToConfirmation outside the gear step', function () {
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'wrong-step-details@example.com', 'first_name' => 'Wrong', 'last_name' => 'Details']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'wrong-step-details@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'wrong-step-details@example.com');
+
+    $component->call('advanceToShifts')
+        ->call('advanceToConfirmation')
+        ->assertHasErrors(['state'])
+        ->assertSee(__('Please continue from the current signup step.'))
+        ->assertSet('state', WizardState::SelectingShifts);
 });
 
 // --- Personal info step ---
@@ -845,6 +1142,53 @@ it('submits signup without phone number for verified volunteer', function () {
         ->assertSet('state', WizardState::Complete);
 
     expect(Volunteer::where('email', 'nophone@example.com')->first()->phone)->toBeNull();
+});
+
+it('rejects submitSignup outside the confirmation step', function () {
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'wrong-step-submit@example.com', 'first_name' => 'Wrong', 'last_name' => 'Submit']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'wrong-step-submit@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'wrong-step-submit@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id])
+        ->call('submitSignup')
+        ->assertHasErrors(['state'])
+        ->assertSee(__('Please continue from the current signup step.'))
+        ->assertSet('state', WizardState::SelectingShifts);
+
+    expect(ShiftSignup::where('shift_id', $this->shift->id)->count())->toBe(0);
+});
+
+it('rejects submitSignup when the verified token has expired', function () {
+    Volunteer::factory()->for($this->project)->verified()->create(['email' => 'expired-submit@example.com', 'first_name' => 'Expired', 'last_name' => 'Submit']);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'expired-submit@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'expired-submit@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$this->shift->id])
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::Confirming);
+
+    EmailVerificationToken::find($component->get('verificationTokenId'))?->update([
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    $component->call('submitSignup')
+        ->assertHasErrors(['volunteerEmail'])
+        ->assertSet('state', WizardState::EmailEntry);
+});
+
+it('includes pending complete and expired step labels in the live region map', function () {
+    Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->assertSee(__('Email verification in progress'))
+        ->assertSee(__('Signup complete'))
+        ->assertSee(__('Reservation expired'));
 });
 
 it('shows error for already signed up volunteer on all selected shifts', function () {
@@ -1097,6 +1441,30 @@ it('can restart signup after expiry', function () {
         ->assertSet('state', WizardState::EmailEntry)
         ->assertSet('selectedShiftIds', [])
         ->assertSet('reservationExpiresAt', '');
+});
+
+it('restartSignup clears volunteer-facing personal data', function () {
+    Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'restart-clear@example.com',
+        'first_name' => 'Restart',
+        'last_name' => 'Clear',
+        'phone' => '+15551230000',
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'restart-clear@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'restart-clear@example.com');
+
+    $component->assertSet('volunteerFirstName', 'Restart')
+        ->assertSet('volunteerLastName', 'Clear')
+        ->assertSet('volunteerEmail', 'restart-clear@example.com')
+        ->assertSet('volunteerPhone', '+15551230000')
+        ->call('restartSignup')
+        ->assertSet('volunteerFirstName', '')
+        ->assertSet('volunteerLastName', '')
+        ->assertSet('volunteerEmail', '')
+        ->assertSet('volunteerPhone', '');
 });
 
 it('sets reservationExpiresAt after reservation', function () {
@@ -1436,6 +1804,10 @@ it('detects overlap between new shift and existing shift for returning volunteer
     $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'returning@example.com']);
     ShiftSignup::factory()->create(['shift_id' => $existingShift->id, 'volunteer_id' => $volunteer->id]);
 
+    $timezone = $this->project->timezone ?? 'UTC';
+    $existingShiftLabel = eventSignupShiftTimeLabel($this->job, $existingShift, $timezone);
+    $newShiftLabel = eventSignupShiftTimeLabel($this->job, $newShift, $timezone);
+
     $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
         ->set('volunteerEmail', 'returning@example.com')
         ->call('submitEmail');
@@ -1445,10 +1817,173 @@ it('detects overlap between new shift and existing shift for returning volunteer
         ->set('selectedShiftIds', [$existingShift->id, $newShift->id])
         ->assertSee(__('Conflict'))
         ->assertSee(__('Some selected shifts overlap in time'))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $newShiftLabel, 'conflicts' => __('your existing shift :shifts', ['shifts' => $existingShiftLabel])]))
+        ->assertDontSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $existingShiftLabel, 'conflicts' => __('your existing shift :shifts', ['shifts' => $newShiftLabel])]))
         ->call('reserveAndAdvance')
         ->assertSet('state', WizardState::SelectingShifts);
 
     expect(ShiftReservation::count())->toBe(0);
+});
+
+it('reactivates a cancelled historical shift when the volunteers active schedule no longer overlaps', function () {
+    $timeline = eventSignupPhaseFourTimeline();
+
+    $activeShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['non_overlapping_active'][0],
+        'ends_at' => $timeline['non_overlapping_active'][1],
+        'capacity' => 10,
+    ]);
+    $cancelledShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['cancelled'][0],
+        'ends_at' => $timeline['cancelled'][1],
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'returning-reactivate@example.com',
+        'first_name' => 'Returning',
+        'last_name' => 'Reactivate',
+    ]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $activeShift->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+    $cancelledSignup = ShiftSignup::factory()->create([
+        'shift_id' => $cancelledShift->id,
+        'volunteer_id' => $volunteer->id,
+        'cancelled_at' => now(),
+    ]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning-reactivate@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning-reactivate@example.com');
+
+    $component->call('advanceToShifts')
+        ->assertSet('existingShiftIds', [$activeShift->id])
+        ->assertSet('selectedShiftIds', [$activeShift->id])
+        ->assertSeeHtml('value="'.$cancelledShift->id.'"')
+        ->assertDontSeeHtml('value="'.$cancelledShift->id.'" disabled')
+        ->set('selectedShiftIds', [$activeShift->id, $cancelledShift->id])
+        ->assertDontSee(__('Conflict'))
+        ->call('reserveAndAdvance')
+        ->assertSet('state', WizardState::Confirming)
+        ->call('submitSignup')
+        ->assertHasNoErrors()
+        ->assertSet('state', WizardState::Complete);
+
+    expect($cancelledSignup->fresh()->cancelled_at)->toBeNull()
+        ->and(ShiftSignup::where('volunteer_id', $volunteer->id)
+            ->where('shift_id', $cancelledShift->id)
+            ->count())
+        ->toBe(1)
+        ->and(ShiftSignup::where('volunteer_id', $volunteer->id)
+            ->where('shift_id', $cancelledShift->id)
+            ->whereNull('cancelled_at')
+            ->count())
+        ->toBe(1);
+});
+
+it('blocks re-selecting a cancelled historical shift when a newer active signup still overlaps it', function () {
+    $timeline = eventSignupPhaseFourTimeline();
+
+    $activeShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['overlapping_active'][0],
+        'ends_at' => $timeline['overlapping_active'][1],
+        'capacity' => 10,
+    ]);
+    $cancelledShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-15',
+        'starts_at' => $timeline['cancelled'][0],
+        'ends_at' => $timeline['cancelled'][1],
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create([
+        'email' => 'returning-overlap@example.com',
+        'first_name' => 'Returning',
+        'last_name' => 'Overlap',
+    ]);
+    ShiftSignup::factory()->create([
+        'shift_id' => $activeShift->id,
+        'volunteer_id' => $volunteer->id,
+    ]);
+    $cancelledSignup = ShiftSignup::factory()->create([
+        'shift_id' => $cancelledShift->id,
+        'volunteer_id' => $volunteer->id,
+        'cancelled_at' => now(),
+    ]);
+
+    $timezone = $this->project->timezone ?? 'UTC';
+    $activeShiftLabel = eventSignupShiftTimeLabel($this->job, $activeShift, $timezone);
+    $cancelledShiftLabel = eventSignupShiftTimeLabel($this->job, $cancelledShift, $timezone);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'returning-overlap@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'returning-overlap@example.com');
+
+    $component->call('advanceToShifts')
+        ->assertSet('existingShiftIds', [$activeShift->id])
+        ->assertSet('selectedShiftIds', [$activeShift->id])
+        ->assertSeeHtml('value="'.$cancelledShift->id.'"')
+        ->assertDontSeeHtml('value="'.$cancelledShift->id.'" disabled')
+        ->set('selectedShiftIds', [$activeShift->id, $cancelledShift->id])
+        ->assertSee(__('Conflict'))
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $cancelledShiftLabel, 'conflicts' => __('your existing shift :shifts', ['shifts' => $activeShiftLabel])]))
+        ->call('reserveAndAdvance')
+        ->assertHasErrors(['selectedShiftIds'])
+        ->assertSee(__('Some selected shifts overlap in time. Review the conflict details below before continuing.'))
+        ->assertSet('state', WizardState::SelectingShifts);
+
+    expect(array_keys($component->instance()->overlapConflictMap))
+        ->toEqualCanonicalizing([$cancelledShift->id])
+        ->and($component->instance()->existingShiftIds)
+        ->toEqual([$activeShift->id]);
+
+    expect(ShiftReservation::count())->toBe(0)
+        ->and($cancelledSignup->fresh()->cancelled_at)->not->toBeNull();
+});
+
+it('uses plural existing-shift wording when one selected shift conflicts with multiple existing shifts', function () {
+    $firstExistingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-16',
+        'starts_at' => Carbon::parse('2026-08-16 10:00:00'),
+        'ends_at' => Carbon::parse('2026-08-16 12:00:00'),
+        'capacity' => 10,
+    ]);
+    $secondExistingShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-16',
+        'starts_at' => Carbon::parse('2026-08-16 11:00:00'),
+        'ends_at' => Carbon::parse('2026-08-16 13:00:00'),
+        'capacity' => 10,
+    ]);
+    $newShift = Shift::factory()->for($this->job, 'volunteerJob')->create([
+        'shift_date' => '2026-08-16',
+        'starts_at' => Carbon::parse('2026-08-16 11:30:00'),
+        'ends_at' => Carbon::parse('2026-08-16 12:30:00'),
+        'capacity' => 10,
+    ]);
+
+    $volunteer = Volunteer::factory()->for($this->project)->verified()->create(['email' => 'multiple-existing@example.com']);
+    ShiftSignup::factory()->create(['shift_id' => $firstExistingShift->id, 'volunteer_id' => $volunteer->id]);
+    ShiftSignup::factory()->create(['shift_id' => $secondExistingShift->id, 'volunteer_id' => $volunteer->id]);
+
+    $timezone = $this->project->timezone ?? 'UTC';
+    $newShiftLabel = eventSignupShiftTimeLabel($this->job, $newShift, $timezone);
+    $expectedExistingLabels = __('your existing shifts :shifts', ['shifts' => eventSignupShiftTimeLabel($this->job, $firstExistingShift, $timezone).' and '.eventSignupShiftTimeLabel($this->job, $secondExistingShift, $timezone)]);
+
+    $component = Livewire::test(EventSignup::class, ['publicToken' => $this->event->public_token])
+        ->set('volunteerEmail', 'multiple-existing@example.com')
+        ->call('submitEmail');
+    simulateVerification($component, 'multiple-existing@example.com');
+
+    $component->call('advanceToShifts')
+        ->set('selectedShiftIds', [$firstExistingShift->id, $secondExistingShift->id, $newShift->id])
+        ->assertSee(__('Deselect :shift because it overlaps :conflicts.', ['shift' => $newShiftLabel, 'conflicts' => $expectedExistingLabels]));
 });
 
 it('allows new shift that does not overlap with existing shift for returning volunteer', function () {


### PR DESCRIPTION
## Summary
- add specific public-signup conflict guidance for overlapping shifts and returning-volunteer re-signups
- harden the signup wizard around step tampering, token expiry, renderable shift validation, and cancelled-shift reactivation coverage
- move Playwright fixture data out of the public web root and add dedicated Phase 4 browser coverage for overlap handling

## Testing
- vendor/bin/sail artisan test --compact tests/Feature/Public/EventSignupTest.php tests/Feature/Actions/SignUpVolunteerForShiftsTest.php
- bash e2e/setup.sh && vendor/bin/sail npm exec playwright test e2e/signup-conflict-ux.spec.ts

Closes #163
Resolves #164